### PR TITLE
Feature/ shared/backups update tf providers versions

### DIFF
--- a/shared/us-east-1/backups/.terraform.lock.hcl
+++ b/shared/us-east-1/backups/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.17.1"
+  constraints = ">= 3.20.0, ~> 4.10"
+  hashes = [
+    "h1:wTtXjaZzaM1lLuXYsFP8X1JyZKOa+m3JAzdcaQOtiyM=",
+    "zh:095c2ad4e42667b6e4c599f3fb7c1d0755b762983474fd3916e89867c30871a2",
+    "zh:0a987960f796289db7eac887d03dcde0311005cbf625499f4eea0a8882295aeb",
+    "zh:1fbe5f897afe3a9e5a41c2ecd1f312e79fb6745367a53f7bad11704aedb3b3e2",
+    "zh:52687f0753fa05a744bd37bb40bcba8ac5e0838cdcd227035b9ccb151635e5f9",
+    "zh:629835a96c682f4e168c12f6d3c0631409d8e6d28165a283d2fe232c4a8ba75a",
+    "zh:6fa6e6fbdc0b0377d750a7960768e22f71d8bd97d30e289b823a3923eb92fce7",
+    "zh:8dfef513861a7c779b34e2f3ea5692f5fb1fb51aa1ee9de78bc755f5652cb597",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:baf507b37a667c773f46d9779277ab9de44a5432694ef95fe9ef03a6af70435f",
+    "zh:bd006bd8f1403f71be8f490e33ea1bcbdd8135678ebe3f1c3c0ebd82615d9b33",
+    "zh:dd0a61fb654837d186376b1dbccc8a93ed1e2f176e3663daac2d5bc9190c7895",
+    "zh:f8db068265495a48476a5ea68aa7148ceb046cbfaad308ef8e12d8fd6f463126",
+  ]
+}

--- a/shared/us-east-1/backups/config.tf
+++ b/shared/us-east-1/backups/config.tf
@@ -2,19 +2,18 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  region                  = var.region
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/${var.project}/config"
+  region  = var.region
+  profile = var.profile
 }
 
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.1.3"
 
   required_providers {
-    aws = "~> 3.27"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/shared/us-east-1/backups/variables.tf
+++ b/shared/us-east-1/backups/variables.tf
@@ -1,5 +1,5 @@
 #
-# config/backend.config
+# /config/backend.tfvars
 #
 #================================#
 # Terraform AWS Backend Settings #
@@ -30,7 +30,18 @@ variable "encrypt" {
 }
 
 #
-# config/base.config
+# /config/account.tfvars
+#
+#========================#
+# Account Configuration  #
+#========================#
+variable "environment" {
+  type        = string
+  description = "Environment Name"
+}
+
+#
+# /config/common.tfvars
 #
 #=============================#
 # Project Variables           #
@@ -45,20 +56,22 @@ variable "project_long" {
   description = "Project Long Name"
 }
 
-variable "environment" {
-  type        = string
-  description = "Environment Name"
-}
-
-#
-# config/extra.config
-#
 #=============================#
 # Accounts & Extra Vars       #
 #=============================#
+variable "region_primary" {
+  type        = string
+  description = "AWS Primary Region for HA"
+}
+
 variable "region_secondary" {
   type        = string
   description = "AWS Scondary Region for HA"
+}
+
+variable "accounts" {
+  type        = map(any)
+  description = "Accounts descriptions"
 }
 
 variable "root_account_id" {
@@ -89,4 +102,59 @@ variable "appsdevstg_account_id" {
 variable "appsprd_account_id" {
   type        = string
   description = "Account: Prod Modules & Libs"
+}
+
+#=============================#
+# AWS SSO  Variables          #
+#=============================#
+variable "sso_role" {
+  description = "SSO Role Name"
+}
+
+variable "sso_enabled" {
+  type        = string
+  description = "Enable SSO Service"
+}
+
+variable "sso_region" {
+  type        = string
+  description = "SSO Region"
+}
+
+variable "sso_start_url" {
+  type        = string
+  description = "SSO Start Url"
+}
+
+#=============================#
+# Hashicorp Vault Vars        #
+#=============================#
+variable "vault_address" {
+  type        = string
+  description = "Hashicorp vault api endpoint address"
+}
+
+variable "vault_token" {
+  type        = string
+  description = "Hashicorp vault admin token"
+}
+
+#=============================#
+# Networking                  #
+#=============================#
+variable "enable_tgw" {
+  description = "Enable Transit Gateway Support"
+  type        = bool
+  default     = false
+}
+
+variable "enable_tgw_multi_region" {
+  description = "Enable Multi-Region Transit Gateway"
+  type        = bool
+  default     = false
+}
+
+variable "tgw_cidrs" {
+  description = "CDIR blocks handled by the TGW"
+  type        = list(string)
 }


### PR DESCRIPTION
## What?
Update and Test Ref Architecture Certs layers (devstg and prd) with tf providers latest versions, Leverage CLI latest version and SSO feature enabled.

## Environment Versions
Leverage CLI : v1.7.0
Terraform : v1.1.9
Provider hashicorp/aws: v4.17.1

## Layers
**shared**/us-east-1/backups/

## How?
Update parameters in `config.tf`
Declare missing variables in `variables.tf` to solve warnings messages running tf apply:
"sso_role" , "sso_start_url" , "sso_enabled" , "sso_region" , "accounts" , "region_primary" , "enable_tgw" , "vault_token" , "vault_address"

## Why?
Keeping Leverage Reference Architecture up to date.

## References
GitHub issue https://github.com/binbashar/le-tf-infra-aws/issues/370

