### PR TITLE
Add network firewall permission to deploymaster role

### DIFF
--- a/network/base-identities/policies.tf
+++ b/network/base-identities/policies.tf
@@ -161,6 +161,7 @@ resource "aws_iam_policy" "deploy_master_access" {
                 "ec2:*",
                 "ecr:*",
                 "iam:*",
+                "network-firewall:*",
                 "logs:*",
                 "route53:*",
                 "route53domains:*",

--- a/security/base-identities/groups_policies.tf
+++ b/security/base-identities/groups_policies.tf
@@ -49,7 +49,7 @@ resource "aws_iam_policy" "assume_admin_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.shared_account_id}:role/Admin",
-                "arn:aws:iam::${var.network_account_id}:role/DevOps",
+                "arn:aws:iam::${var.network_account_id}:role/Admin",
                 "arn:aws:iam::${var.security_account_id}:role/Admin",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Admin",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Admin"
@@ -78,7 +78,7 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.shared_account_id}:role/DeployMaster",
-                "arn:aws:iam::${var.network_account_id}:role/DevOps",
+                "arn:aws:iam::${var.network_account_id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster"
             ]


### PR DESCRIPTION
## what
* Add network firewall permission to deploymaster role

## why
* To be able to run terratest and circleci pipeline using the DeployMaster role

cc: @diego-ojeda-binbash 