### PR TITLE
Import OrganizationAccountAccessRole in all accounts and enable MFA on it

### DIFF
--- a/apps-devstg/base-identities/roles.tf
+++ b/apps-devstg/base-identities/roles.tf
@@ -109,3 +109,29 @@ module "iam_assumable_role_deploy_master" {
 
   tags = local.tags
 }
+
+#
+# Assumable Role Cross-Account: OrganizationAccountAccessRole
+#
+module "iam_assumable_role_oaar" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v2.20.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.root_account_id}:root"
+  ]
+
+  create_role           = true
+  role_name             = "OrganizationAccountAccessRole"
+  admin_role_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  attach_admin_policy   = true
+  role_path             = "/"
+
+  #
+  # MFA setup
+  #
+  role_requires_mfa    = true
+  mfa_age              = 3600 # Maximum CLI/API session duration in seconds between 3600 and 43200
+  max_session_duration = 7200 # Max age of the session (in seconds) when assuming roles
+
+  tags = local.tags
+}

--- a/apps-prd/base-identities/roles.tf
+++ b/apps-prd/base-identities/roles.tf
@@ -109,3 +109,29 @@ module "iam_assumable_role_deploy_master" {
 
   tags = local.tags
 }
+
+#
+# Assumable Role Cross-Account: OrganizationAccountAccessRole
+#
+module "iam_assumable_role_oaar" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v2.20.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.root_account_id}:root"
+  ]
+
+  create_role           = true
+  role_name             = "OrganizationAccountAccessRole"
+  admin_role_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  attach_admin_policy   = true
+  role_path             = "/"
+
+  #
+  # MFA setup
+  #
+  role_requires_mfa    = true
+  mfa_age              = 3600 # Maximum CLI/API session duration in seconds between 3600 and 43200
+  max_session_duration = 7200 # Max age of the session (in seconds) when assuming roles
+
+  tags = local.tags
+}

--- a/security/base-identities/Makefile
+++ b/security/base-identities/Makefile
@@ -1,1 +1,1 @@
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/security/base-identities/roles.tf
+++ b/security/base-identities/roles.tf
@@ -82,3 +82,29 @@ module "iam_assumable_role_auditor" {
 
   tags = local.tags
 }
+
+#
+# Assumable Role Cross-Account: OrganizationAccountAccessRole
+#
+module "iam_assumable_role_oaar" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v2.20.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.root_account_id}:root"
+  ]
+
+  create_role           = true
+  role_name             = "OrganizationAccountAccessRole"
+  admin_role_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  attach_admin_policy   = true
+  role_path             = "/"
+
+  #
+  # MFA setup
+  #
+  role_requires_mfa    = true
+  mfa_age              = 3600 # Maximum CLI/API session duration in seconds between 3600 and 43200
+  max_session_duration = 7200 # Max age of the session (in seconds) when assuming roles
+
+  tags = local.tags
+}

--- a/security/base-tf-backend/Makefile
+++ b/security/base-tf-backend/Makefile
@@ -15,4 +15,4 @@ define TF_RM_RESOURCE_ARG
 "module.terraform_backend.aws_iam_role.bucket_replication[0]"
 endef
 
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/security/config/backend.config
+++ b/security/config/backend.config
@@ -3,7 +3,7 @@
 #
 
 # AWS Profile (required by the backend but also used for other resources)
-profile         = "bb-security-admin"
+profile         = "bb-security-devops"
 
 # S3 bucket
 bucket          = "bb-security-terraform-backend"

--- a/security/notifications/Makefile
+++ b/security/notifications/Makefile
@@ -1,1 +1,1 @@
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/security/security-audit/Makefile
+++ b/security/security-audit/Makefile
@@ -1,1 +1,1 @@
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/security/security-base/Makefile
+++ b/security/security-base/Makefile
@@ -1,1 +1,1 @@
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/security/security-compliance --/Makefile
+++ b/security/security-compliance --/Makefile
@@ -1,1 +1,1 @@
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/security/security-keys/Makefile
+++ b/security/security-keys/Makefile
@@ -1,1 +1,1 @@
-include ../../@bin/makefiles/terraform13/terraform13-mfa.mk
+include ../../@bin/makefiles/terraform13/terraform13.mk

--- a/shared/base-identities/roles.tf
+++ b/shared/base-identities/roles.tf
@@ -139,3 +139,29 @@ module "iam_assumable_role_finops" {
 
   tags = local.tags
 }
+
+#
+# Assumable Role Cross-Account: OrganizationAccountAccessRole
+#
+module "iam_assumable_role_oaar" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v2.20.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.root_account_id}:root"
+  ]
+
+  create_role           = true
+  role_name             = "OrganizationAccountAccessRole"
+  admin_role_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  attach_admin_policy   = true
+  role_path             = "/"
+
+  #
+  # MFA setup
+  #
+  role_requires_mfa    = true
+  mfa_age              = 3600 # Maximum CLI/API session duration in seconds between 3600 and 43200
+  max_session_duration = 7200 # Max age of the session (in seconds) when assuming roles
+
+  tags = local.tags
+}


### PR DESCRIPTION
## what
* Import OrganizationAccountAccessRole in all accounts and enable MFA on it
* Also disable MFA on Security until the MFA script can support multi-profiles per layer

## why
* We want to support MFA when accessing accounts from the root account
* Having MFA enabled on Security while the MFA script does not support multiple profiles only causes a problem
