### PR TITLE
BBL-121 testing policy for sns budget permissions.

### DIFF
--- a/root-org/4_notifications/main.tf
+++ b/root-org/4_notifications/main.tf
@@ -50,6 +50,25 @@ data "aws_iam_policy_document" "sns-topic-policy" {
 
   statement {
     actions = [
+      "SNS:Publish",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["budgets.amazonaws.com"]
+    }
+
+    resources = [
+      "${module.notify_slack.this_slack_topic_arn}",
+    ]
+
+    sid = "_budgets_service_access_ID"
+  }
+
+  statement {
+    actions = [
       "SNS:Subscribe",
       "SNS:SetTopicAttributes",
       "SNS:RemovePermission",
@@ -75,11 +94,6 @@ data "aws_iam_policy_document" "sns-topic-policy" {
     principals {
       type        = "AWS"
       identifiers = ["*"]
-    }
-
-    principals {
-      type        = "Service"
-      identifiers = ["budgets.amazonaws.com"]
     }
 
     resources = [


### PR DESCRIPTION
- AWS Budget SNS policy corrected based on: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-sns-policy.html
