### PR TITLE
Import AccessAnalyzer in Security. Also fix a data resource in Root's…

### DIFF
--- a/root/security-audit/awscloudtrail.tf
+++ b/root/security-audit/awscloudtrail.tf
@@ -7,7 +7,7 @@ module "cloudtrail" {
   enable_log_file_validation    = "true"
   include_global_service_events = "true"
   is_multi_region_trail         = "true"
-  s3_bucket_name                = data.terraform_remote_state.security_keys.outputs.bucket_id
+  s3_bucket_name                = data.terraform_remote_state.security_audit.outputs.bucket_id
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events.arn
 }

--- a/root/security-audit/config.tf
+++ b/root/security-audit/config.tf
@@ -33,13 +33,13 @@ data "terraform_remote_state" "notifications" {
   }
 }
 
-data "terraform_remote_state" "security_keys" {
+data "terraform_remote_state" "security_audit" {
   backend = "s3"
 
   config = {
     region  = var.region
     profile = "${var.project}-security-devops"
     bucket  = "${var.project}-security-terraform-backend"
-    key     = "security/security/terraform.tfstate"
+    key     = "security/security-audit/terraform.tfstate"
   }
 }

--- a/security/base-identities/role_policies.tf
+++ b/security/base-identities/role_policies.tf
@@ -20,6 +20,7 @@ resource "aws_iam_policy" "devops_access" {
             "Sid": "MultiServiceFullAccessCustom",
             "Effect": "Allow",
             "Action": [
+                "access-analyzer:*",
                 "acm:*",
                 "aws-portal:*",
                 "backup:*",
@@ -38,6 +39,8 @@ resource "aws_iam_policy" "devops_access" {
                 "kms:*",
                 "lambda:*",
                 "logs:*",
+                "organizations:Describe*",
+                "organizations:List*",
                 "route53:*",
                 "route53domains:*",
                 "route53resolver:*",

--- a/security/security-base/config.tf
+++ b/security/security-base/config.tf
@@ -2,7 +2,7 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  version                 = "~> 2.69"
+  version                 = "~> 3.2.0"
   region                  = var.region
   profile                 = var.profile
   shared_credentials_file = "~/.aws/${var.project}/config"

--- a/security/security-base/iam_access_analizer.tf
+++ b/security/security-base/iam_access_analizer.tf
@@ -1,0 +1,13 @@
+#
+# NOTE: In order to enable AccessAnalyzer with the Organization at the zone of
+# of trust in the Security account, this account needs to be set as a delegated
+# administrator. Such step cannot be performed by Terraform yet so it was set
+# up manually as described below:
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-settings.html
+#
+
+resource "aws_accessanalyzer_analyzer" "default" {
+  analyzer_name = "ConsoleAnalyzer-bc3bc4d6-09cb-43f5-974c-303a7c55ded2"
+  type          = "ORGANIZATION"
+  tags          = local.tags
+}

--- a/security/security-base/locals.tf
+++ b/security/security-base/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  tags = {
+    Name      = "${var.project}-${var.environment}-cloudtrail-org"
+    Namespace = var.project
+    Stage     = var.environment
+  }
+}


### PR DESCRIPTION
… CloudTrail layer

## what
* Import AccessAnalyzer in Security
* Also fix a data resource in Root's CloudTrail layer

## why
* AccessAnalyzer was not defined as code because Terraform AWS provider did not support it at the Organizational level
