### PR TITLE
Remove network.auto.tfvars from the repo so they do not override cust…

### DIFF
--- a/apps-devstg/k8s-eks-demoapps/network/network.auto.tfvars
+++ b/apps-devstg/k8s-eks-demoapps/network/network.auto.tfvars
@@ -1,1 +1,0 @@
-vpc_enable_nat_gateway = false

--- a/apps-devstg/k8s-eks/network/network.auto.tfvars
+++ b/apps-devstg/k8s-eks/network/network.auto.tfvars
@@ -1,1 +1,0 @@
-vpc_enable_nat_gateway = false


### PR DESCRIPTION
…om values defined in terraform.tfvars file used by workflows

## what
* Remove network.auto.tfvars from eks network layers

## why
* Their values kept overriding custom values defined by the terraform.tfvars file that eks workflows use for toggling layer features. If needed, the files removed could still be created in local workstations and even added to .gitignore