### PR TITLE
Fix Terraform version

### DIFF
--- a/build.env
+++ b/build.env
@@ -6,6 +6,6 @@ MFA_ENABLED=true
 
 # Terraform
 TERRAFORM_IMAGE_NAME=binbash/terraform-awscli-slim
-TERRAFORM_IMAGE_TAG=0.14.4
+TERRAFORM_IMAGE_TAG=0.14.11
 TERRAFORM_ENTRYPOINT=/bin/terraform
 TERRAFORM_MFA_ENTRYPOINT=/root/scripts/aws-mfa/aws-mfa-entrypoint.sh


### PR DESCRIPTION
## what
* Fix Terraform version in main build.env

## why
* Since EKS DemoApps identities in Shared were updated the EKS DemoApps workflow started to fail with the following error:
```
Error: Unsupported Terraform Core version

  on config.tf line 14, in terraform:
  14:   required_version = ">= 0.14.11"
```