### PR TITLE
Add VPC attachment appliance mode support

### DIFF
--- a/network/us-east-1/transit-gateway/vpc_attachments.tf
+++ b/network/us-east-1/transit-gateway/vpc_attachments.tf
@@ -32,7 +32,7 @@ module "tgw_vpc_attachments_and_subnet_routes_network_firewall" {
   create_transit_gateway_route_table                             = false
   create_transit_gateway_vpc_attachment                          = true
   create_transit_gateway_route_table_association_and_propagation = false
-  appliance_mode_support                                         = "enable"
+  vpc_attachment_appliance_mode_support                          = "enable"
 
   config = {
     (each.key) = {
@@ -73,7 +73,7 @@ module "tgw_vpc_attachments_and_subnet_routes_network" {
   create_transit_gateway_route_table                             = false
   create_transit_gateway_vpc_attachment                          = true
   create_transit_gateway_route_table_association_and_propagation = false
-  appliance_mode_support                                         = "enable"
+  vpc_attachment_appliance_mode_support                          = "enable"
 
   config = {
     (each.key) = {
@@ -114,7 +114,7 @@ module "tgw_vpc_attachments_and_subnet_routes_apps-devstg" {
   create_transit_gateway_route_table                             = false
   create_transit_gateway_vpc_attachment                          = true
   create_transit_gateway_route_table_association_and_propagation = false
-  appliance_mode_support                                         = "enable"
+  vpc_attachment_appliance_mode_support                          = "enable"
 
   config = {
     (each.key) = {
@@ -159,7 +159,7 @@ module "tgw_vpc_attachments_and_subnet_routes_apps-prd" {
   create_transit_gateway_route_table                             = false
   create_transit_gateway_vpc_attachment                          = true
   create_transit_gateway_route_table_association_and_propagation = false
-  appliance_mode_support                                         = "enable"
+  vpc_attachment_appliance_mode_support                          = "enable"
 
   config = {
     (each.key) = {
@@ -204,7 +204,7 @@ module "tgw_vpc_attachments_and_subnet_routes_shared" {
   create_transit_gateway_route_table                             = false
   create_transit_gateway_vpc_attachment                          = true
   create_transit_gateway_route_table_association_and_propagation = false
-  appliance_mode_support                                         = "enable"
+  vpc_attachment_appliance_mode_support                          = "enable"
 
   config = {
     (each.key) = {


### PR DESCRIPTION
## what
* Add VPC attachment appliance mode support

## why
* To enable traffic flow between  source and destination in the same Availability Zone for the VPC attachment for the lifetime of that flow.

## references
* https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-appliance-scenario.html

CC: @diego-ojeda-binbash 
