### PR TITLE
fix | upgrading to latest terraform-aws-notify-slack module + re-appl…

### DIFF
--- a/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/apps-devstg/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/apps-devstg/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring_sec" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_sec" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/apps-prd/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/apps-prd/us-east-1/notifications/slack_tools_monitoring.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/apps-prd/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/apps-prd/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring_sec" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_sec" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/network/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/network/us-east-1/notifications/slack_tools_monitoring.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/network/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/network/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring_sec" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_sec" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/root/us-east-1/notifications/costs_tools_monitoring.tf
+++ b/root/us-east-1/notifications/costs_tools_monitoring.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "aws_sns_topic_policy" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_costs" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.15.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags
@@ -66,7 +66,7 @@ module "notify_slack_monitoring_costs" {
 
   kms_key_arn          = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
   lambda_function_name = "${var.project}-${var.environment}-notify-slack-monitoring-costs"
-  lambda_description   = "Lambda function which sends notifications to Slacki from the Cost Topic"
+  lambda_description   = "Lambda function which sends notifications to Slack from the Cost Topic"
   log_events           = false
   sns_topic_name       = var.sns_topic_name_costs
 

--- a/root/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/root/us-east-1/notifications/slack_tools_monitoring.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/root/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/root/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring_sec" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_sec" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/security/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/security/us-east-1/notifications/slack_tools_monitoring.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/security/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/security/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring_sec" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_sec" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/shared/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/shared/us-east-1/notifications/slack_tools_monitoring.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags

--- a/shared/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/shared/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -11,7 +11,7 @@ data "aws_kms_ciphertext" "slack_url_monitoring_sec" {
 # Set create_with_kms_key = true
 # when providing value of kms_key_arn to create required IAM policy which allows to decrypt using specified KMS key.
 module "notify_slack_monitoring_sec" {
-  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.18.0"
+  source = "github.com/binbashar/terraform-aws-notify-slack.git?ref=v4.24.0"
 
   #
   # Creation Flags


### PR DESCRIPTION
## What?

### Commits on Dec 15, 2021
- fix | upgrading to latest terraform-aws-notify-slack module + re-applying this layer to configure the latest slack-webhook for monitoring channels - @exequielrafaela

## Why?
- https://hooks.slack.com/services/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 posted at https://github.com/binbashar/le-tf-infra-aws/blob/35cf5c28f72c8595308fa8bc3593a1ae4c317ca0/apps-devstg/6_notifications/slack_bb_tools_monitoring.tf
- https://hooks.slack.com/services/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 posted at https://github.com/binbashar/le-tf-infra-aws/blob/9b5bcc057efa6090f2a9d47f5f7bc08c41277455/root-org/4_notifications/variables.tf
- Keep the Leverage Reference Architecture for AWS up to date.


