### PR TITLE
BBL-146 updating makefiles + IAM roles and policies for cost controls…

### DIFF
--- a/dev/3_identities/roles.tf
+++ b/dev/3_identities/roles.tf
@@ -3,7 +3,7 @@
 #
 
 #
-# Assumable Role: DevOps
+# Assumable Role Cross-Account: DevOps
 #
 module "iam_assumable_roles" {
   source = "git::git@github.com:binbashar/terraform-aws-iam-role-sts.git?ref=v0.0.2"
@@ -15,64 +15,6 @@ module "iam_assumable_roles" {
   role_name         = "DevOps"
   role_requires_mfa = false
   role_policy_arn   = "${aws_iam_policy.devops_access.arn}"
-}
-
-#
-# User Managed Policy: DevOps Access
-#
-resource "aws_iam_policy" "devops_access" {
-  name        = "devops_access"
-  description = "Services enabled for DevOps role"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "acm:*",
-                "autoscaling:*",
-                "application-autoscaling:*",
-                "aws-portal:*",
-                "backup:*",
-                "ce:*",
-                "cloudformation:*",
-                "cloudfront:*",
-                "cloudtrail:*",
-                "cloudwatch:*",
-                "config:*",
-                "dlm:*",
-                "dynamodb:*",
-                "ec2:*",
-                "ecr:*",
-                "ecs:*",
-                "elasticloadbalancing:*",
-                "events:*",
-                "health:*",
-                "iam:*",
-                "kms:*",
-                "lambda:*",
-                "logs:*",
-                "redshift:*",
-                "rds:*",
-                "route53:*",
-                "route53domains:*",
-                "s3:*",
-                "shield:*",
-                "sns:*",
-                "sqs:*",
-                "ssm:*",
-                "vpc:*",
-                "waf:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-EOF
 }
 
 #
@@ -103,15 +45,7 @@ EOF
 }
 
 #
-# AWS Managed Policy: Admin Access
-#
-resource "aws_iam_role_policy_attachment" "admins_have_read_only_access" {
-  role       = "${aws_iam_role.admin_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-#
-# Auditor Role
+# Assumable Role Cross-Account: Auditor Role
 #
 resource "aws_iam_role" "auditor_role" {
   name = "Auditor"
@@ -137,20 +71,7 @@ EOF
 }
 
 #
-# AWS Managed Policies: Auditor Access
-#
-resource "aws_iam_role_policy_attachment" "auditors_have_read_only_access" {
-  role       = "${aws_iam_role.auditor_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "auditors_have_security_audit_access" {
-  role       = "${aws_iam_role.auditor_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
-}
-
-#
-# Assumable Role: DeployMaster
+# Assumable Role Cross-Account: DeployMaster
 #
 module "iam_assumable_roles_deploy_master" {
   source = "git::git@github.com:binbashar/terraform-aws-iam-role-sts.git?ref=v0.0.2"
@@ -162,47 +83,4 @@ module "iam_assumable_roles_deploy_master" {
   role_name         = "DeployMaster"
   role_requires_mfa = false
   role_policy_arn   = "${aws_iam_policy.deploy_master_access.arn}"
-}
-
-#
-# Policy: DeployMaster
-#
-resource "aws_iam_policy" "deploy_master_access" {
-  name        = "deploy_master_access"
-  description = "Services enabled for DeployMaster role"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "budgets:*",
-                "cloudfront:*",
-                "config:*",
-                "ecr:*",
-                "iam:*",
-                "dynamodb:*",
-                "ec2:*",
-                "ecr:*",
-                "iam:*",
-                "logs:*",
-                "route53:*",
-                "route53domains:*",
-                "s3:*",
-                "sns:*",
-                "ssm:*",
-                "sqs:*",
-                "vpc:*",
-                "waf:*",
-                "waf-regional:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-EOF
 }

--- a/dev/3_identities/roles_policies.tf
+++ b/dev/3_identities/roles_policies.tf
@@ -1,0 +1,187 @@
+#
+# Policies attached to Roles
+#
+
+#
+# User Managed Policy: DevOps Access
+#
+resource "aws_iam_policy" "devops_access" {
+  name        = "devops_access"
+  description = "Services enabled for DevOps role"
+
+#
+# IMPORTANT: Multiple condition keys in the same statement are not supported for some ec2 and rds actions.
+#
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MultiServiceFullAccessCustom",
+            "Effect": "Allow",
+            "Action": [
+                "acm:*",
+                "autoscaling:*",
+                "application-autoscaling:*",
+                "aws-portal:*",
+                "backup:*",
+                "ce:*",
+                "cloudformation:*",
+                "cloudfront:*",
+                "cloudtrail:*",
+                "cloudwatch:*",
+                "config:*",
+                "dlm:*",
+                "dynamodb:*",
+                "ec2:*",
+                "ecr:*",
+                "ecs:*",
+                "elasticloadbalancing:*",
+                "events:*",
+                "health:*",
+                "iam:*",
+                "kms:*",
+                "lambda:*",
+                "logs:*",
+                "rds:*",
+                "redshift:*",
+                "route53:*",
+                "route53domains:*",
+                "s3:*",
+                "shield:*",
+                "sns:*",
+                "sqs:*",
+                "ssm:*",
+                "vpc:*",
+                "waf:*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "Ec2RunInstanceCustomSize",
+            "Effect": "Deny",
+            "Action": "ec2:RunInstances",
+            "Resource": [
+                "arn:aws:ec2:*:*:instance/*"
+            ],
+            "Condition": {
+                "ForAnyValue:StringNotLike": {
+                    "ec2:InstanceType": [
+                        "*.nano",
+                        "*.micro",
+                        "*.small",
+                        "*.medium",
+                        "*.large"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "RdsFullAccessCustomSize",
+            "Effect": "Deny",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:CreateDBCluster"
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:db:*"
+            ],
+            "Condition": {
+                "ForAnyValue:StringNotLike": {
+                    "rds:DatabaseClass": [
+                        "*.micro",
+                        "*.small",
+                        "*.medium",
+                        "*.large"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
+#
+# AWS Managed Policy: Admin Access
+#
+resource "aws_iam_role_policy_attachment" "admins_have_read_only_access" {
+  role       = "${aws_iam_role.admin_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+#
+# AWS Managed Policies: Auditor Access
+#
+resource "aws_iam_role_policy_attachment" "auditors_have_read_only_access" {
+  role       = "${aws_iam_role.auditor_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "auditors_have_security_audit_access" {
+  role       = "${aws_iam_role.auditor_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+#
+# Policy: DeployMaster
+#
+resource "aws_iam_policy" "deploy_master_access" {
+  name        = "deploy_master_access"
+  description = "Services enabled for DeployMaster role"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "budgets:*",
+                "cloudfront:*",
+                "config:*",
+                "ecr:*",
+                "iam:*",
+                "dynamodb:*",
+                "ec2:*",
+                "ecr:*",
+                "iam:*",
+                "logs:*",
+                "route53:*",
+                "route53domains:*",
+                "s3:*",
+                "sns:*",
+                "ssm:*",
+                "sqs:*",
+                "vpc:*",
+                "waf:*",
+                "waf-regional:*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/dev/6_cloud-nuke/Makefile
+++ b/dev/6_cloud-nuke/Makefile
@@ -5,6 +5,7 @@ LOCAL_OS_USER := $(shell whoami)
 LOCAL_OS_SSH_DIR := ~/.ssh
 LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
 LOCAL_OS_AWS_CONF_DIR := ~/.aws
+
 TF_PWD_DIR := $(shell pwd)
 TF_PWD_CONT_DIR := "/go/src/project/"
 TF_PWD_CONFIG_DIR := $(shell cd .. && cd config && pwd)

--- a/security/3_identities/Makefile
+++ b/security/3_identities/Makefile
@@ -68,5 +68,8 @@ format: ## The terraform fmt is used to rewrite tf conf files to a canonical for
 force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}
 
+validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
+	../../@scripts/validate-terraform-layout.sh
+
 encrypt: ## ansible-vault encrypt secrets
 	ansible-vault encrypt secrets.tf

--- a/security/3_identities/groups_policies.tf
+++ b/security/3_identities/groups_policies.tf
@@ -1,4 +1,8 @@
 #
+# Policies attached to Groups
+#
+
+#
 # Policy: Standard AWS Console User
 #
 resource "aws_iam_policy" "standard_console_user" {

--- a/security/3_identities/roles.tf
+++ b/security/3_identities/roles.tf
@@ -3,7 +3,7 @@
 #
 
 #
-# Assumable Role: DevOps
+# Assumable Role Cross-Account: DevOps
 #
 module "iam_assumable_roles" {
   source = "git::git@github.com:binbashar/terraform-aws-iam-role-sts.git?ref=v0.0.2"
@@ -15,63 +15,6 @@ module "iam_assumable_roles" {
   role_name         = "DevOps"
   role_requires_mfa = false
   role_policy_arn   = "${aws_iam_policy.devops_access.arn}"
-}
-
-#
-# User Managed Policy: DevOps Access
-#
-resource "aws_iam_policy" "devops_access" {
-  name        = "devops_access"
-  description = "Services enabled for DevOps role"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "acm:*",
-                "autoscaling:*",
-                "application-autoscaling:*",
-                "aws-portal:*",
-                "backup:*",
-                "ce:*",
-                "cloudformation:*",
-                "cloudfront:*",
-                "cloudtrail:*",
-                "cloudwatch:*",
-                "config:*",
-                "dlm:*",
-                "dynamodb:*",
-                "ec2:*",
-                "ecr:*",
-                "ecs:*",
-                "elasticloadbalancing:*",
-                "events:*",
-                "health:*",
-                "iam:*",
-                "kms:*",
-                "lambda:*",
-                "logs:*",
-                "redshift:*",
-                "rds:*",
-                "route53:*",
-                "route53domains:*",
-                "s3:*",
-                "shield:*",
-                "sns:*",
-                "sqs:*",
-                "ssm:*",
-                "waf:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-EOF
 }
 
 #
@@ -102,15 +45,7 @@ EOF
 }
 
 #
-# AWS Managed Policy: Admin Access
-#
-resource "aws_iam_role_policy_attachment" "admins_have_read_only_access" {
-  role       = "${aws_iam_role.admin_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-#
-# Auditor Role
+# Assumable Role Cross-Account: Auditor Role
 #
 resource "aws_iam_role" "auditor_role" {
   name = "Auditor"
@@ -136,20 +71,7 @@ EOF
 }
 
 #
-# AWS Managed Policies: Auditor Access
-#
-resource "aws_iam_role_policy_attachment" "auditors_have_read_only_access" {
-  role       = "${aws_iam_role.auditor_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "auditors_have_security_audit_access" {
-  role       = "${aws_iam_role.auditor_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
-}
-
-#
-# Assumable Role: DeployMaster
+# Assumable Role Cross-Account: DeployMaster
 #
 module "iam_assumable_roles_deploy_master" {
   source = "git::git@github.com:binbashar/terraform-aws-iam-role-sts.git?ref=v0.0.2"
@@ -161,33 +83,4 @@ module "iam_assumable_roles_deploy_master" {
   role_name         = "DeployMaster"
   role_requires_mfa = false
   role_policy_arn   = "${aws_iam_policy.deploy_master_access.arn}"
-}
-
-#
-# Policy: DeployMaster
-#
-resource "aws_iam_policy" "deploy_master_access" {
-  name        = "deploy_master_access"
-  description = "Services enabled for DeployMaster role"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:*",
-                "route53:*",
-                "route53domains:*",
-                "ssm:*",
-                "sqs:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-EOF
 }

--- a/security/3_identities/roles_policies.tf
+++ b/security/3_identities/roles_policies.tf
@@ -1,0 +1,173 @@
+#
+# Policies attached to Roles
+#
+
+#
+# User Managed Policy: DevOps Access
+#
+resource "aws_iam_policy" "devops_access" {
+  name        = "devops_access"
+  description = "Services enabled for DevOps role"
+
+#
+# IMPORTANT: Multiple condition keys in the same statement are not supported for some ec2 and rds actions.
+#
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MultiServiceFullAccessCustom",
+            "Effect": "Allow",
+            "Action": [
+                "acm:*",
+                "autoscaling:*",
+                "application-autoscaling:*",
+                "aws-portal:*",
+                "backup:*",
+                "ce:*",
+                "cloudformation:*",
+                "cloudfront:*",
+                "cloudtrail:*",
+                "cloudwatch:*",
+                "config:*",
+                "dlm:*",
+                "dynamodb:*",
+                "ec2:*",
+                "ecr:*",
+                "ecs:*",
+                "elasticloadbalancing:*",
+                "events:*",
+                "health:*",
+                "iam:*",
+                "kms:*",
+                "lambda:*",
+                "logs:*",
+                "rds:*",
+                "redshift:*",
+                "route53:*",
+                "route53domains:*",
+                "s3:*",
+                "shield:*",
+                "sns:*",
+                "sqs:*",
+                "ssm:*",
+                "vpc:*",
+                "waf:*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "Ec2RunInstanceCustomSize",
+            "Effect": "Deny",
+            "Action": "ec2:RunInstances",
+            "Resource": [
+                "arn:aws:ec2:*:*:instance/*"
+            ],
+            "Condition": {
+                "ForAnyValue:StringNotLike": {
+                    "ec2:InstanceType": [
+                        "*.nano",
+                        "*.micro",
+                        "*.small",
+                        "*.medium",
+                        "*.large"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "RdsFullAccessCustomSize",
+            "Effect": "Deny",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:CreateDBCluster"
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:db:*"
+            ],
+            "Condition": {
+                "ForAnyValue:StringNotLike": {
+                    "rds:DatabaseClass": [
+                        "*.micro",
+                        "*.small",
+                        "*.medium",
+                        "*.large"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
+#
+# AWS Managed Policy: Admin Access
+#
+resource "aws_iam_role_policy_attachment" "admins_have_read_only_access" {
+  role       = "${aws_iam_role.admin_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+#
+# AWS Managed Policies: Auditor Access
+#
+resource "aws_iam_role_policy_attachment" "auditors_have_read_only_access" {
+  role       = "${aws_iam_role.auditor_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "auditors_have_security_audit_access" {
+  role       = "${aws_iam_role.auditor_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+#
+# Policy: DeployMaster
+#
+resource "aws_iam_policy" "deploy_master_access" {
+  name        = "deploy_master_access"
+  description = "Services enabled for DeployMaster role"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:*",
+                "route53:*",
+                "route53domains:*",
+                "ssm:*",
+                "sqs:*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/shared/3_identities/Makefile
+++ b/shared/3_identities/Makefile
@@ -1,23 +1,72 @@
 .PHONY: help
+SHELL := /bin/bash
+
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+LOCAL_OS_AWS_CONF_DIR := ~/.aws
+
+TF_PWD_DIR := $(shell pwd)
+TF_PWD_CONT_DIR := "/go/src/project/"
+TF_PWD_CONFIG_DIR := $(shell cd .. && cd config && pwd)
+TF_VER := 0.11.14
+TF_DOCKER_BACKEND_CONF_VARS_FILE := /config/backend.config
+TF_DOCKER_MAIN_CONF_VARS_FILE := /config/main.config
+TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
+TF_DOCKER_IMAGE := binbash/terraform-resources
+
+define TF_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${TF_PWD_CONFIG_DIR}:/config \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
 
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-version: ## Show terraform versio
-	terraform version
+tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+	@echo LOCAL_OS_USER: ${LOCAL_OS_USER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.terraform
 
-init: ## Initialize terraform backend, plugins, and modules"
-	terraform init -backend-config=../config/backend.config
+version: ## Show terraform version
+	docker run --rm \
+	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
+
+init: init-cmd tf-dir-chmod
+init-cmd: ## Initialize terraform backend, plugins, and modules"
+	${TF_CMD_PREFIX} init -backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 plan: ## Preview terraform changes"
-	terraform plan -var-file=../config/backend.config -var-file=../config/main.config
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan-detailed: ## Preview terraform changes with a more detailed output"
+	${TF_CMD_PREFIX} plan -detailed-exitcode -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 diff: ## Terraform plan with landscape
-	terraform plan -var-file=../config/backend.config -var-file=../config/main.config | docker run -i --rm binbash/terraform-landscape
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} | docker run -i --rm binbash/terraform-landscape
 
-apply: ## Make terraform apply any changes"
-	terraform apply -var-file=../config/backend.config -var-file=../config/main.config
+apply: apply-cmd tf-dir-chmod
+apply-cmd: ## Make terraform apply any changes"
+	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+output: ## Terraform output command is used to extract the value of an output variable from the state file.
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
-	terraform destroy -var-file=../config/backend.config -var-file=../config/main.config
+	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+format: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+	${TF_CMD_PREFIX} fmt ${TF_PWD_CONT_DIR}
+
+force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}
+
+validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
+	../../@scripts/validate-terraform-layout.sh

--- a/shared/3_identities/roles.tf
+++ b/shared/3_identities/roles.tf
@@ -3,7 +3,7 @@
 #
 
 #
-# Assumable Role: DevOps
+# Assumable Role Cross-Account: DevOps
 #
 module "iam_assumable_roles" {
   source = "git::git@github.com:binbashar/terraform-aws-iam-role-sts.git?ref=v0.0.2"
@@ -15,63 +15,6 @@ module "iam_assumable_roles" {
   role_name         = "DevOps"
   role_requires_mfa = false
   role_policy_arn   = "${aws_iam_policy.devops_access.arn}"
-}
-
-#
-# User Managed Policy: DevOps Access
-#
-resource "aws_iam_policy" "devops_access" {
-  name        = "devops_access"
-  description = "Services enabled for DevOps role"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "acm:*",
-                "autoscaling:*",
-                "application-autoscaling:*",
-                "aws-portal:*",
-                "backup:*",
-                "ce:*",
-                "cloudformation:*",
-                "cloudfront:*",
-                "cloudtrail:*",
-                "cloudwatch:*",
-                "config:*",
-                "dlm:*",
-                "dynamodb:*",
-                "ec2:*",
-                "ecr:*",
-                "ecs:*",
-                "elasticloadbalancing:*",
-                "events:*",
-                "health:*",
-                "iam:*",
-                "kms:*",
-                "lambda:*",
-                "logs:*",
-                "redshift:*",
-                "rds:*",
-                "route53:*",
-                "route53domains:*",
-                "s3:*",
-                "shield:*",
-                "sns:*",
-                "sqs:*",
-                "ssm:*",
-                "waf:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-EOF
 }
 
 #
@@ -102,15 +45,7 @@ EOF
 }
 
 #
-# AWS Managed Policy: Admin Access
-#
-resource "aws_iam_role_policy_attachment" "admins_have_read_only_access" {
-  role       = "${aws_iam_role.admin_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-#
-# Auditor Role
+# Assumable Role Cross-Account: Auditor Role
 #
 resource "aws_iam_role" "auditor_role" {
   name = "Auditor"
@@ -136,20 +71,7 @@ EOF
 }
 
 #
-# AWS Managed Policies: Auditor Access
-#
-resource "aws_iam_role_policy_attachment" "auditors_have_read_only_access" {
-  role       = "${aws_iam_role.auditor_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "auditors_have_security_audit_access" {
-  role       = "${aws_iam_role.auditor_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
-}
-
-#
-# Assumable Role: DeployMaster
+# Assumable Role Cross-Account: DeployMaster
 #
 module "iam_assumable_roles_deploy_master" {
   source = "git::git@github.com:binbashar/terraform-aws-iam-role-sts.git?ref=v0.0.2"
@@ -161,33 +83,4 @@ module "iam_assumable_roles_deploy_master" {
   role_name         = "DeployMaster"
   role_requires_mfa = false
   role_policy_arn   = "${aws_iam_policy.deploy_master_access.arn}"
-}
-
-#
-# Policy: DeployMaster
-#
-resource "aws_iam_policy" "deploy_master_access" {
-  name        = "deploy_master_access"
-  description = "Services enabled for DeployMaster role"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:*",
-                "route53:*",
-                "route53domains:*",
-                "ssm:*",
-                "sqs:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-EOF
 }

--- a/shared/3_identities/roles_policies.tf
+++ b/shared/3_identities/roles_policies.tf
@@ -1,0 +1,173 @@
+#
+# Policies attached to Roles
+#
+
+#
+# User Managed Policy: DevOps Access
+#
+resource "aws_iam_policy" "devops_access" {
+  name        = "devops_access"
+  description = "Services enabled for DevOps role"
+
+#
+# IMPORTANT: Multiple condition keys in the same statement are not supported for some ec2 and rds actions.
+#
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MultiServiceFullAccessCustom",
+            "Effect": "Allow",
+            "Action": [
+                "acm:*",
+                "autoscaling:*",
+                "application-autoscaling:*",
+                "aws-portal:*",
+                "backup:*",
+                "ce:*",
+                "cloudformation:*",
+                "cloudfront:*",
+                "cloudtrail:*",
+                "cloudwatch:*",
+                "config:*",
+                "dlm:*",
+                "dynamodb:*",
+                "ec2:*",
+                "ecr:*",
+                "ecs:*",
+                "elasticloadbalancing:*",
+                "events:*",
+                "health:*",
+                "iam:*",
+                "kms:*",
+                "lambda:*",
+                "logs:*",
+                "rds:*",
+                "redshift:*",
+                "route53:*",
+                "route53domains:*",
+                "s3:*",
+                "shield:*",
+                "sns:*",
+                "sqs:*",
+                "ssm:*",
+                "vpc:*",
+                "waf:*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "Ec2RunInstanceCustomSize",
+            "Effect": "Deny",
+            "Action": "ec2:RunInstances",
+            "Resource": [
+                "arn:aws:ec2:*:*:instance/*"
+            ],
+            "Condition": {
+                "ForAnyValue:StringNotLike": {
+                    "ec2:InstanceType": [
+                        "*.nano",
+                        "*.micro",
+                        "*.small",
+                        "*.medium",
+                        "*.large"
+                    ]
+                }
+            }
+        },
+        {
+            "Sid": "RdsFullAccessCustomSize",
+            "Effect": "Deny",
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:CreateDBCluster"
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:db:*"
+            ],
+            "Condition": {
+                "ForAnyValue:StringNotLike": {
+                    "rds:DatabaseClass": [
+                        "*.micro",
+                        "*.small",
+                        "*.medium",
+                        "*.large"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
+#
+# AWS Managed Policy: Admin Access
+#
+resource "aws_iam_role_policy_attachment" "admins_have_read_only_access" {
+  role       = "${aws_iam_role.admin_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+#
+# AWS Managed Policies: Auditor Access
+#
+resource "aws_iam_role_policy_attachment" "auditors_have_read_only_access" {
+  role       = "${aws_iam_role.auditor_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "auditors_have_security_audit_access" {
+  role       = "${aws_iam_role.auditor_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+#
+# Policy: DeployMaster
+#
+resource "aws_iam_policy" "deploy_master_access" {
+  name        = "deploy_master_access"
+  description = "Services enabled for DeployMaster role"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:*",
+                "route53:*",
+                "route53domains:*",
+                "ssm:*",
+                "sqs:*"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/shared/7_jenkins-vault/Makefile
+++ b/shared/7_jenkins-vault/Makefile
@@ -68,5 +68,9 @@ format: ## The terraform fmt is used to rewrite tf conf files to a canonical for
 force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}
 
+validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
+	../../@scripts/validate-terraform-layout.sh
+
 encrypt: ## ansible-vault encrypt secrets
 	ansible-vault encrypt secrets.tf
+

--- a/shared/7_jenkins-vault/variables.tf
+++ b/shared/7_jenkins-vault/variables.tf
@@ -78,18 +78,6 @@ variable "volume_size_extra_2" {
 #
 # S3
 #
-variable "aws_s3_bucket_name_1" {
-  description = "AWS S3 bucket name"
-  default     = "bb-shared-vault-storage"
-}
-
-variable "aws_s3_bucket_name_2" {
-  description = "AWS S3 bucket name"
-  default     = "bb-shared-ssl-certificates"
-}
-#
-# S3
-#
 variable "aws_s3_bucket_1_enabled" {
   description = "AWS S3 bucket will be created if set to true, otherwise don't"
   default     = "true"


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> devops-tf-infra-aws repo:

<div align="middle">
  <img src="https://raw.githubusercontent.com/binbashar/terraform-aws-waf-owasp/master/figures/binbash-leverage-terraform.png" alt="terraform" width="180"/>
  <img src="https://pbs.twimg.com/profile_images/907881675304181760/_ftIQb3v_400x400.jpg" alt="aws" width="100"/>
</div>

### :card_index_dividers: Cards / Tkts:
- **leverage:** https://trello.com/c/U3BNgvTZ/146-aws-updating-iam-roles-for-cost-controls-control-access-to-regions-or-resource-types-with-iam-policies
- **flex-lmb:** https://trello.com/c/RyDMeUw8/17-waf-29-aws-waf-cost-optimization-report

###  :notebook: Summary 
1. **AWS Sec/Shared/Dev accounts**: [aws] updating IAM roles for cost controls - control access to regions or resource types with IAM policies.

- **ref link:** https://stackoverflow.com/a/58758732/2033312

### :man_technologist:  New Commits
- 40a657e - exequielrafaela - BBL-146 updating makefiles + IAM roles and policies for cost controls control access to regions or resource types.

### :triangular_flag_on_post:  Post Tasks
- Evaluate this improvement for the BB Leverage Reference Architecture