### PR TITLE
Improve MFA script to better handle error conditions, improve logs, i…

### DIFF
--- a/@bin/scripts/aws-mfa/aws-mfa-entrypoint.sh
+++ b/@bin/scripts/aws-mfa/aws-mfa-entrypoint.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# -----------------------------------------------------------------------------
+# - In a nutshell, what the script does is:
+# -----------------------------------------------------------------------------
+#   1. Figure out all the AWS profiles used by Terraform
+#   2. For each profile:
+#       2.1. Get the role, MFA serial number, and source profile
+#       2.2. Figure out the OTP or prompt the user
+#       2.3. Assume the role to create temporary credentials
+#       2.4. Generate the AWS profiles config files
+#   3. Pass the control back to the main process (e.g. Terraform)
+# -----------------------------------------------------------------------------
+
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -9,10 +21,13 @@ set -o nounset
 # Helper Functions
 # ---------------------------
 
-# A simple logging function
+# Simple logging functions
+function error { log "[ERROR] $1" 0; }
+function info { log "[INFO] $1" 1; }
+function debug { log "[DEBUG] $1" 2; }
 function log {
-    if [[ "$MFA_SCRIPT_ENABLE_DEBUG" -ne "0" ]]; then
-        echo -e "[$(date +"%m-%d-%y %H:%M:%S")] $*"
+    if [[ $MFA_SCRIPT_LOG_LEVEL -gt "$2" ]]; then
+        echo -e "[$(date +"%m-%d-%y %H:%M:%S")] $1"
     fi
 }
 
@@ -21,10 +36,10 @@ function get_config {
     local config_file=$1
     local config_key=$2
     local config_value=```
-grep -oEi "^$config_key\s+=.*\"([a-zA-Z0-9\-]+)\"" $config_file \
-| grep -oEi "\".+\"" \
-| sed 's/\"//g'
-```
+    grep -oEi "^$config_key\s+=.*\"([a-zA-Z0-9\-]+)\"" $config_file \
+    | grep -oEi "\".+\"" \
+    | sed 's/\"//g'
+    ```
     echo $config_value
 }
 
@@ -35,10 +50,10 @@ function get_profile {
     local profile_name="$3"
     local profile_key="$4"
     local profile_value=```
-AWS_CONFIG_FILE=$aws_config; \
-AWS_SHARED_CREDENTIALS_FILE=$aws_credentials; \
-aws configure get profile.$profile_name.$profile_key
-```
+    AWS_CONFIG_FILE=$aws_config; \
+    AWS_SHARED_CREDENTIALS_FILE=$aws_credentials; \
+    aws configure get profile.$profile_name.$profile_key
+    ```
     echo $profile_value
 }
 
@@ -46,7 +61,7 @@ aws configure get profile.$profile_name.$profile_key
 # -----------------------------------------------------------------------------
 # Initialize variables
 # -----------------------------------------------------------------------------
-MFA_SCRIPT_ENABLE_DEBUG=`printenv MFA_SCRIPT_ENABLE_DEBUG || echo 0`
+MFA_SCRIPT_LOG_LEVEL=`printenv MFA_SCRIPT_LOG_LEVEL || echo 2`
 BACKEND_CONFIG_FILE=`printenv BACKEND_CONFIG_FILE`
 COMMON_CONFIG_FILE=`printenv COMMON_CONFIG_FILE`
 SRC_AWS_CONFIG_FILE=`printenv SRC_AWS_CONFIG_FILE`
@@ -55,26 +70,28 @@ TF_AWS_CONFIG_FILE=`printenv AWS_CONFIG_FILE`
 TF_AWS_SHARED_CREDENTIALS_FILE=`printenv AWS_SHARED_CREDENTIALS_FILE`
 AWS_REGION="$(get_config $BACKEND_CONFIG_FILE region)"
 AWS_OUTPUT=json
-log "BACKEND_CONFIG_FILE: $BACKEND_CONFIG_FILE"
-log "SRC_AWS_CONFIG_FILE: $SRC_AWS_CONFIG_FILE"
-log "SRC_AWS_SHARED_CREDENTIALS_FILE: $SRC_AWS_SHARED_CREDENTIALS_FILE"
-log "TF_AWS_CONFIG_FILE: $TF_AWS_CONFIG_FILE"
-log "TF_AWS_SHARED_CREDENTIALS_FILE: $TF_AWS_SHARED_CREDENTIALS_FILE"
-log "AWS_REGION: $AWS_REGION"
-log "AWS_OUTPUT: $AWS_OUTPUT"
+debug "BACKEND_CONFIG_FILE=$BACKEND_CONFIG_FILE"
+debug "SRC_AWS_CONFIG_FILE=$SRC_AWS_CONFIG_FILE"
+debug "SRC_AWS_SHARED_CREDENTIALS_FILE=$SRC_AWS_SHARED_CREDENTIALS_FILE"
+debug "TF_AWS_CONFIG_FILE=$TF_AWS_CONFIG_FILE"
+debug "TF_AWS_SHARED_CREDENTIALS_FILE=$TF_AWS_SHARED_CREDENTIALS_FILE"
+debug "AWS_REGION=$AWS_REGION"
+debug "AWS_OUTPUT=$AWS_OUTPUT"
 
 
 # -----------------------------------------------------------------------------
-# Parse all profiles from config.tf
+# 1. Figure out all the AWS profiles used by Terraform
 # -----------------------------------------------------------------------------
-# Find any available profiles in config.tf
+
+# Parse all available profiles in config.tf
+set +e
 RAW_PROFILES=()
 PARSED_PROFILES=`grep -E "^\s+profile" config.tf`
 while IFS= read -r line ; do
     RAW_PROFILES+=(`echo $line | sed 's/ //g' | sed 's/[\"\$\{\}]//g'`)
 done <<< "$PARSED_PROFILES"
 
-# Replace placeholders in profiles
+# Now we need to replace any placeholders in the profiles
 PROFILES=()
 for i in "${RAW_PROFILES[@]}" ; do
     PROFILE_VALUE="$(get_config $BACKEND_CONFIG_FILE profile)"
@@ -83,84 +100,118 @@ for i in "${RAW_PROFILES[@]}" ; do
     PROFILES+=("$TMP_PROFILE")
 done
 
-# De-duplicate profiles
+# And then we have to remove repeated profiles
 UNIQ_PROFILES=($(echo "${PROFILES[@]}" | tr ' ' '\n' | uniq | tr '\n' ' '))
 if [[ "${#UNIQ_PROFILES[@]}" -eq 0 ]]; then
-    log "ERROR: Unable to find any profiles in config.tf"
+    error "Unable to find any profiles in config.tf"
+    exit 100
 fi
+info "MFA: Found ${#UNIQ_PROFILES[@]} profile/s"
 
 
 # -----------------------------------------------------------------------------
-# Loop through PROFILES and do all of the following
+# 2. For each profile:
 # -----------------------------------------------------------------------------
 for i in "${UNIQ_PROFILES[@]}" ; do
-    echo "[MFA-SCRIPT] Processing profile: $i"
+    info "MFA: Attempting to get temporary credentials for profile=$i"
 
     # -----------------------------------------------------------------------------
-    # Get the role, serial number and source profile from the AWS config file
+    # 2.1. Get the role, serial number and source profile from AWS config file
     # -----------------------------------------------------------------------------
     MFA_ROLE_ARN="$(get_profile $SRC_AWS_CONFIG_FILE $SRC_AWS_SHARED_CREDENTIALS_FILE $i role_arn)"
-    log "MFA_ROLE_ARN: $MFA_ROLE_ARN"
+    debug "MFA_ROLE_ARN=$MFA_ROLE_ARN"
     MFA_SERIAL_NUMBER="$(get_profile $SRC_AWS_CONFIG_FILE $SRC_AWS_SHARED_CREDENTIALS_FILE $i mfa_serial)"
-    log "MFA_SERIAL_NUMBER: $MFA_SERIAL_NUMBER"
+    debug "MFA_SERIAL_NUMBER=$MFA_SERIAL_NUMBER"
     MFA_PROFILE_NAME="$(get_profile $SRC_AWS_CONFIG_FILE $SRC_AWS_SHARED_CREDENTIALS_FILE $i source_profile)"
-    log "MFA_PROFILE_NAME: $MFA_PROFILE_NAME"
+    debug "MFA_PROFILE_NAME=$MFA_PROFILE_NAME"
     MFA_TOTP_KEY="$(get_profile $SRC_AWS_CONFIG_FILE $SRC_AWS_SHARED_CREDENTIALS_FILE $i totp_key)"
-    log "MFA_TOTP_KEY: $MFA_TOTP_KEY"
-    # Validate required fields
-    if [[ $MFA_ROLE_ARN == "" ]]; then log "[ERROR] Missing 'role_arn'" && exit 1; fi
-    if [[ $MFA_SERIAL_NUMBER == "" ]]; then log "[ERROR] Missing 'mfa_serial'" && exit 1; fi
-    if [[ $MFA_PROFILE_NAME == "" ]]; then log "[ERROR] Missing 'source_profile'" && exit 1; fi
+    debug "MFA_TOTP_KEY=$MFA_TOTP_KEY"
+    # Validate all required fields
+    if [[ $MFA_ROLE_ARN == "" ]]; then error "Missing 'role_arn'" && exit 150; fi
+    if [[ $MFA_SERIAL_NUMBER == "" ]]; then error "Missing 'mfa_serial'" && exit 151; fi
+    if [[ $MFA_PROFILE_NAME == "" ]]; then error "Missing 'source_profile'" && exit 152; fi
 
     # -----------------------------------------------------------------------------
-    # Try and get and MFA key from the profile
+    # 2.2. Figure out the OTP or prompt the user
     # -----------------------------------------------------------------------------
-    if [[ $MFA_TOTP_KEY != "" ]]; then
-        log "MFA_TOTP_KEY: $MFA_TOTP_KEY"
-        MFA_TOKEN_CODE=`oathtool --totp -b $MFA_TOTP_KEY`
-    else
-        # If the MFA TOTP Key was not found, prompt the user for the MFA Token
-        MFA_TOKEN_CODE=```
-    read -p "[MFA-SCRIPT] Type in your OTP: " TOKEN_CODE
-    echo $TOKEN_CODE
-    ```
-    fi
-    log "MFA_TOKEN_CODE: $MFA_TOKEN_CODE"
-
+    # Loop a predefined number of times in case the OTP becomes invalid between
+    # the time it is generated and the time it is provided to the script
     # -----------------------------------------------------------------------------
-    # At this point we are ready to assume the role to generate the temporary credentials
-    # -----------------------------------------------------------------------------
-    MFA_ROLE_SESSION_NAME="$MFA_PROFILE_NAME-temp"
+    MAX_RETRIES=3
+    RETRIES_COUNT=0
+    OTP_FAILED=true
     MFA_DURATION=900
-    MFA_ASSUME_ROLE_OUTPUT=```
-    AWS_CONFIG_FILE=$SRC_AWS_CONFIG_FILE \
-    AWS_SHARED_CREDENTIALS_FILE=$SRC_AWS_SHARED_CREDENTIALS_FILE \
-    aws sts assume-role \
-      --role-arn $MFA_ROLE_ARN \
-      --serial-number $MFA_SERIAL_NUMBER \
-      --role-session-name $MFA_ROLE_SESSION_NAME \
-      --duration-seconds $MFA_DURATION \
-      --token-code $MFA_TOKEN_CODE \
-      --profile $MFA_PROFILE_NAME
-    ```
-    # log "MFA_ASSUME_ROLE_OUTPUT: $MFA_ASSUME_ROLE_OUTPUT"
     TEMP_FILE=/tmp/mfa-tmp-credentials
-    echo "$MFA_ASSUME_ROLE_OUTPUT" > $TEMP_FILE
+    while [[ $OTP_FAILED == true && $RETRIES_COUNT -lt $MAX_RETRIES ]]; do
+
+        # Let's see if can automatically generate the OTP
+        if [[ $MFA_TOTP_KEY != "" ]]; then
+            debug "MFA_TOTP_KEY=$MFA_TOTP_KEY"
+            MFA_TOKEN_CODE=`oathtool --totp -b $MFA_TOTP_KEY`
+        else
+            # If the MFA TOTP Key was not found, prompt the user for the MFA Token
+            MFA_TOKEN_CODE=```
+            read -p "MFA: Please type in your OTP: " TOKEN_CODE;
+            echo $TOKEN_CODE
+            ```
+        fi
+        debug "MFA_TOKEN_CODE=$MFA_TOKEN_CODE"
+
+        # -----------------------------------------------------------------------------
+        # 2.3. Assume the role to generate the temporary credentials
+        # -----------------------------------------------------------------------------
+        MFA_ROLE_SESSION_NAME="$MFA_PROFILE_NAME-temp"
+        set +e
+        MFA_ASSUME_ROLE_OUTPUT=```
+        AWS_CONFIG_FILE=$SRC_AWS_CONFIG_FILE; \
+        AWS_SHARED_CREDENTIALS_FILE=$SRC_AWS_SHARED_CREDENTIALS_FILE; \
+        aws sts assume-role \
+        --role-arn $MFA_ROLE_ARN \
+        --serial-number $MFA_SERIAL_NUMBER \
+        --role-session-name $MFA_ROLE_SESSION_NAME \
+        --duration-seconds $MFA_DURATION \
+        --token-code $MFA_TOKEN_CODE \
+        --profile $MFA_PROFILE_NAME \
+        2>&1
+        ```
+        set -e
+        debug "MFA_ASSUME_ROLE_OUTPUT=${MFA_ASSUME_ROLE_OUTPUT:0:20}"
+
+        # Check if STS call failed because of invalid token
+        if [[ $MFA_ASSUME_ROLE_OUTPUT == *"invalid MFA"* ]]; then
+            OTP_FAILED=true
+            info "Unable to get valid credentials. Let's try again..."
+        else
+            OTP_FAILED=false
+            echo "$MFA_ASSUME_ROLE_OUTPUT" > $TEMP_FILE
+        fi
+
+        debug "OTP_FAILED=$OTP_FAILED"
+        RETRIES_COUNT=$((RETRIES_COUNT+1))
+        debug "RETRIES_COUNT=$RETRIES_COUNT"
+
+    done
+
+    # Check if credentials were actually created
+    if [[ ! $OTP_FAILED ]]; then
+        error "Unable to get valid credentials after $MAX_RETRIES attempts"
+        exit 160
+    fi
 
     # -----------------------------------------------------------------------------
-    # Parse id, secret and session from the output above
+    # 2.4. Generate the AWS profiles config files
     # -----------------------------------------------------------------------------
+
+    # Parse id, secret and session from the output above
     AWS_ACCESS_KEY_ID=`cat $TEMP_FILE | jq .Credentials.AccessKeyId | sed -e 's/"//g'`
     AWS_SECRET_ACCESS_KEY=`cat $TEMP_FILE | jq .Credentials.SecretAccessKey | sed -e 's/"//g'`
     AWS_SESSION_TOKEN=`cat $TEMP_FILE | jq .Credentials.SessionToken | sed -e 's/"//g'`
-    log "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:0:4}**************"
-    log "AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:0:4}**************"
-    log "AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:0:4}**************"
+    debug "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:0:4}**************"
+    debug "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:0:4}**************"
+    debug "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:0:4}**************"
     rm $TEMP_FILE
 
-    # -----------------------------------------------------------------------------
     # Create a profile block in the AWS credentials file using the credentials above
-    # -----------------------------------------------------------------------------
     REPLACE_CREDENTIALS=```
     AWS_CONFIG_FILE=$TF_AWS_CONFIG_FILE; \
     AWS_SHARED_CREDENTIALS_FILE=$TF_AWS_SHARED_CREDENTIALS_FILE; \
@@ -171,8 +222,10 @@ for i in "${UNIQ_PROFILES[@]}" ; do
     aws configure set output $AWS_OUTPUT
     ```
 
-    echo "[MFA-SCRIPT] Credentials written.\n"
+    info "MFA: Credentials written succesfully!"
 done
 
-# Delegate execution to the given process
+# -----------------------------------------------------------------------------
+# 3. Pass the control back to the main process
+# -----------------------------------------------------------------------------
 exec "$@"


### PR DESCRIPTION
…mprove documentation

## what
* Improve error conditions handling
* Improve logging
* Improve documentation

## why
* Sometimes the MFA workflow would fail because the OTP expires which would cause inconsistent Terraform operations forcing the user to start the workflow all over which could be annoying
* Logging only accepted one level (debug), the rest was accomplished through 'echo' commands; now the script has very basic logging levels which helps to show only the necessary information during normal execution but provides the ability to enable more verbose logging that can help with debugging
* Documentation also needed some improvements to help both future development and troubleshooting