### PR TITLE
BIZSUP-36 increasing no_output_timeout to avoid "Too long with no out…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
           working_directory: ~/project/shared/storage/@scripts
           environment:
             ANSIBLE_VAULT_PASSWORD_FILE: .vault_pass
+          no_output_timeout: 60m
           command: |
             # pre-reqs: install ansible and add ansible-vault binary to the path
             pwd && ls -ltra


### PR DESCRIPTION
### Commits on Jun 14, 2020
- @exequielrafaela - BIZSUP-36 increasing no_output_timeout to avoid "Too long with no output (exceeded 10m0s): context deadline exceeded" - a083aa3