### PR TITLE
Rename Notifications SNS topic

### DIFF
--- a/apps-devstg/notifications/variables.tf
+++ b/apps-devstg/notifications/variables.tf
@@ -93,7 +93,7 @@ variable "appsprd_account_id" {
 #
 variable "sns_topic_name_monitoring" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring"
+  default     = "sns-topic-slack-notify-monitoring"
 }
 
 #
@@ -101,5 +101,5 @@ variable "sns_topic_name_monitoring" {
 #
 variable "sns_topic_name_monitoring_sec" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring-sec"
+  default     = "sns-topic-slack-notify-monitoring-sec"
 }

--- a/apps-prd/notifications/variables.tf
+++ b/apps-prd/notifications/variables.tf
@@ -94,7 +94,7 @@ variable "appsprd_account_id" {
 #
 variable "sns_topic_name_monitoring" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring"
+  default     = "sns-topic-slack-notify-monitoring"
 }
 
 #
@@ -102,5 +102,5 @@ variable "sns_topic_name_monitoring" {
 #
 variable "sns_topic_name_monitoring_sec" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring-sec"
+  default     = "sns-topic-slack-notify-monitoring-sec"
 }

--- a/root/cost-mgmt/main.tf
+++ b/root/cost-mgmt/main.tf
@@ -8,7 +8,7 @@ module "aws_cost_mgmt_billing_alert_50" {
   aws_env                   = "${var.project}-${var.environment}-50"
   monthly_billing_threshold = var.monthly_billing_threshold_50
   currency                  = var.currency
-  aws_sns_topic_arn         = data.terraform_remote_state.notifications.outputs.sns_topic_arn_bb_monitoring
+  aws_sns_topic_arn         = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
 
   tags = local.tags
 }
@@ -20,7 +20,7 @@ module "aws_cost_mgmt_billing_alert_100" {
   aws_env                   = "${var.project}-${var.environment}-100"
   monthly_billing_threshold = var.monthly_billing_threshold_100
   currency                  = var.currency
-  aws_sns_topic_arn         = data.terraform_remote_state.notifications.outputs.sns_topic_arn_bb_monitoring
+  aws_sns_topic_arn         = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
 
   tags = local.tags
 }
@@ -38,7 +38,7 @@ module "aws_cost_mgmt_budget_notif_75" {
   time_unit              = var.time_unit
   time_period_start      = var.time_period_start
   notification_threshold = var.notification_threshold_75
-  aws_sns_topic_arn      = data.terraform_remote_state.notifications.outputs.sns_topic_arn_bb_monitoring
+  aws_sns_topic_arn      = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
   aws_sns_account_id     = var.root_account_id
 }
 
@@ -52,6 +52,6 @@ module "aws_cost_mgmt_budget_notif_100" {
   time_unit              = var.time_unit
   time_period_start      = var.time_period_start
   notification_threshold = var.notification_threshold_100
-  aws_sns_topic_arn      = data.terraform_remote_state.notifications.outputs.sns_topic_arn_bb_monitoring
+  aws_sns_topic_arn      = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
   aws_sns_account_id     = var.root_account_id
 }

--- a/root/notifications/variables.tf
+++ b/root/notifications/variables.tf
@@ -93,7 +93,7 @@ variable "root_account_id" {
 #
 variable "sns_topic_name_monitoring" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring"
+  default     = "sns-topic-slack-notify-monitoring"
 }
 
 #
@@ -101,5 +101,5 @@ variable "sns_topic_name_monitoring" {
 #
 variable "sns_topic_name_monitoring_sec" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring-sec"
+  default     = "sns-topic-slack-notify-monitoring-sec"
 }

--- a/security/notifications/variables.tf
+++ b/security/notifications/variables.tf
@@ -94,7 +94,7 @@ variable "appsprd_account_id" {
 #
 variable "sns_topic_name_monitoring" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring"
+  default     = "sns-topic-slack-notify-monitoring"
 }
 
 #
@@ -102,5 +102,5 @@ variable "sns_topic_name_monitoring" {
 #
 variable "sns_topic_name_monitoring_sec" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring-sec"
+  default     = "sns-topic-slack-notify-monitoring-sec"
 }

--- a/shared/notifications/variables.tf
+++ b/shared/notifications/variables.tf
@@ -94,7 +94,7 @@ variable "appsprd_account_id" {
 #
 variable "sns_topic_name_monitoring" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring"
+  default     = "sns-topic-slack-notify-monitoring"
 }
 
 #
@@ -102,5 +102,5 @@ variable "sns_topic_name_monitoring" {
 #
 variable "sns_topic_name_monitoring_sec" {
   description = ""
-  default     = "sns-topic-slack-notify-monitoring-monitoring-sec"
+  default     = "sns-topic-slack-notify-monitoring-sec"
 }


### PR DESCRIPTION
## what
* Rename Notification's SNS topic name

## why
* The word 'monitoring' was repeated in the SNS topic name
