### PR TITLE
Feature | Add SSO authentication support in Ref Arch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
     python: python3
 
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
       - id: check-json
@@ -16,7 +16,7 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.55.0
     hooks:
       - id: terraform_fmt

--- a/apps-devstg/config/account.tfvars
+++ b/apps-devstg/config/account.tfvars
@@ -4,3 +4,6 @@
 
 # Environment Name
 environment = "apps-devstg"
+
+# SSO
+sso_role = "DevOps"

--- a/apps-prd/config/account.tfvars
+++ b/apps-prd/config/account.tfvars
@@ -4,3 +4,6 @@
 
 # Environment Name
 environment = "apps-prd"
+
+# SSO
+sso_role = "DevOps"

--- a/build.env
+++ b/build.env
@@ -2,10 +2,10 @@
 PROJECT=bb
 
 # General
-MFA_ENABLED=true
+MFA_ENABLED=false
 
 # Terraform
 TERRAFORM_IMAGE_NAME=binbash/terraform-awscli-slim
-TERRAFORM_IMAGE_TAG=1.0.9
+TERRAFORM_IMAGE_TAG=1.1.3
 TERRAFORM_ENTRYPOINT=/bin/terraform
 TERRAFORM_MFA_ENTRYPOINT=/root/scripts/aws-mfa/aws-mfa-entrypoint.sh

--- a/config/common.tfvars.example
+++ b/config/common.tfvars.example
@@ -4,7 +4,7 @@ project         = "bb"
 # Project (long name)
 project_long    = "binbash"
 
-# AWS Region for DR replicatin (required by the backend but also used for other resources)
+# AWS Region for DR replication (required by the backend but also used for other resources)
 region_secondary      = "us-east-2"
 
 # Account IDs
@@ -14,6 +14,35 @@ shared_account_id     = "333333333333"
 network_account_id    = "444444444444"
 appsdevstg_account_id = "555555555555"
 appsprd_account_id    = "666666666666"
+
+# Accounts
+accounts = {
+  root = {
+    email = "aws+root@binbash.com.ar",
+    id    = 111111111111
+  },
+  security = {
+    email = "binbash-security@binbash.com.ar",
+    id    = 222222222222
+  },
+  shared = {
+    email = "binbash-shared@binbash.com.ar",
+    id    = 333333333333
+  },
+  network = {
+    email = "binbash-network@binbash.com.ar",
+    id    = 444444444444
+  },
+  apps-devstg = {
+    email = "binbash-apps-devstg@binbash.com.ar",
+    id    = 555555555555
+  },
+  apps-prd = {
+    email = "binbash-apps-prd@binbash.com.ar",
+    id    = 666666666666
+  }
+}
+
 
 # Hashicorp Vault private API endpoint
 vault_address = "https://bb-le-shared-vault-cluster.private.vault.XXXXXX.aws.hashicorp.cloud:8200"
@@ -39,6 +68,11 @@ vault_address = "https://bb-le-shared-vault-cluster.private.vault.XXXXXX.aws.has
 #   security audit trail reasons
 #
 vault_token = "s.XXXXXXXXXXXXXXXXXXXXXX.Apshc"
+
+# AWS SSO
+sso_enabled   = true
+sso_start_url = "https://binbash.awsapps.com/start"
+sso_region    = "us-east-1"
 
 # The following values will be moved to another config file in a future release
 #

--- a/network/config/account.tfvars
+++ b/network/config/account.tfvars
@@ -4,3 +4,6 @@
 
 # Environment Name
 environment = "network"
+
+# SSO
+sso_role = "DevOps"

--- a/root/config/account.tfvars
+++ b/root/config/account.tfvars
@@ -4,3 +4,6 @@
 
 # Environment Name
 environment = "root"
+
+# SSO
+sso_role = "Administrator"

--- a/root/global/organizations/accounts.tf
+++ b/root/global/organizations/accounts.tf
@@ -4,7 +4,7 @@
 #
 resource "aws_organizations_account" "root" {
   name  = "binbash-root"
-  email = "info@binbash.com.ar"
+  email = "aws+root@binbash.com.ar"
 }
 
 #
@@ -12,8 +12,8 @@ resource "aws_organizations_account" "root" {
 #  permissions over the other accounts.
 #
 resource "aws_organizations_account" "security" {
-  name      = "binbash-aws-sec"
-  email     = "binbash-aws-sec@binbash.com.ar"
+  name      = "binbash-security"
+  email     = "aws+security@binbash.com.ar"
   parent_id = aws_organizations_organizational_unit.security.id
 }
 
@@ -22,8 +22,8 @@ resource "aws_organizations_account" "security" {
 #  or provide services to the other accounts.
 #
 resource "aws_organizations_account" "shared" {
-  name      = "binbash-aws-sr"
-  email     = "binbash-aws-sr@binbash.com.ar"
+  name      = "binbash-shared"
+  email     = "aws+shared@binbash.com.ar"
   parent_id = aws_organizations_organizational_unit.shared.id
 }
 
@@ -32,8 +32,8 @@ resource "aws_organizations_account" "shared" {
 #  or provide services to the other accounts.
 #
 resource "aws_organizations_account" "network" {
-  name      = "binbash-aws-net"
-  email     = "binbash-aws-net@binbash.com.ar"
+  name      = "binbash-network"
+  email     = "aws+network@binbash.com.ar"
   parent_id = aws_organizations_organizational_unit.network.id
 }
 
@@ -42,8 +42,8 @@ resource "aws_organizations_account" "network" {
 #  placed and maintained here.
 #
 resource "aws_organizations_account" "apps_devstg" {
-  name      = "binbash-aws-dev"
-  email     = "binbash-aws-dev@binbash.com.ar"
+  name      = "binbash-apps-devstg"
+  email     = "aws+apps-devstg@binbash.com.ar"
   parent_id = aws_organizations_organizational_unit.bbl_apps_devstg.id
 }
 
@@ -52,7 +52,7 @@ resource "aws_organizations_account" "apps_devstg" {
 #  maintained here.
 #
 resource "aws_organizations_account" "apps_prd" {
-  name      = "binbash-aws-prd"
-  email     = "info+binbash-aws-prd@binbash.com.ar"
+  name      = "binbash-apps-prd"
+  email     = "aws+apps-prd@binbash.com.ar"
   parent_id = aws_organizations_organizational_unit.bbl_apps_prd.id
 }

--- a/root/global/organizations/organization.tf
+++ b/root/global/organizations/organization.tf
@@ -12,6 +12,7 @@ resource "aws_organizations_organization" "main" {
     "config.amazonaws.com",
     "ram.amazonaws.com",
     "sso.amazonaws.com",
+    "fms.amazonaws.com",
   ]
 
   # Enable all feature set to enable SCPs

--- a/security/config/account.tfvars
+++ b/security/config/account.tfvars
@@ -4,3 +4,6 @@
 
 # Environment Name
 environment = "security"
+
+# SSO
+sso_role = "DevOps"

--- a/security/config/backend.tfvars
+++ b/security/config/backend.tfvars
@@ -3,7 +3,7 @@
 #
 
 # AWS Profile (required by the backend but also used for other resources)
-profile = "bb-security-secops"
+profile = "bb-security-devops"
 
 # S3 bucket
 bucket = "bb-security-terraform-backend"

--- a/shared/config/account.tfvars
+++ b/shared/config/account.tfvars
@@ -4,3 +4,6 @@
 
 # Environment Name
 environment = "shared"
+
+# SSO
+sso_role = "DevOps"


### PR DESCRIPTION
## What?
* Make the necessary changes to the Ref Arch to allow Leverage CLI to authenticate a user via AWS SSO

## Why?
* SSO provides ease of use and security enhancements as it deprecates the use of long-lived credentials in the user's machine.

## References
* closes https://github.com/binbashar/leverage/issues/70

