### PR TITLE
Bugfix | Change pre-commit hooks url's protocol to https

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
     python: python3
 
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
       - id: check-json
@@ -16,7 +16,7 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.55.0
     hooks:
       - id: terraform_fmt


### PR DESCRIPTION
## What?
* In the pre-commit hooks configuration, the repositories urls use `git` protocol, replace this with `https`

## Why?
* To address https://github.blog/2021-09-01-improving-git-protocol-security-github/