### PR TITLE
Fix/ test pr to validate gh actions release-drafter workflow

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     steps:
       # Drafts your next Release notes
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write 
     steps:
       # Drafts your next Release notes
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -13,9 +13,6 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
     steps:
       # Drafts your next Release notes
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -14,7 +14,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     permissions:
-      issues: write 
+      contents: write
     steps:
       # Drafts your next Release notes
       - uses: release-drafter/release-drafter@v5

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ use to make changes on AWS.
 
 ## Project context commands
 ```shell
-╭─    ~/Binbash/repos/Leverage/ref-architecture/le-tf-infra-aws/shared/base-network  on   master !2 ······························································································ ✔  at 08:52:43 
+╭─    ~/ref-architecture/le-tf-infra-aws  on   master · ✔  at 12:13:36 
 ╰─ leverage
 
 Usage: leverage [OPTIONS] COMMAND [ARGS]...
@@ -81,7 +81,7 @@ Commands:
 
 ## Layer context Terraform commands
 ```shell
-╭─    ~/B/r/L/ref-architecture/le-tf-infra-aws  on   feature/guarduty-update · ✔  at 12:13:36 
+╭─    ~/ref-architecture/le-tf-infra-aws  on   master · ✔  at 12:13:36 
 ╰─ leverage terraform
 Usage: leverage terraform [OPTIONS] COMMAND [ARGS]...
 


### PR DESCRIPTION
## What?

We've tested the `GITHUB_TOKEN` default permissions in order to work with our automated release-drafter workflow. We've rolled-back the token permissions to be able to write from the UI.

### Commits on Feb 16, 2022
- [test pr to validate gh actions release-drafter workflow](https://github.com/binbashar/le-tf-infra-aws/commit/17e500c4b7710191bc186cfb705ca6de1e0980ca)[](https://github.com/exequielrafaela) - @[exequielrafaela](https://github.com/binbashar/le-tf-infra-aws/commits?author=exequielrafaela)

#### References

- https://github.com/release-drafter/release-drafter/issues/820
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
- https://stackoverflow.com/questions/67389957/what-permissions-does-github-token-require-for-releases-from-a-github-action?rq=1
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ 