### PR TITLE
Disable SSM endpoints in apps-prd

### DIFF
--- a/apps-prd/us-east-1/base-network/network.auto.tfvars
+++ b/apps-prd/us-east-1/base-network/network.auto.tfvars
@@ -1,2 +1,2 @@
 vpc_enable_nat_gateway = false
-enable_ssm_endpoints   = true
+enable_ssm_endpoints   = false


### PR DESCRIPTION
## What?
* Disable SSM and EC2Messages endpoints by default in apps-prd

## Why?
* Such endpoints are not free to use but, more importantly, they are not actually needed at this time in our baseline.
