### PR TITLE
Fix an issue with MFA script failing to deduplicate the list of profi…

### DIFF
--- a/@bin/scripts/aws-mfa/aws-mfa-entrypoint.sh
+++ b/@bin/scripts/aws-mfa/aws-mfa-entrypoint.sh
@@ -101,7 +101,7 @@ for i in "${RAW_PROFILES[@]}" ; do
 done
 
 # And then we have to remove repeated profiles
-UNIQ_PROFILES=($(echo "${PROFILES[@]}" | tr ' ' '\n' | uniq | tr '\n' ' '))
+UNIQ_PROFILES=($(echo "${PROFILES[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
 if [[ "${#UNIQ_PROFILES[@]}" -eq 0 ]]; then
     error "Unable to find any profiles in config.tf"
     exit 100


### PR DESCRIPTION
…les that are parsed from Terraform config files

## what
* Fix an issue with MFA script failing to deduplicate the list of profiles that are parsed from Terraform config files

## why
* It was making us enter the OTP for each profile twice
