### PR TITLE
Create a custom policy and permission set for DevOps, plus other smal…

### DIFF
--- a/root/global/sso/account_assignments.tf
+++ b/root/global/sso/account_assignments.tf
@@ -2,9 +2,9 @@ module "account_assignments" {
   source = "github.com/binbashar/terraform-aws-sso.git//modules/account-assignments?ref=0.6.1"
 
   account_assignments = [
-    # ------------------------------
+    # -------------------------------------------------------------------------
     # AWS_Administrators Permissions
-    # ------------------------------
+    # -------------------------------------------------------------------------
     {
       account             = var.root_account_id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
@@ -12,49 +12,84 @@ module "account_assignments" {
       principal_type      = "GROUP",
       principal_name      = "AWS_Administrators"
     },
-
-    # ----------------------
-    # AWS_DevOps Permissions
-    # ----------------------
     {
       account             = var.shared_account_id,
-      permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
-      permission_set_name = "Administrator",
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
+      principal_type      = "GROUP",
+      principal_name      = "AWS_Administrators"
+    },
+    {
+      account             = var.security_account_id,
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
+      principal_type      = "GROUP",
+      principal_name      = "AWS_Administrators"
+    },
+    {
+      account             = var.network_account_id,
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
+      principal_type      = "GROUP",
+      principal_name      = "AWS_Administrators"
+    },
+    {
+      account             = var.appsdevstg_account_id,
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
+      principal_type      = "GROUP",
+      principal_name      = "AWS_Administrators"
+    },
+    {
+      account             = var.appsprd_account_id,
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
+      principal_type      = "GROUP",
+      principal_name      = "AWS_Administrators"
+    },
+
+    # -------------------------------------------------------------------------
+    # AWS_DevOps Permissions
+    # -------------------------------------------------------------------------
+    {
+      account             = var.shared_account_id,
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
       principal_type      = "GROUP",
       principal_name      = "AWS_DevOps"
     },
     {
       account             = var.security_account_id,
-      permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
-      permission_set_name = "Administrator",
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
       principal_type      = "GROUP",
       principal_name      = "AWS_DevOps"
     },
     {
       account             = var.network_account_id,
-      permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
-      permission_set_name = "Administrator",
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
       principal_type      = "GROUP",
       principal_name      = "AWS_DevOps"
     },
     {
       account             = var.appsdevstg_account_id,
-      permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
-      permission_set_name = "Administrator",
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
       principal_type      = "GROUP",
       principal_name      = "AWS_DevOps"
     },
     {
       account             = var.appsprd_account_id,
-      permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
-      permission_set_name = "Administrator",
+      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
+      permission_set_name = "DevOps",
       principal_type      = "GROUP",
       principal_name      = "AWS_DevOps"
     },
 
-    # ----------------------
+    # -------------------------------------------------------------------------
     # AWS_FinOps Permissions
-    # ----------------------
+    # -------------------------------------------------------------------------
     {
       account             = var.root_account_id,
       permission_set_arn  = module.permission_sets.permission_sets["FinOps"].arn,
@@ -63,9 +98,9 @@ module "account_assignments" {
       principal_name      = "AWS_FinOps"
     },
 
-    # ----------------------
+    # -------------------------------------------------------------------------
     # AWS_SecOps Permissions
-    # ----------------------
+    # -------------------------------------------------------------------------
     {
       account             = var.shared_account_id,
       permission_set_arn  = module.permission_sets.permission_sets["SecurityAuditor"].arn,
@@ -102,9 +137,9 @@ module "account_assignments" {
       principal_name      = "AWS_SecOps"
     },
 
-    # ----------------------
+    # -------------------------------------------------------------------------
     # AWS_Guests Permissions
-    # ----------------------
+    # -------------------------------------------------------------------------
     {
       account             = var.shared_account_id,
       permission_set_arn  = module.permission_sets.permission_sets["ReadOnly"].arn,

--- a/root/global/sso/permission_sets.tf
+++ b/root/global/sso/permission_sets.tf
@@ -12,6 +12,15 @@ module "permission_sets" {
       policy_attachments = ["arn:aws:iam::aws:policy/AdministratorAccess"]
     },
     {
+      name               = "DevOps",
+      description        = "Grants permissions for managing most resources except billing.",
+      relay_state        = "",
+      session_duration   = local.session_duration,
+      tags               = local.tags,
+      inline_policy      = data.aws_iam_policy_document.devops.json,
+      policy_attachments = []
+    },
+    {
       name               = "FinOps",
       description        = "Grants permissions for billing and cost management.",
       relay_state        = "",
@@ -38,14 +47,14 @@ module "permission_sets" {
       inline_policy      = "",
       policy_attachments = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
     },
-    # {
-    #   name               = "Automation",
-    #   description        = "Grants permissions for build, deployment and other automation tasks.",
-    #   relay_state        = "",
-    #   session_duration   = local.session_duration,
-    #   tags               = local.tags,
-    #   inline_policy      = data.aws_iam_policy_document.Automation.json,
-    #   policy_attachments = []
-    # }
+    {
+      name               = "GithubAutomation",
+      description        = "GrantsGrants permissions for automation tasks that run on Github Actions.",
+      relay_state        = "",
+      session_duration   = local.session_duration,
+      tags               = local.tags,
+      inline_policy      = data.aws_iam_policy_document.github_automation.json,
+      policy_attachments = []
+    }
   ]
 }

--- a/root/global/sso/policies.tf
+++ b/root/global/sso/policies.tf
@@ -1,20 +1,132 @@
-# data "aws_iam_policy_document" "Automation" {
-#   statement {
-#     sid       = "CloudWatchReader"
-#     resources = ["*"]
-#     actions = [
-#       "cloudwatch:Describe*",
-#       "cloudwatch:List*",
-#       "cloudwatch:Describe*"
-#     ]
-#   }
+data "aws_iam_policy_document" "devops" {
 
-#   statement {
-#     sid       = "NetworkReader"
-#     resources = ["*"]
-#     actions = [
-#       "ec2:Describe*",
-#       "vpc:Describe*"
-#     ]
-#   }
-# }
+  statement {
+    sid = "MultiServiceFullAccessCustom"
+    actions = [
+      "acm:*",
+      "athena:*",
+      "autoscaling:*",
+      "appconfig:*",
+      "application-autoscaling:*",
+      "apprunner:*",
+      "apigateway:*",
+      "aws-portal:*",
+      "aws-marketplace:*",
+      "backup:*",
+      "backup-storage:*",
+      "ce:*",
+      "cloudformation:*",
+      "cloudfront:*",
+      "cloudtrail:*",
+      "cloudwatch:*",
+      "config:*",
+      "compute-optimizer:*",
+      "datasync:*",
+      "dlm:*",
+      "dynamodb:*",
+      "ec2:*",
+      "ecr:*",
+      "ecr-public:*",
+      "ecs:*",
+      "eks:*",
+      "elasticbeanstalk:*",
+      "elasticloadbalancing:*",
+      "es:*",
+      "events:*",
+      "glue:*",
+      "guardduty:*",
+      "health:*",
+      "iam:*",
+      "kms:*",
+      "lambda:*",
+      "lightsail:*",
+      "logs:*",
+      "ram:*",
+      "rds:*",
+      "redshift:*",
+      "resource-explorer:*",
+      "resource-groups:*",
+      "route53:*",
+      "route53domains:*",
+      "route53resolver:*",
+      "s3:*",
+      "ses:*",
+      "shield:*",
+      "sns:*",
+      "sqs:*",
+      "ssm:*",
+      "sts:*",
+      "support:*",
+      "tag:*",
+      "trustedadvisor:*",
+      "vpc:*",
+      "waf:*",
+      "wafv2:*",
+      "waf-regional:*",
+      "wellarchitected:*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values = [
+        "us-east-1",
+        "us-west-2"
+      ]
+    }
+  }
+
+  statement {
+    sid = "Ec2RunInstanceCustomSize"
+    actions = [
+      "ec2:RunInstances"
+    ]
+    effect = "Deny"
+    resources = [
+      "arn:aws:ec2:*:*:instance/*"
+    ]
+    condition {
+      test     = "ForAnyValue:StringNotLike"
+      variable = "ec2:InstanceType"
+      values = [
+        "*.nano",
+        "*.micro",
+        "*.small",
+        "*.medium",
+        "*.large"
+      ]
+    }
+  }
+
+  statement {
+    sid = "RdsFullAccessCustomSize"
+    actions = [
+      "rds:CreateDBInstance",
+      "rds:CreateDBCluster"
+    ]
+    effect    = "Deny"
+    resources = ["arn:aws:rds:*:*:db:*"]
+    condition {
+      test     = "ForAnyValue:StringNotLike"
+      variable = "rds:DatabaseClass"
+      values = [
+        "*.micro",
+        "*.small",
+        "*.medium",
+        "*.large"
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "github_automation" {
+  statement {
+    sid = "NATGatewayManager"
+    actions = [
+      "ec2:Describe*",
+      "ec2:CreateNatGateway",
+      "ec2:DeleteNatGateway",
+    ]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
…l adjustments

## what
* We now have a custom policy for DevOps permission set that is more restricted than the Administrator policy we had set for it
* A new GithubAutomation permission set was created as an example
* AWS_Administrator group now also gets Administrator permissions on all accounts
