### PR TITLE
Add a small Terraform State helper to Leverage build file

### DIFF
--- a/_lib/terraform.py
+++ b/_lib/terraform.py
@@ -139,6 +139,10 @@ def shell(extra_args):
     cmd = _build_cmd(command="", entrypoint="/bin/sh", extra_args=extra_args)
     return subprocess.call(cmd)
 
+def state():
+    cmd = _build_cmd(command="", extra_args=["--", "/bin/sh"])
+    return subprocess.call(cmd)
+
 def format_check():
     # We don't need MFA for this command
     global mfa_enabled

--- a/build.py
+++ b/build.py
@@ -86,6 +86,21 @@ def encrypt():
     os.system("ansible-vault encrypt --output secrets.enc secrets.dec.tf && rm -rf secrets.dec.tf")
 
 @task(_checkdir)
+def state():
+    '''Perform Terraform state operations.'''
+    print('''
+===============================================================================
+- IMPORTANT:
+===============================================================================
+- Leverage CLI does not yet support Terraform state operations. However this
+- task provides a small helper to make it a bit easier.
+- This task will present you with a shell that is ready to run Terraform state
+- commands such as `terraform state list` and more.
+===============================================================================
+''')
+    terraform.state()
+
+@task(_checkdir)
 def validate_layout():
     '''Validate the layout convention of this Terraform layer.'''
     return os.system("../../@bin/scripts/validate-terraform-layout.sh")


### PR DESCRIPTION
## what
* Add a small Terraform State helper to Leverage build file.

## why
* We will be properly implementing Terraform State tasks down the road but for the moment we wanted to have a self documented way to help CLI users perform such tasks.