### PR TITLE
Changing the source on outputs

### DIFF
--- a/shared/us-east-1/ec2-fleet-bastions --/outputs.tf
+++ b/shared/us-east-1/ec2-fleet-bastions --/outputs.tf
@@ -1,6 +1,11 @@
 output "public_ips" {
   description = "List of public IP addresses assigned to the instances"
-  value       = module.ec2_bastion.*.public_ip
+  value       = aws_eip.bastion_instance.*.public_ip
+}
+
+output "public_dns" {
+  description = "Public DNS associated with the Elastic IP address"
+  value       = aws_eip.bastion_instance.*.public_dns
 }
 
 output "private_ips" {


### PR DESCRIPTION
## What?
* Changes the source value on `public_ip` output.
* Adds the `public_dns` output

## Why?
* Trying to avoid showing the `public_ip` value assigned to the `ec2_instance`, which changes after the eip is assigned to the instance, for example:
```bash
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.ec2_bastion[1].aws_instance.this[0] has been changed
  ~ resource "aws_instance" "this" {
        id                                   = "i-007442a0c1fada754"
      ~ public_dns                           = "ec2-18-215-241-4.compute-1.amazonaws.com" -> "ec2-34-203-82-212.compute-1.amazonaws.com"
      ~ public_ip                            = "18.215.241.4" -> "34.203.82.212"
        tags                                 = {
            "Environment" = "shared"
            "Name"        = "ec2-fleet-bastion-1"
            "Terraform"   = "true"
        }
        # (29 unchanged attributes hidden)
```

It is not a problem itself, but could lead to confusions.

## References
* [It's an expected behavior](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#public_ip) that we should try to avoid:


