### PR TITLE
Enable KMS on CloudTrail and CloudWatch Logs. Enforce SSL requests in…

### DIFF
--- a/apps-devstg/base-network/config.tf
+++ b/apps-devstg/base-network/config.tf
@@ -2,7 +2,7 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  version                 = "~> 2.69"
+  version                 = "~> 3.0"
   region                  = var.region
   profile                 = var.profile
   shared_credentials_file = "~/.aws/${var.project}/config"

--- a/apps-devstg/base-network/network.tf
+++ b/apps-devstg/base-network/network.tf
@@ -2,7 +2,7 @@
 # Network Resources
 #
 module "vpc" {
-  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v2.48.0"
+  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v2.55.0"
 
   name = local.vpc_name
   cidr = local.vpc_cidr_block

--- a/apps-devstg/base-network/network_vpc_flow_logs.tf
+++ b/apps-devstg/base-network/network_vpc_flow_logs.tf
@@ -1,8 +1,7 @@
 module "vpc_flow_logs" {
-  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.0"
+  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.8"
 
   vpc_id             = module.vpc.vpc_id
   bucket_name_prefix = "${var.project}-${var.environment}"
-  bucket_region      = var.region
   tags               = local.tags
 }

--- a/apps-devstg/security-audit/awscloudtrail.tf
+++ b/apps-devstg/security-audit/awscloudtrail.tf
@@ -10,6 +10,7 @@ module "cloudtrail" {
   s3_bucket_name                = data.terraform_remote_state.security_audit.outputs.bucket_id
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events.arn
+  kms_key_arn                   = data.terraform_remote_state.security_keys.outputs.aws_kms_key_arn
 }
 
 module "cloudtrail_api_alarms" {
@@ -32,6 +33,7 @@ module "cloudtrail_api_alarms" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "${var.project}-${var.environment}-cloudtrail"
   retention_in_days = "14"
+  kms_key_id        = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 
   tags = local.tags
 }

--- a/apps-devstg/security-audit/config.tf
+++ b/apps-devstg/security-audit/config.tf
@@ -22,6 +22,17 @@ terraform {
 #=============================#
 # Data sources                #
 #=============================#
+data "terraform_remote_state" "keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/security-keys/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "notifications" {
   backend = "s3"
 
@@ -41,5 +52,16 @@ data "terraform_remote_state" "security_audit" {
     profile = "${var.project}-security-devops"
     bucket  = "${var.project}-security-terraform-backend"
     key     = "security/security-audit/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "security_keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-security-devops"
+    bucket  = "${var.project}-security-terraform-backend"
+    key     = "security/security-keys/terraform.tfstate"
   }
 }

--- a/apps-devstg/security-keys/kms.tf
+++ b/apps-devstg/security-keys/kms.tf
@@ -10,5 +10,43 @@ module "kms_key" {
   deletion_window_in_days = 7
   enable_key_rotation     = true
   alias                   = "alias/${var.project}_${var.environment}_${var.kms_key_name}_key"
+  policy                  = data.aws_iam_policy_document.kms.json
   tags                    = local.tags
+}
+
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Enable CloudWatch Logs Service"
+    effect    = "Allow"
+    actions   = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    condition {
+      test      = "ArnLike"
+      variable  = "kms:EncryptionContext:aws:logs:arn"
+      values    = ["arn:aws:logs:${var.region}:${var.appsdevstg_account_id}:*"]
+    }
+  }
 }

--- a/apps-prd/base-network/config.tf
+++ b/apps-prd/base-network/config.tf
@@ -2,7 +2,7 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  version                 = "~> 2.69"
+  version                 = "~> 3.0"
   region                  = var.region
   profile                 = var.profile
   shared_credentials_file = "~/.aws/${var.project}/config"

--- a/apps-prd/base-network/network.tf
+++ b/apps-prd/base-network/network.tf
@@ -2,7 +2,7 @@
 # Network Resources
 #
 module "vpc" {
-  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v2.48.0"
+  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v2.55.0"
 
   name = local.vpc_name
   cidr = local.vpc_cidr_block

--- a/apps-prd/base-network/network_vpc_flow_logs.tf
+++ b/apps-prd/base-network/network_vpc_flow_logs.tf
@@ -1,8 +1,7 @@
 module "vpc_flow_logs" {
-  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.0"
+  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.8"
 
   vpc_id             = module.vpc.vpc_id
   bucket_name_prefix = "${var.project}-${var.environment}"
-  bucket_region      = var.region
   tags               = local.tags
 }

--- a/apps-prd/security-audit/awscloudtrail.tf
+++ b/apps-prd/security-audit/awscloudtrail.tf
@@ -10,6 +10,7 @@ module "cloudtrail" {
   s3_bucket_name                = data.terraform_remote_state.security_audit.outputs.bucket_id
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events.arn
+  kms_key_arn                   = data.terraform_remote_state.security_keys.outputs.aws_kms_key_arn
 }
 
 module "cloudtrail_api_alarms" {
@@ -32,6 +33,7 @@ module "cloudtrail_api_alarms" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "${var.project}-${var.environment}-cloudtrail"
   retention_in_days = "14"
+  kms_key_id        = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 
   tags = local.tags
 }

--- a/apps-prd/security-audit/config.tf
+++ b/apps-prd/security-audit/config.tf
@@ -22,6 +22,17 @@ terraform {
 #=============================#
 # Data sources                #
 #=============================#
+data "terraform_remote_state" "keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/security-keys/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "notifications" {
   backend = "s3"
 
@@ -41,5 +52,16 @@ data "terraform_remote_state" "security_audit" {
     profile = "${var.project}-security-devops"
     bucket  = "${var.project}-security-terraform-backend"
     key     = "security/security-audit/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "security_keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-security-devops"
+    bucket  = "${var.project}-security-terraform-backend"
+    key     = "security/security-keys/terraform.tfstate"
   }
 }

--- a/apps-prd/security-keys/kms.tf
+++ b/apps-prd/security-keys/kms.tf
@@ -10,5 +10,43 @@ module "kms_key" {
   deletion_window_in_days = 7
   enable_key_rotation     = true
   alias                   = "alias/${var.project}_${var.environment}_${var.kms_key_name}_key"
+  policy                  = data.aws_iam_policy_document.kms.json
   tags                    = local.tags
+}
+
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.appsprd_account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Enable CloudWatch Logs Service"
+    effect    = "Allow"
+    actions   = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    condition {
+      test      = "ArnLike"
+      variable  = "kms:EncryptionContext:aws:logs:arn"
+      values    = ["arn:aws:logs:${var.region}:${var.appsprd_account_id}:*"]
+    }
+  }
 }

--- a/root/security-audit/awscloudtrail.tf
+++ b/root/security-audit/awscloudtrail.tf
@@ -10,6 +10,7 @@ module "cloudtrail" {
   s3_bucket_name                = data.terraform_remote_state.security_audit.outputs.bucket_id
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events.arn
+  kms_key_arn                   = data.terraform_remote_state.security_keys.outputs.aws_kms_key_arn
 }
 
 module "cloudtrail_api_alarms" {
@@ -30,6 +31,7 @@ module "cloudtrail_api_alarms" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "${var.project}-${var.environment}-cloudtrail"
   retention_in_days = "14"
+  kms_key_id        = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 
   tags = local.tags
 }

--- a/root/security-audit/config.tf
+++ b/root/security-audit/config.tf
@@ -22,6 +22,17 @@ terraform {
 #=============================#
 # Data sources                #
 #=============================#
+data "terraform_remote_state" "keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/security-keys/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "notifications" {
   backend = "s3"
 
@@ -41,5 +52,16 @@ data "terraform_remote_state" "security_audit" {
     profile = "${var.project}-security-devops"
     bucket  = "${var.project}-security-terraform-backend"
     key     = "security/security-audit/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "security_keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-security-devops"
+    bucket  = "${var.project}-security-terraform-backend"
+    key     = "security/security-keys/terraform.tfstate"
   }
 }

--- a/root/security-keys/kms.tf
+++ b/root/security-keys/kms.tf
@@ -10,5 +10,43 @@ module "kms_key" {
   deletion_window_in_days = 7
   enable_key_rotation     = true
   alias                   = "alias/${var.project}_${var.environment}_${var.kms_key_name}_key"
+  policy                  = data.aws_iam_policy_document.kms.json
   tags                    = local.tags
+}
+
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.root_account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Enable CloudWatch Logs Service"
+    effect    = "Allow"
+    actions   = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    condition {
+      test      = "ArnLike"
+      variable  = "kms:EncryptionContext:aws:logs:arn"
+      values    = ["arn:aws:logs:${var.region}:${var.root_account_id}:*"]
+    }
+  }
 }

--- a/security/security-audit/awscloudtrail.tf
+++ b/security/security-audit/awscloudtrail.tf
@@ -10,6 +10,7 @@ module "cloudtrail" {
   s3_bucket_name                = module.cloudtrail_s3_bucket.bucket_id
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events.arn
+  kms_key_arn                   = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 
 module "cloudtrail_s3_bucket" {
@@ -45,6 +46,7 @@ module "cloudtrail_api_alarms" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "${var.project}-${var.environment}-cloudtrail"
   retention_in_days = "14"
+  kms_key_id        = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 
   tags = local.tags
 }

--- a/security/security-audit/config.tf
+++ b/security/security-audit/config.tf
@@ -36,3 +36,13 @@ data "terraform_remote_state" "notifications" {
     key     = "${var.environment}/notifications/terraform.tfstate"
   }
 }
+data "terraform_remote_state" "keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/security-keys/terraform.tfstate"
+  }
+}

--- a/security/security-audit/policies.tf
+++ b/security/security-audit/policies.tf
@@ -29,15 +29,27 @@ resource "aws_s3_bucket_policy" "cloudtrail_s3_bucket" {
                 ]
             },
             "Action": "s3:PutObject",
-            "Resource": [
-                "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org/AWSLogs/${var.shared_account_id}/*",
-                "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org/AWSLogs/${var.security_account_id}/*",
-                "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org/AWSLogs/${var.appsdevstg_account_id}/*",
-                "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org/*"
-            ],
+            "Resource": "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org/*",
             "Condition": {
                 "StringEquals": {
                     "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        },
+        {
+            "Sid": "EnforceSslRequestsOnly",
+            "Effect": "Deny",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "s3:*",
+            "Resource": [
+                "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org",
+                "arn:aws:s3:::${var.project}-${var.environment}-cloudtrail-org/*"
+            ],
+            "Condition": {
+                "Bool": {
+                    "aws:SecureTransport": "false"
                 }
             }
         }

--- a/security/security-keys/kms.tf
+++ b/security/security-keys/kms.tf
@@ -10,5 +10,69 @@ module "kms_key" {
   deletion_window_in_days = 7
   enable_key_rotation     = true
   alias                   = "alias/${var.project}_${var.environment}_${var.kms_key_name}_key"
+  policy                  = data.aws_iam_policy_document.kms.json
   tags                    = local.tags
+}
+
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.security_account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Enable CloudTrail Service"
+    effect    = "Allow"
+    actions   = [
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    condition {
+      test      = "StringLike"
+      variable  = "kms:EncryptionContext:aws:cloudtrail:arn"
+      values    = [
+        "arn:aws:cloudtrail:*:${var.security_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.shared_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.root_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.appsdevstg_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.appsprd_account_id}:trail/*"
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Enable CloudWatch Logs Service"
+    effect    = "Allow"
+    actions   = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    condition {
+      test      = "ArnLike"
+      variable  = "kms:EncryptionContext:aws:logs:arn"
+      values    = ["arn:aws:logs:${var.region}:${var.security_account_id}:*"]
+    }
+  }
 }

--- a/shared/base-network/config.tf
+++ b/shared/base-network/config.tf
@@ -2,7 +2,7 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  version                 = "~> 2.69"
+  version                 = "~> 3.0"
   region                  = var.region
   profile                 = var.profile
   shared_credentials_file = "~/.aws/${var.project}/config"

--- a/shared/base-network/network.tf
+++ b/shared/base-network/network.tf
@@ -2,7 +2,7 @@
 # Network Resources
 #
 module "vpc" {
-  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v2.48.0"
+  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v2.55.0"
 
   name = local.vpc_name
   cidr = local.vpc_cidr_block

--- a/shared/base-network/network_vpc_flow_logs.tf
+++ b/shared/base-network/network_vpc_flow_logs.tf
@@ -1,8 +1,7 @@
 module "vpc_flow_logs" {
-  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.0"
+  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.8"
 
   vpc_id             = module.vpc.vpc_id
   bucket_name_prefix = "${var.project}-${var.environment}"
-  bucket_region      = var.region
   tags               = local.tags
 }

--- a/shared/security-audit/awscloudtrail.tf
+++ b/shared/security-audit/awscloudtrail.tf
@@ -10,6 +10,7 @@ module "cloudtrail" {
   s3_bucket_name                = data.terraform_remote_state.security_audit.outputs.bucket_id
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events.arn
+  kms_key_arn                   = data.terraform_remote_state.security_keys.outputs.aws_kms_key_arn
 }
 
 module "cloudtrail_api_alarms" {
@@ -32,6 +33,7 @@ module "cloudtrail_api_alarms" {
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "${var.project}-${var.environment}-cloudtrail"
   retention_in_days = "14"
+  kms_key_id        = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 
   tags = local.tags
 }

--- a/shared/security-audit/config.tf
+++ b/shared/security-audit/config.tf
@@ -37,6 +37,17 @@ data "terraform_remote_state" "notifications" {
   }
 }
 
+data "terraform_remote_state" "keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/security-keys/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "security_audit" {
   backend = "s3"
 
@@ -45,5 +56,16 @@ data "terraform_remote_state" "security_audit" {
     profile = "${var.project}-security-devops"
     bucket  = "${var.project}-security-terraform-backend"
     key     = "security/security-audit/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "security_keys" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-security-devops"
+    bucket  = "${var.project}-security-terraform-backend"
+    key     = "security/security-keys/terraform.tfstate"
   }
 }

--- a/shared/security-keys/kms.tf
+++ b/shared/security-keys/kms.tf
@@ -6,9 +6,47 @@ module "kms_key" {
   stage                   = var.environment
   name                    = var.kms_key_name
   delimiter               = "-"
-  description             = "KMS key for Dev Account"
+  description             = "KMS key for ${var.environment} Account"
   deletion_window_in_days = 7
   enable_key_rotation     = true
   alias                   = "alias/${var.project}_${var.environment}_${var.kms_key_name}_key"
+  policy                  = data.aws_iam_policy_document.kms.json
   tags                    = local.tags
+}
+
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.shared_account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Enable CloudWatch Logs Service"
+    effect    = "Allow"
+    actions   = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+    condition {
+      test      = "ArnLike"
+      variable  = "kms:EncryptionContext:aws:logs:arn"
+      values    = ["arn:aws:logs:${var.region}:${var.shared_account_id}:*"]
+    }
+  }
 }


### PR DESCRIPTION
… VPC Flow Logs

## what
* Enable KMS on CloudTrail and CloudWatch Logs.
* Enforce SSL requests in VPC Flow Logs.

## why
* Both are recommended best practices enforced through the AWS Config rules we implement.