### PR TITLE
Increase max session duration to 3h in all accounts. Also fix a minor…

### DIFF
--- a/@bin/scripts/aws_credentials_setup/aws_setup_credentials.py
+++ b/@bin/scripts/aws_credentials_setup/aws_setup_credentials.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, unicode_literals
 from PyInquirer import style_from_dict, Token, prompt, Separator
-import subprocess, os, git
+import subprocess, os, git, sys
 from pathlib import Path
 
 
@@ -46,7 +46,7 @@ def find_account(config_entries, search_account):
 def exit_if_empty(value, message):
     if len(value) == 0:
         print(message)
-        exit(0)
+        sys.exit(0)
 
 def build_accounts_choices():
     accounts_choices = []

--- a/apps-devstg/base-identities/roles.tf
+++ b/apps-devstg/base-identities/roles.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_devops" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "${aws_iam_policy.devops_access.arn}"
   ]
@@ -50,7 +50,7 @@ module "iam_assumable_role_admin" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
 
   tags = local.tags
 }
@@ -75,7 +75,7 @@ module "iam_assumable_role_auditor" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/SecurityAudit"
   ]
@@ -102,7 +102,7 @@ module "iam_assumable_role_deploy_master" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "${aws_iam_policy.deploy_master_access.arn}"
   ]

--- a/apps-prd/base-identities/roles.tf
+++ b/apps-prd/base-identities/roles.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_devops" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "${aws_iam_policy.devops_access.arn}"
   ]
@@ -50,7 +50,7 @@ module "iam_assumable_role_admin" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
 
   tags = local.tags
 }
@@ -75,7 +75,7 @@ module "iam_assumable_role_auditor" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/SecurityAudit"
   ]
@@ -102,7 +102,7 @@ module "iam_assumable_role_deploy_master" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "${aws_iam_policy.deploy_master_access.arn}"
   ]

--- a/security/base-identities/outputs.tf
+++ b/security/base-identities/outputs.tf
@@ -6,22 +6,22 @@ output "user_diego_ojeda_name" {
   value       = module.user_diego_ojeda.this_iam_user_name
 }
 
-output "user_diego_ojeda_login_profile_encrypted_password" {
-  description = "The encrypted password, base64 encoded"
-  value       = module.user_diego_ojeda.this_iam_user_login_profile_encrypted_password
-  sensitive   = true
-}
+# output "user_diego_ojeda_login_profile_encrypted_password" {
+#   description = "The encrypted password, base64 encoded"
+#   value       = module.user_diego_ojeda.this_iam_user_login_profile_encrypted_password
+#   sensitive   = true
+# }
 
 output "user_exequiel_barrirero_name" {
   description = "The user's name"
   value       = module.user_exequiel_barrirero.this_iam_user_name
 }
 
-output "user_exequiel_barrirero_login_profile_encrypted_password" {
-  description = "The encrypted password, base64 encoded"
-  value       = module.user_exequiel_barrirero.this_iam_user_login_profile_encrypted_password
-  sensitive   = true
-}
+# output "user_exequiel_barrirero_login_profile_encrypted_password" {
+#   description = "The encrypted password, base64 encoded"
+#   value       = module.user_exequiel_barrirero.this_iam_user_login_profile_encrypted_password
+#   sensitive   = true
+# }
 
 
 output "user_marcelo_beresvil_name" {
@@ -29,22 +29,22 @@ output "user_marcelo_beresvil_name" {
   value       = module.user_marcelo_beresvil.this_iam_user_name
 }
 
-output "user_marcelo_beresvil_login_profile_encrypted_password" {
-  description = "The encrypted password, base64 encoded"
-  value       = module.user_marcelo_beresvil.this_iam_user_login_profile_encrypted_password
-  sensitive   = true
-}
+# output "user_marcelo_beresvil_login_profile_encrypted_password" {
+#   description = "The encrypted password, base64 encoded"
+#   value       = module.user_marcelo_beresvil.this_iam_user_login_profile_encrypted_password
+#   sensitive   = true
+# }
 
 output "user_marcos_pagnuco_name" {
   description = "The user's name"
   value       = module.user_marcos_pagnuco.this_iam_user_name
 }
 
-output "user_marcos_pagnuco_login_profile_encrypted_password" {
-  description = "The encrypted password, base64 encoded"
-  value       = module.user_marcos_pagnuco.this_iam_user_login_profile_encrypted_password
-  sensitive   = true
-}
+# output "user_marcos_pagnuco_login_profile_encrypted_password" {
+#   description = "The encrypted password, base64 encoded"
+#   value       = module.user_marcos_pagnuco.this_iam_user_login_profile_encrypted_password
+#   sensitive   = true
+# }
 
 #
 # Machine / Automation Users
@@ -54,14 +54,14 @@ output "user_circle_ci_name" {
   value       = module.user_circle_ci.this_iam_user_name
 }
 
-output "user_circle_ci_iam_access_key_id" {
-  description = "The aws aim access key"
-  value       = module.user_circle_ci.this_iam_access_key_id
-  sensitive   = true
-}
+# output "user_circle_ci_iam_access_key_id" {
+#   description = "The aws aim access key"
+#   value       = module.user_circle_ci.this_iam_access_key_id
+#   sensitive   = true
+# }
 
-output "user_circle_ci_iam_access_key_encrypted_secret" {
-  description = "The encrypted secret key, base64 encoded"
-  value       = module.user_circle_ci.this_iam_access_key_encrypted_secret
-  sensitive   = true
-}
+# output "user_circle_ci_iam_access_key_encrypted_secret" {
+#   description = "The encrypted secret key, base64 encoded"
+#   value       = module.user_circle_ci.this_iam_access_key_encrypted_secret
+#   sensitive   = true
+# }

--- a/security/base-identities/roles.tf
+++ b/security/base-identities/roles.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_devops" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     aws_iam_policy.devops_access.arn
   ]
@@ -39,7 +39,7 @@ module "iam_assumable_role_admin" {
     "arn:aws:iam::${var.security_account_id}:root"
   ]
 
-  create_role           = true
+  create_role           = false
   role_name             = "Admin"
   admin_role_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
   attach_admin_policy   = true
@@ -50,7 +50,7 @@ module "iam_assumable_role_admin" {
   #
   role_requires_mfa    = true
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
 
   tags = local.tags
 }
@@ -75,7 +75,7 @@ module "iam_assumable_role_auditor" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/SecurityAudit"
   ]

--- a/shared/base-identities/roles.tf
+++ b/shared/base-identities/roles.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_devops" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     aws_iam_policy.devops_access.arn
   ]
@@ -50,7 +50,7 @@ module "iam_assumable_role_admin" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
 
   tags = local.tags
 }
@@ -75,7 +75,7 @@ module "iam_assumable_role_auditor" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/SecurityAudit"
   ]
@@ -102,7 +102,7 @@ module "iam_assumable_role_deploy_master" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     aws_iam_policy.deploy_master_access.arn
   ]
@@ -131,7 +131,7 @@ module "iam_assumable_role_finops" {
   #
   role_requires_mfa    = false
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
-  max_session_duration = 3600  # Max age of valid MFA (in seconds) for roles which require MFA
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
     "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess",
     aws_iam_policy.s3_put_gdrive_to_s3_backup.arn,


### PR DESCRIPTION
… with AWS Setup Credentials script.

## what
* Increase max session duration to 3h in all accounts

## why
* 1h was too short for most cases. 3h sounds more reasonable to the kind of usage we normally do with the AWS console
