### PR TITLE
Add support permissions to DevOps role in Shared

### DIFF
--- a/shared/base-identities/policies.tf
+++ b/shared/base-identities/policies.tf
@@ -65,6 +65,7 @@ resource "aws_iam_policy" "devops_access" {
                 "sns:*",
                 "sqs:*",
                 "ssm:*",
+                "support:*",
                 "tag:*",
                 "trustedadvisor:*",
                 "vpc:*",


### PR DESCRIPTION
## what
* Add support permissions to DevOps role in Shared

## why
* We needed this to create support cases

## references
* #277 

