### PR TITLE
updated external-dns bitnami chart version

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks/k8s-resources/networking.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-resources/networking.tf
@@ -33,7 +33,7 @@ resource "helm_release" "externaldns_private" {
   namespace  = kubernetes_namespace.externaldns.id
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "external-dns"
-  version    = "4.6.0"
+  version    = "6.5.3"
   values = [
     templatefile("chart-values/externaldns-private.yaml", {
       roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-externaldns-private"


### PR DESCRIPTION
## What?
* Updated Bitnami external-dns helm chart version

## Why?
* Previous version was giving an error: `Error: could not download chart: chart "external-dns" version "4.6.0" not found in https://charts.bitnami.com/bitnami repository  `

## References
* [Bitnami external-dns artifact HUB](https://artifacthub.io/packages/helm/bitnami/external-dns)

