### PR TITLE
Update Github Runners' EC2 userdata script to match the installed mod…

### DIFF
--- a/shared/tools-github-selfhosted-runners/templates/user-data.sh
+++ b/shared/tools-github-selfhosted-runners/templates/user-data.sh
@@ -5,7 +5,15 @@ ${pre_install}
 
 # Install AWS CLI
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y awscli jq curl wget git uidmap unzip
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    awscli \
+    jq \
+    curl \
+    wget \
+    git \
+    uidmap \
+    build-essential \
+    unzip
 
 USER_NAME=runners
 useradd -m -s /bin/bash $USER_NAME


### PR DESCRIPTION
…ule version

## what
* Update Github Runners' EC2 userdata script to match the installed module version
* The main fix was applied to the secrets stored in HCP Vault which are used by the GH runners

## why
* The userdata script was taken from the ubuntu example in the previous module version