### PR TITLE
Implement credentials caching in MFA script

### DIFF
--- a/@bin/scripts/aws-mfa/aws-mfa-entrypoint.sh
+++ b/@bin/scripts/aws-mfa/aws-mfa-entrypoint.sh
@@ -162,7 +162,7 @@ for i in "${UNIQ_PROFILES[@]}" ; do
     MFA_DURATION=3600
     TEMP_FILE="$AWS_CACHE_DIR/$i"
     debug "TEMP_FILE=$TEMP_FILE"
-    
+
     while [[ $OTP_FAILED == true && $RETRIES_COUNT -lt $MAX_RETRIES ]]; do
 
         #


### PR DESCRIPTION
IMPORTANT: this requires that Terraform Makefiles pass a new environment variables like follows:
```
-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
```

## what
* Implement credentials caching in MFA script

## why
* It gets annoying to be prompt for MFA's OTP every time you run a terraform command
