### PR TITLE
Fix CloudTrail bucket policy which was mistakenly declared as a bucke…

### DIFF
--- a/security/security-audit/awscloudtrail.tf
+++ b/security/security-audit/awscloudtrail.tf
@@ -23,7 +23,7 @@ module "cloudtrail_s3_bucket" {
   #       module which is trying to set tags to lifecycle policies
   #
   lifecycle_tags         = null
-  policy                 = aws_s3_bucket.cloudtrail_s3_bucket.policy
+  policy                 = aws_s3_bucket_policy.cloudtrail_s3_bucket.policy
   acl                    = "private"
   expiration_days        = 120
 }

--- a/security/security-audit/policies.tf
+++ b/security/security-audit/policies.tf
@@ -3,7 +3,7 @@
 # Services: cloudtrail & config
 # Accounts: shared, security and apps-devstg
 #
-resource "aws_s3_bucket" "cloudtrail_s3_bucket" {
+resource "aws_s3_bucket_policy" "cloudtrail_s3_bucket" {
   bucket = module.cloudtrail_s3_bucket.bucket_id
 
   policy = <<EOF


### PR DESCRIPTION
…t instead of a bucket policy

## what
* Replace the bucket resource with a bucket policy in Security's CloudTrail layer

## why
* The bucket policy was mistakenly declared as bucket and, even though it is somehow valid, it causes issues when enabling glacier storage class through the CloudTrail Bucket module
