### PR TITLE
Feature / Update bb_mysql_db to use the latest version of tf_aws_rds module

### DIFF
--- a/apps-devstg/us-east-1/databases-mysql --/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/databases-mysql --/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.6.0"
+  constraints = ">= 3.62.0, >= 4.0.0, ~> 4.0"
+  hashes = [
+    "h1:UeSj1fU5z8dSZvuA/3cIAKzCObQYYWTUI6nyxgxHlTI=",
+    "zh:43d00e886384dc48ca3e2949327af0dba3eb3052104367456b47882a8456ba91",
+    "zh:7d586c26021fd3ea9d377f8024a5bb3f8d877a84792d39f2e2e96a3ec0848480",
+    "zh:84a01d4060916daf2973eaaabab0cadbb97fa850b74458b0bce98565268e37c1",
+    "zh:8a65dbf2ec7c433bf1c751a4f0ec332fd1bddd14e8aab64de4ee01890223f3a0",
+    "zh:92582a5d81f2cfecb2832895091f58eec5a978cdf4982ef8d7b9d88e74b265fe",
+    "zh:98c61fc2bf6a3af8b6ac8233860fefe8620e382a5fd25040f58297485ea0422a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a32ae8bb7397b4fd4eb4f5b21a119460bc74ec4be2baf8e0cc543c6945a74415",
+    "zh:ae38e3d167cf69c5b8734eb581044c8621d70ed0df8b0433d5dadb6b81741483",
+    "zh:d4686842c9cb4a73167c73b4aa6145729237c14cb520c3eb89b22c0317923525",
+    "zh:dad0005f2f451512098fd1bdb838934a05267f6f170c1b652e7f12f02b595476",
+    "zh:f64b0387a75838776f6edbc00ad01cda323c200bd6eaafa15acc92b9cdbd9e3a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.2"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:5A5VsY5wNmOZlupUcLnIoziMPn8htSZBXbP3lI7lBEM=",
+    "zh:0daceba867b330d3f8e2c5dc895c4291845a78f31955ce1b91ab2c4d1cd1c10b",
+    "zh:104050099efd30a630741f788f9576b19998e7a09347decbec3da0b21d64ba2d",
+    "zh:173f4ef3fdf0c7e2564a3db0fac560e9f5afdf6afd0b75d6646af6576b122b16",
+    "zh:41d50f975e535f968b3f37170fb07937c15b76d85ba947d0ce5e5ff9530eda65",
+    "zh:51a5038867e5e60757ed7f513dd6a973068241190d158a81d1b69296efb9cb8d",
+    "zh:6432a568e97a5a36cc8aebca5a7e9c879a55d3bc71d0da1ab849ad905f41c0be",
+    "zh:6bac6501394b87138a5e17c9f3a41e46ff7833ad0ba2a96197bb7787e95b641c",
+    "zh:6c0a7f5faacda644b022e7718e53f5868187435be6d000786d1ca05aa6683a25",
+    "zh:74c89de3fa6ef3027efe08f8473c2baeb41b4c6cee250ba7aeb5b64e8c79800d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b29eabbf0a5298f0e95a1df214c7cfe06ea9bcf362c63b3ad2f72d85da7d4685",
+    "zh:e891458c7a61e5b964e09616f1a4f87d0471feae1ec04cc51776e7dec1a3abce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "3.3.1"
+  constraints = ">= 2.21.0"
+  hashes = [
+    "h1:i7EC2IF0KParI+JPA5ZtXJrAn3bAntW5gEMLvOXwpW4=",
+    "zh:3e1866037f43c1083ff825dce2a9e3853c757bb0121c5ae528ee3cf3f99b4113",
+    "zh:49636cc5c4939134e098c4ec0163c41fae103f24d7e1e8fc0432f8ad93d596a0",
+    "zh:5258a7001719c4aeb84f4c4da7115b795da4794754938a3c4176a4b578fe93a1",
+    "zh:7461738691e2e8ea91aba73d4351cfbc30fcaedcf0e332c9d35ef215f93aa282",
+    "zh:815529478e33a6727273b08340a4c62c9aeb3da02abf8f091bb4f545c8451fce",
+    "zh:8e6fede9f5e25b507faf6cacd61b997035b8b62859245861149ddb2990ada8eb",
+    "zh:9acc2387084b9c411e264c4351633bc82f9c4e420f8e6bbad9f87b145351f929",
+    "zh:b9e4af3b06386ceed720f0163a1496088c154aa1430ae072c525ffefa4b37891",
+    "zh:c7d5dfb8f8536694db6740e2a4afd2d681b60b396ded469282524c62ce154861",
+    "zh:d0850be710c6fd682634a2f823beed0164231cc873b1dc09038aa477c926f57c",
+    "zh:e90c2cba9d89db5eab295b2f046f24a53f23002bcfe008633d398fb3fa16d941",
+  ]
+}

--- a/apps-devstg/us-east-1/databases-mysql --/config.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/config.tf
@@ -2,9 +2,10 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  region                  = var.region
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
+  region                   = var.region
+  profile                  = var.profile
+  shared_credentials_files = ["~/.aws/${var.project}/credentials"]
+  shared_config_files      = ["~/.aws/${var.project}/config"]
 }
 
 #=============================#
@@ -27,7 +28,7 @@ terraform {
   required_version = ">= 0.14.11"
 
   required_providers {
-    aws   = "~> 3.8"
+    aws   = "~> 4.0"
     vault = ">= 2.21.0"
   }
 

--- a/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
@@ -75,8 +75,7 @@ module "bb_mysql_db" {
   create_monitoring_role = false # true if Enhanced Monitoring needed
 
   # Tags + Bakup tag -> True
-  tags = merge(local.tags, map("Backup", "True"))
-  # tags = merge(local.tags, tomap({ Backup = "True" }))
+  tags = merge(local.tags, tomap({ Backup = "True" }))
 
   # Specifies whether any database modifications are applied immediately, or
   # during the next maintenance window

--- a/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
@@ -24,7 +24,7 @@ resource "aws_security_group_rule" "allow_mysql_port" {
 # Binbash Reference DB
 #
 module "bb_mysql_db" {
-  source = "github.com/binbashar/terraform-aws-rds.git?ref=v3.3.0"
+  source = "github.com/binbashar/terraform-aws-rds.git?ref=v4.1.2"
 
   # Instance settings
   # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html

--- a/apps-devstg/us-east-1/databases-mysql --/variables.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/variables.tf
@@ -103,3 +103,11 @@ variable "vault_token" {
   type        = string
   description = "Hashicorp vault admin token"
 }
+
+# Delete this section before commit
+# Vaule for undeclared variable
+variable "enable_tgw" {
+  description = "Enable Transit Gateway Support"
+  type        = bool
+  default     = false
+}

--- a/apps-devstg/us-east-1/databases-mysql --/variables.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/variables.tf
@@ -105,7 +105,7 @@ variable "vault_token" {
 }
 
 # Delete this section before commit
-# Vaule for undeclared variable
+# Vaule for undeclared variable - clear error message
 variable "enable_tgw" {
   description = "Enable Transit Gateway Support"
   type        = bool


### PR DESCRIPTION
### What?
* Updating Binbash MySQL_DB module to use AWS RDS Terraform module latest version (`v4.2.0`)


### How?

• ~/le-tf-infra-aws/apps-devstg/us-east-1/databases-mysql/bb_mysql.tf 

	□ MODIFY this line in module  bb_mysql_db, to use the latest version of tf-aws-rds module 
	
	module "bb_mysql_db" {
	  # source = "github.com/binbashar/terraform-aws-rds.git?ref=v3.3.0" # from this
	  source = "github.com/binbashar/terraform-aws-rds.git?ref=v4.2.0"   # to this


	□ MODIFY this line in module  bb_mysql_db, to use the new format of namig a db, since tf aws provider plugin v4.0.

	module "bb_mysql_db" {
	  # name     = "${var.project}_${replace(var.environment, "apps-", "")}_binbash_mysql".   # from this
	  db_name  = "${var.project}_${replace(var.environment, "apps-", "")}_binbash_mysql".     # to this


	□ ADD this line in module  bb_mysql_db, to use the subnet module and create a subnet for db instance

    module "bb_mysql_db" {
      # Network settings
      create_db_subnet_group = true  


	□ MODIFY "tags" argument in order to solve "Error Message: Missiong Atribute value" during tf apply
	source doc: https://www.terraform.io/language/functions/map

	module "bb_mysql_db" {
      # Tags + Bakup tag -> True
	    # tags = merge(local.tags, map("Backup", "True"))     # from this
        tags = merge(local.tags, tomap({ Backup = "True" }))  # to this


• ~/le-tf-infra-aws/apps-devstg/us-east-1/databases-mysql/variables.tf 

	□ ADD this block to eliminate warning message in tf apply

	variable "enable_tgw" {
	  description = "Enable Transit Gateway Support"
	  type        = bool
	  default     = false
	}
	
	
• ~/le-tf-infra-aws/apps-devstg/us-east-1/databases-mysql/config.tf 

	□ MODIFY this line in block terraform --> required_providers, to use the correct version of tf-aws provider pluging and avoid constrins version error message .
	source doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#provider-version-configuration
	
	terraform {
	  required_version = ">= 0.14.11"
	
	  required_providers {
	    # aws = "~> 3.8"      # from this
	    aws   = "~= 4.0".     # to this
	    vault = ">= 2.21.0"
	  }
	
	
	□ ADD new providers arguments in block provider "aws", to use the correct format for tf-aws-provider version 4.x.x 
	source doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#new-provider-arguments
	
	provider "aws" {
	  region  = var.region
	  profile = var.profile
	  # shared_credentials_file = "~/.aws/${var.project}/config"           # from this
	  shared_credentials_files = ["~/.aws/${var.project}/credentials"]     # to this
	  shared_config_files      = ["~/.aws/${var.project}/config"]          # to this
	}
	
	Note: Must to specify the argument as a [list], not as a "string" as used in the previous version





###  Why?
* Keeping Leverage Reference Architecture up to date.

###  References
* PR related with GitHub issue `#358`

