### PR TITLE
Enable NAT Gateway for shared account

### DIFF
--- a/shared/us-east-1/base-network/network.auto.tfvars
+++ b/shared/us-east-1/base-network/network.auto.tfvars
@@ -1,5 +1,5 @@
 # NAT GW
-vpc_enable_nat_gateway = false
+vpc_enable_nat_gateway = true
 vpc_single_nat_gateway = true
 
 # VPN Gateways


### PR DESCRIPTION
## What?
* Enable NAT Gateway for shared account

## Why?
* To have the resource deployed and ready to use by other components, like pipeline runners.
