### PR TITLE
Fix an issue with DevOps SSO PermissionSet not applying to our actual…

### DIFF
--- a/root/global/sso/policies.tf
+++ b/root/global/sso/policies.tf
@@ -72,8 +72,8 @@ data "aws_iam_policy_document" "devops" {
       test     = "StringEquals"
       variable = "aws:RequestedRegion"
       values = [
-        "us-east-1",
-        "us-west-2"
+        "${var.region}",
+        "${var.region_secondary}"
       ]
     }
   }

--- a/shared/global/base-identities/policies.tf
+++ b/shared/global/base-identities/policies.tf
@@ -67,6 +67,7 @@ resource "aws_iam_policy" "devops_access" {
                 "route53domains:*",
                 "route53resolver:*",
                 "s3:*",
+                "secretsmanager:*",
                 "ses:*",
                 "shield:*",
                 "sns:*",


### PR DESCRIPTION
… secondary region

## What?
* The DevOps PermissionSet Inline Policy was not allowing access to the actual secondary region that we use.
* Also grant DevOps access to Secrets Manager.