### PR TITLE
Disable SSM and EC2Messages endpoints by default in Shared and DevStg…

### DIFF
--- a/apps-devstg/us-east-1/base-network/network.auto.tfvars
+++ b/apps-devstg/us-east-1/base-network/network.auto.tfvars
@@ -1,2 +1,2 @@
 vpc_enable_nat_gateway = false
-enable_ssm_endpoints   = true
+enable_ssm_endpoints   = false

--- a/shared/us-east-1/base-network/network.auto.tfvars
+++ b/shared/us-east-1/base-network/network.auto.tfvars
@@ -6,4 +6,4 @@ vpc_single_nat_gateway = true
 vpc_enable_vpn_gateway = false
 
 # SSM
-enable_ssm_endpoints = true
+enable_ssm_endpoints = false


### PR DESCRIPTION
… (primary region)

## What?
* Disable SSM and EC2Messages endpoints by default in Shared and DevStg (primary region)

## Why?
* Such endpoints are not free to use but, more importantly, they are not actually needed at this time in our baseline.
