### PR TITLE
Feature/ apps-devstg/us-east-1/k8s-eks/network layer baseline for terraform-aws-eks 1.18 module

### DIFF
--- a/apps-devstg/us-east-1/base-network/locals.tf
+++ b/apps-devstg/us-east-1/base-network/locals.tf
@@ -186,6 +186,12 @@ locals {
       bucket  = "${var.project}-apps-devstg-terraform-backend"
       key     = "apps-devstg/k8s-eks-demoapps/network/terraform.tfstate"
     }
+    apps-devstg-k8s-eks = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/k8s-eks/network/terraform.tfstate"
+    }
   }
 
 }

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/README.md
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/README.md
@@ -33,13 +33,13 @@ The typical use cases would be:
 - You need to set up a new cluster in a new account
 - Or you need to set up another cluster in an existing account which already has a cluster
 
-Below we'll cover the first case but we'll assume that we are creating the `prd` cluster from the code that 
+Below we'll cover the first case but we'll assume that we are creating the `prd` cluster from the code that
 defines the `devstg` cluster:
 1. First, you would copy-paste an existing EKS layer along with all its sublayers: `cp -r apps-devstg/us-east-1/k8s-eks apps-prd/us-east-1/k8s-eks`
-2. Then, you need to go through each layer, open up the `config.tf` file and replace any occurrences of `devstg` with `prd`. 
+2. Then, you need to go through each layer, open up the `config.tf` file and replace any occurrences of `devstg` with `prd`.
    1. There should be a `config.tf` in each sublayer so please make sure you cover all of them.
-   
-Now that you created the layers for the cluster you need to create a few other layers in the 
+
+Now that you created the layers for the cluster you need to create a few other layers in the
 new account that the cluster layers depend on, they are:
 3. The `security-keys` layer
     - This layer creates a KMS key that we use for encrypting EKS state.
@@ -55,18 +55,18 @@ Following the [leverage terraform workflow](https://leverage.binbash.com.ar/user
 The EKS layers need to be orchestrated in the following order:
 
 1. Network
-    1. Open the `locals.tf` file and make sure the VPC CIDR and subnets are correct. 
+    1. Open the `locals.tf` file and make sure the VPC CIDR and subnets are correct.
        1. Check the CIDR/subnets definition that were made for DevStg and Prd clusters and avoid segments overlapping.
-    2. In the same `locals.tf` file, there is a "VPC Peerings" section. 
+    2. In the same `locals.tf` file, there is a "VPC Peerings" section.
        1. Make sure it contains the right entries to match the VPC peerings that you actually need to set up.
-    3. In the `variables.tf` file you will find several variables you can use to configure multiple settings. 
-       1. For instance, if you anticipate this cluster is going to be permanent, you could set the `vpc_enable_nat_gateway` flag to `true`; 
+    3. In the `variables.tf` file you will find several variables you can use to configure multiple settings.
+       1. For instance, if you anticipate this cluster is going to be permanent, you could set the `vpc_enable_nat_gateway` flag to `true`;
        2. or if you are standing up a production cluster, you may want to set `vpc_single_nat_gateway` to `false` in order to have a NAT Gateways per availability zone.
 2. Cluster
     1. Since we’re deploying a private K8s cluster you’ll need to be **connected to the VPN**
     2. Check out the `variables.tf` file to configure the Kubernetes version or whether you want to create a cluster with a public endpoint (in most cases you don't but the possibility is there).
-    3. Open up `locals.tf` and make sure the `map_accounts`, `map_users` and `map_roles` variables define the right accounts, users and roles that will be granted permissions on the cluster. 
-    4. Then open `eks-managed-nodes.tf` to set the node groups and their attributes according to your requirements. 
+    3. Open up `locals.tf` and make sure the `map_accounts`, `map_users` and `map_roles` variables define the right accounts, users and roles that will be granted permissions on the cluster.
+    4. Then open `eks-managed-nodes.tf` to set the node groups and their attributes according to your requirements.
        1. In this file you can also configure security group rules, both for granting access to the cluster API or to the nodes.
     5. Go to this layer and run `leverage tf apply`
     6. In the output you should see the credentials you need to talk to Kubernetes API via kubectl (or other clients).
@@ -114,10 +114,10 @@ users:
 
 ```
 
-3. Identities layers 
-   1. The main files begin with the `ids_` prefix. 
-      1. They declare roles and their respective policies. 
-      2. The former are intended to be assumed by pods in your cluster through the EKS IRSA feature. 
+3. Identities layers
+   1. The main files begin with the `ids_` prefix.
+      1. They declare roles and their respective policies.
+      2. The former are intended to be assumed by pods in your cluster through the EKS IRSA feature.
    2. Go to this layer and run `leverage tf apply`
 
 #### Setup auth and test cluster connectivity

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/variables.tf
@@ -1,5 +1,5 @@
 #===========================================#
-# K8s EKS                                   #
+# K8s EKS Variables                         #
 #===========================================#
 variable "cluster_version" {
   description = "Kubernetes version to use for the EKS cluster."

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/network/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/network/config.tf
@@ -86,7 +86,7 @@ data "terraform_remote_state" "shared-vpcs" {
 
 data "terraform_remote_state" "shared-dns" {
   backend = "s3"
-  config  = {
+  config = {
     region  = var.region
     profile = "${var.project}-shared-devops"
     bucket  = "${var.project}-shared-terraform-backend"

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/network/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/network/config.tf
@@ -72,7 +72,6 @@ data "terraform_remote_state" "network-vpcs" {
 
 # VPC remote states for shared
 data "terraform_remote_state" "shared-vpcs" {
-
   for_each = local.shared-vpcs
 
   backend = "s3"
@@ -87,8 +86,7 @@ data "terraform_remote_state" "shared-vpcs" {
 
 data "terraform_remote_state" "shared-dns" {
   backend = "s3"
-
-  config = {
+  config  = {
     region  = var.region
     profile = "${var.project}-shared-devops"
     bucket  = "${var.project}-shared-terraform-backend"

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/network/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/network/locals.tf
@@ -7,7 +7,7 @@ locals {
   # Docker runs in the 172.17.0.0/16 CIDR range in Amazon EKS clusters. We recommend that your cluster's VPC subnets do
   # not overlap this range. Otherwise, you will receive the following error:
   # Error: : error upgrading connection: error dialing backend: dial tcp 172.17.nn.nn:10250: getsockopt: no route to host
-  vpc_name       = "${var.project}-${var.environment}-vpc-eks"
+  vpc_name       = "${var.project}-${var.environment}-vpc-eks-v117-1ry"
   vpc_cidr_block = "10.0.0.0/16"
   azs = [
     "${var.region}a",
@@ -176,6 +176,13 @@ locals {
       key     = "apps-devstg/network/terraform.tfstate"
       tgw     = false
     }
+    apps-devstg-k8s-eks-v117 = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/k8s-eks-v1.17/network/terraform.tfstate"
+      tgw     = false
+    }
     apps-devstg-k8s-eks = {
       region  = var.region
       profile = "${var.project}-apps-devstg-devops"
@@ -191,5 +198,4 @@ locals {
       tgw     = false
     }
   }
-
 }

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/network/network.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/network/network.tf
@@ -2,7 +2,7 @@
 # EKS VPC
 #
 module "vpc-eks" {
-  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v3.11.0"
+  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v3.14.0"
 
   name = local.vpc_name
   cidr = local.vpc_cidr_block

--- a/apps-devstg/us-east-1/k8s-eks/network/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/k8s-eks/network/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 3.28.0, >= 3.63.0, ~> 4.10"
+  hashes = [
+    "h1:KPu3MdNXCScye05Sp4JlE9WwhS9k3yD9KRoRDHg5sDE=",
+    "zh:1d944144f8d613b8090c0c8391e4b205ca036086d70aceb4cdf664856fa8410c",
+    "zh:2a0ca16a6b12c0ac509f64512f80bd2ed6e7ea0ec369212efd4be3fa65e9773d",
+    "zh:3f9efdce4f1c320ffd061e8715e1d031deac1be0b959eaa60c25a274925653e4",
+    "zh:4cf82f3267b0c3e08be29b0345f711ab84ea1ea75f0e8ce81f5a2fe635ba67b4",
+    "zh:58474a0b7da438e1bcd53e87f10e28830836ff9b46cce5f09413c90952ae4f78",
+    "zh:6eb1be8afb0314b6b8424fe212b13beeb04f3f24692f0f3ee86c5153c7eb2e63",
+    "zh:8022da7d3b050d452ce6c679844e13729bdb4e1b3e75dcf68931af17a06b9277",
+    "zh:8e2683d00fff1df43440d6e7c04a2c1eb432c7d5dacff32fe8ce9045bc948fe6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b0c22d9a306e8ac2de57b5291a3d0a7a2c1713e33b7d076005662451afdc4d29",
+    "zh:ba6b7d7d91388b636145b133da6b4e32620cdc8046352e2dc8f3f0f81ff5d2e2",
+    "zh:d38a816eb60f4419d99303136a3bb61a0d2df3ca8a1dce2ced9b99bf23efa9f7",
+  ]
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/common-variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/common-variables.tf
@@ -1,0 +1,159 @@
+#================================#
+# Common variables               #
+#================================#
+
+#
+# config/backend.config
+#
+#================================#
+# Terraform AWS Backend Settings #
+#================================#
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "profile" {
+  type        = string
+  description = "AWS Profile (required by the backend but also used for other resources)"
+}
+
+variable "bucket" {
+  type        = string
+  description = "AWS S3 TF State Backend Bucket"
+}
+
+variable "dynamodb_table" {
+  type        = string
+  description = "AWS DynamoDB TF Lock state table name"
+}
+
+variable "encrypt" {
+  type        = bool
+  description = "Enable AWS DynamoDB with server side encryption"
+}
+
+#
+# config/base.config
+#
+#=============================#
+# Project Variables           #
+#=============================#
+variable "project" {
+  type        = string
+  description = "Project Name"
+}
+
+variable "project_long" {
+  type        = string
+  description = "Project Long Name"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment Name"
+}
+
+#
+# config/extra.config
+#
+#=============================#
+# Accounts & Extra Vars       #
+#=============================#
+variable "region_primary" {
+  type        = string
+  description = "AWS Primary Region for HA"
+}
+
+variable "region_secondary" {
+  type        = string
+  description = "AWS Scondary Region for HA"
+}
+
+variable "accounts" {
+  type        = map(any)
+  description = "Accounts descriptions"
+}
+
+variable "root_account_id" {
+  type        = string
+  description = "Account: Root"
+}
+
+variable "security_account_id" {
+  type        = string
+  description = "Account: Security & Users Management"
+}
+
+variable "shared_account_id" {
+  type        = string
+  description = "Account: Shared Resources"
+}
+
+variable "network_account_id" {
+  type        = string
+  description = "Account: Networking Resources"
+}
+
+variable "appsdevstg_account_id" {
+  type        = string
+  description = "Account: Dev Modules & Libs"
+}
+
+variable "appsprd_account_id" {
+  type        = string
+  description = "Account: Prod Modules & Libs"
+}
+
+variable "vault_address" {
+  type        = string
+  description = "Vault Address"
+}
+
+variable "vault_token" {
+  type        = string
+  description = "Vault Token"
+}
+
+#=============================#
+# AWS SSO  Variables          #
+#=============================#
+variable "sso_role" {
+  description = "SSO Role Name"
+}
+
+variable "sso_enabled" {
+  type        = string
+  description = "Enable SSO Service"
+}
+
+variable "sso_region" {
+  type        = string
+  description = "SSO Region"
+}
+
+variable "sso_start_url" {
+  type        = string
+  description = "SSO Start Url"
+}
+
+#===========================================#
+# Networking                                #
+#===========================================#
+variable "enable_tgw" {
+  description = "Enable Transit Gateway Support"
+  type        = bool
+  default     = false
+}
+
+variable "enable_tgw_multi_region" {
+  description = "Enable Transit Gateway multi region support"
+  type        = bool
+  default     = false
+}
+
+variable "tgw_cidrs" {
+  description = "CIDRs to be added as routes to public RT"
+  type        = list(string)
+  default     = []
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/config.tf
@@ -86,7 +86,7 @@ data "terraform_remote_state" "shared-vpcs" {
 
 data "terraform_remote_state" "shared-dns" {
   backend = "s3"
-  config  = {
+  config = {
     region  = var.region
     profile = "${var.project}-shared-devops"
     bucket  = "${var.project}-shared-terraform-backend"

--- a/apps-devstg/us-east-1/k8s-eks/network/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/config.tf
@@ -1,0 +1,95 @@
+#
+# Providers
+#
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+provider "aws" {
+  alias   = "shared"
+  region  = var.region
+  profile = "${var.project}-shared-devops"
+}
+
+#
+# Backend Config (partial)
+#
+terraform {
+  required_version = "~> 1.1.3"
+
+  required_providers {
+    aws = "~> 4.10"
+  }
+
+  backend "s3" {
+    key = "apps-devstg/k8s-eks/network/terraform.tfstate"
+  }
+}
+
+#
+# Data sources
+#
+
+# TGW
+data "terraform_remote_state" "tgw" {
+  count = var.enable_tgw ? 1 : 0
+
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-network-devops"
+    bucket  = "${var.project}-network-terraform-backend"
+    key     = "network/transit-gateway/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "tools-vpn-server" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-shared-devops"
+    bucket  = "${var.project}-shared-terraform-backend"
+    key     = "shared/vpn/terraform.tfstate"
+  }
+}
+#
+# VPC remote states for network
+data "terraform_remote_state" "network-vpcs" {
+  for_each = local.network-vpcs
+
+  backend = "s3"
+
+  config = {
+    region  = lookup(each.value, "region")
+    profile = lookup(each.value, "profile")
+    bucket  = lookup(each.value, "bucket")
+    key     = lookup(each.value, "key")
+  }
+}
+
+# VPC remote states for shared
+data "terraform_remote_state" "shared-vpcs" {
+  for_each = local.shared-vpcs
+
+  backend = "s3"
+
+  config = {
+    region  = lookup(each.value, "region")
+    profile = lookup(each.value, "profile")
+    bucket  = lookup(each.value, "bucket")
+    key     = lookup(each.value, "key")
+  }
+}
+
+data "terraform_remote_state" "shared-dns" {
+  backend = "s3"
+  config  = {
+    region  = var.region
+    profile = "${var.project}-shared-devops"
+    bucket  = "${var.project}-shared-terraform-backend"
+    key     = "shared/dns/binbash.com.ar/terraform.tfstate"
+  }
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/dns_vpc_association_with_shared.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/dns_vpc_association_with_shared.tf
@@ -1,0 +1,24 @@
+#============================================================#
+# Hosted Zone / VPC Association:
+#   - Hosted Zone: aws.binbash.com.ar
+#   - VPC: EKS VPC
+#
+# Ref: https://aws.amazon.com/premiumsupport/knowledge-center/private-hosted-zone-different-account/
+#============================================================#
+
+# 1. Request authorization to associate EKS VPC to the Hosted Zone (the zone's
+# owner must issue this request)
+resource "aws_route53_vpc_association_authorization" "with_shared_vpc" {
+  provider = aws.shared
+
+  vpc_id  = module.vpc-eks.vpc_id
+  zone_id = data.terraform_remote_state.shared-dns.outputs.aws_internal_zone_id[0]
+}
+
+# 2. Accept the association authorization from the Hosted Zone owner account (shared)
+resource "aws_route53_zone_association" "with_shared_vpc" {
+  vpc_id  = module.vpc-eks.vpc_id
+  zone_id = data.terraform_remote_state.shared-dns.outputs.aws_internal_zone_id[0]
+
+  depends_on = [aws_route53_vpc_association_authorization.with_shared_vpc]
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/locals.tf
@@ -1,0 +1,202 @@
+locals {
+  cluster_name = "${var.project}-${var.environment}-eks-1ry"
+
+  # Network Local Vars
+  # https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
+  # Important
+  # Docker runs in the 172.17.0.0/16 CIDR range in Amazon EKS clusters. We recommend that your cluster's VPC subnets do
+  # not overlap this range. Otherwise, you will receive the following error:
+  # Error: : error upgrading connection: error dialing backend: dial tcp 172.17.nn.nn:10250: getsockopt: no route to host
+  vpc_name       = "${var.project}-${var.environment}-vpc-eks"
+  # Visual Subnet Calculator: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.20.0.0&mask=16&division=15.7231
+  vpc_cidr_block = "10.2.0.0/16"
+  azs = [
+    "${var.region}a",
+    "${var.region}b",
+    "${var.region}c",
+  ]
+
+  private_subnets_cidr = ["10.2.0.0/17"]
+  private_subnets = [
+    "10.2.0.0/19",
+    "10.2.32.0/19",
+    "10.2.64.0/19",
+    # "10.2.96.0/19"
+  ]
+
+  public_subnets_cidr = ["10.2.128.0/17"]
+  public_subnets = [
+    "10.2.128.0/19",
+    "10.2.160.0/19",
+    "10.2.192.0/19",
+    # "10.2.224.0/19"
+  ]
+
+  tags = {
+    Terraform   = "true"
+    Environment = var.environment
+  }
+
+  # We need these so that k8s aws cloud provider recognizes our private subnets
+  # and associates them to any load balancer that is created
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+}
+
+locals {
+  # private inbounds
+  private_inbound = flatten([
+    for index, state in local.datasources-vpcs : [
+      for k, v in state.outputs.private_subnets_cidr :
+      {
+        rule_number = 10 * (index(keys(local.datasources-vpcs), index) + 1) + 100 * k
+        rule_action = "allow"
+        from_port   = 0
+        to_port     = 65535
+        protocol    = "all"
+        cidr_block  = state.outputs.private_subnets_cidr[k]
+      }
+    ]
+  ])
+
+  network_acls = {
+    #
+    # Allow / Deny VPC private subnets inbound default traffic
+    #
+    default_inbound = [
+      {
+        rule_number = 200 # Allow traffic from this vpc's private subnets
+        rule_action = "allow"
+        from_port   = 0
+        to_port     = 65535
+        protocol    = "all"
+        cidr_block  = local.private_subnets_cidr[0]
+      },
+      {
+        rule_number = 900 # shared pritunl vpn server
+        rule_action = "allow"
+        from_port   = 0
+        to_port     = 65535
+        protocol    = "all"
+        cidr_block  = "${data.terraform_remote_state.tools-vpn-server.outputs.instance_private_ip}/32"
+      },
+      {
+        rule_number = 910 # NTP traffic
+        rule_action = "allow"
+        from_port   = 123
+        to_port     = 123
+        protocol    = "udp"
+        cidr_block  = "0.0.0.0/0"
+      },
+      {
+        rule_number = 920 # Fltering known TCP ports (0-1024)
+        rule_action = "allow"
+        from_port   = 1024
+        to_port     = 65525
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+      },
+      {
+        rule_number = 930 # Fltering known UDP ports (0-1024)
+        rule_action = "allow"
+        from_port   = 1024
+        to_port     = 65525
+        protocol    = "udp"
+        cidr_block  = "0.0.0.0/0"
+      },
+      {
+        rule_number = 940 # HCP Vault HVN vpc
+        rule_action = "allow"
+        from_port   = 0
+        to_port     = 65535
+        protocol    = "all"
+        cidr_block  = var.vpc_vault_hvn_cidr
+      },
+    ]
+
+    #
+    # Allow VPC private subnets inbound traffic
+    #
+    private_inbound = local.private_inbound
+  }
+
+  # Data source definitions
+  #
+
+  #########
+  # NACLs #
+  #########
+
+  # shared
+  shared-vpcs = {
+    shared-base = {
+      region  = var.region
+      profile = "${var.project}-shared-devops"
+      bucket  = "${var.project}-shared-terraform-backend"
+      key     = "shared/network/terraform.tfstate"
+    }
+  }
+
+  # network
+  network-vpcs = {
+    network-base = {
+      region  = var.region
+      profile = "${var.project}-network-devops"
+      bucket  = "${var.project}-network-terraform-backend"
+      key     = "network/network/terraform.tfstate"
+    }
+    network-firewall = {
+      region  = var.region
+      profile = "${var.project}-network-devops"
+      bucket  = "${var.project}-network-terraform-backend"
+      key     = "network/network-firewall/terraform.tfstate"
+    }
+  }
+
+  datasources-vpcs = merge(
+    var.enable_tgw ? data.terraform_remote_state.network-vpcs : null, # network
+    data.terraform_remote_state.shared-vpcs,                          # shared
+  )
+
+  ################
+  # VPC Peerings #
+  ################
+
+  # apps-devstg
+  apps-devstg-vpcs = {
+    apps-devstg-base = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/network/terraform.tfstate"
+      tgw     = false
+    }
+    apps-devstg-k8s-eks-v117 = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/k8s-eks-v1.17/network/terraform.tfstate"
+      tgw     = false
+    }
+    apps-devstg-k8s-eks = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/k8s-eks/network/terraform.tfstate"
+      tgw     = false
+    }
+    apps-devstg-k8s-eks-demoapps = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/k8s-eks-demoapps/network/terraform.tfstate"
+      tgw     = false
+    }
+  }
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/locals.tf
@@ -7,7 +7,7 @@ locals {
   # Docker runs in the 172.17.0.0/16 CIDR range in Amazon EKS clusters. We recommend that your cluster's VPC subnets do
   # not overlap this range. Otherwise, you will receive the following error:
   # Error: : error upgrading connection: error dialing backend: dial tcp 172.17.nn.nn:10250: getsockopt: no route to host
-  vpc_name       = "${var.project}-${var.environment}-vpc-eks"
+  vpc_name = "${var.project}-${var.environment}-vpc-eks"
   # Visual Subnet Calculator: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.20.0.0&mask=16&division=15.7231
   vpc_cidr_block = "10.2.0.0/16"
   azs = [

--- a/apps-devstg/us-east-1/k8s-eks/network/network.auto.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks/network/network.auto.tfvars
@@ -1,0 +1,1 @@
+vpc_enable_nat_gateway = true

--- a/apps-devstg/us-east-1/k8s-eks/network/network.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/network.tf
@@ -1,0 +1,135 @@
+#
+# EKS VPC
+#
+module "vpc-eks" {
+  source = "github.com/binbashar/terraform-aws-vpc.git?ref=v3.14.2"
+
+  name = local.vpc_name
+  cidr = local.vpc_cidr_block
+
+  azs             = local.azs
+  private_subnets = local.private_subnets
+  public_subnets  = local.public_subnets
+
+  enable_nat_gateway   = var.vpc_enable_nat_gateway
+  single_nat_gateway   = var.vpc_single_nat_gateway
+  enable_dns_hostnames = var.vpc_enable_dns_hostnames
+  enable_vpn_gateway   = var.vpc_enable_vpn_gateway
+
+  # Use a custom network ACL rules for private and public subnets
+  manage_default_network_acl    = false
+  public_dedicated_network_acl  = true
+  private_dedicated_network_acl = true
+  private_inbound_acl_rules = concat(
+    local.network_acls["default_inbound"],
+    local.network_acls["private_inbound"],
+  )
+
+  public_subnet_tags  = local.public_subnet_tags
+  private_subnet_tags = local.private_subnet_tags
+  tags                = local.tags
+}
+
+# VPC Endpoints
+locals {
+  vpc_endpoints = merge({
+    # S3
+    s3 = {
+      service      = "s3"
+      service_type = "Gateway"
+    }
+    # DynamamoDB
+    dynamodb = {
+      service      = "dynamodb"
+      service_type = "Gateway"
+    }
+    },
+    # KMS
+    { for k, v in { kms = "Interface" } :
+      k => {
+        service             = k
+        service_type        = v
+        security_group_ids  = aws_security_group.kms_vpce[0].id
+        private_dns_enabled = var.enable_kms_endpoint_private_dns
+      } if var.enable_kms_endpoint
+    }
+  )
+}
+
+# VPC Endpoints
+module "vpc_endpoints" {
+  source = "github.com/binbashar/terraform-aws-vpc.git//modules/vpc-endpoints?ref=v3.11.0"
+
+  for_each = local.vpc_endpoints
+
+  vpc_id = module.vpc-eks.vpc_id
+
+  endpoints = {
+    endpoint = merge(each.value,
+      {
+        route_table_ids = concat(module.vpc-eks.private_route_table_ids, module.vpc-eks.public_route_table_ids)
+      }
+    )
+  }
+
+  tags = local.tags
+}
+
+#
+# KMS VPC Endpoint: Security Group
+#
+resource "aws_security_group" "kms_vpce" {
+  count       = var.enable_kms_endpoint ? 1 : 0
+  name        = "kms_vpce"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = module.vpc-eks.vpc_id
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [local.vpc_cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+####################
+# TGW Route tables #
+####################
+
+# Update public RT
+resource "aws_route" "public_rt_routes_to_tgw" {
+
+  # For TWG CIDRs
+  for_each = {
+    for k, v in var.tgw_cidrs :
+    k => v if var.enable_tgw && length(var.tgw_cidrs) > 0
+  }
+
+  # ...add a route into the network public RT
+  route_table_id         = module.vpc-eks.public_route_table_ids[0]
+  destination_cidr_block = each.value
+  transit_gateway_id     = data.terraform_remote_state.tgw[0].outputs.tgw_id
+
+}
+
+# Update private RT
+resource "aws_route" "private_rt_routes_to_tgw" {
+
+  # If TGW enable
+  count = var.enable_tgw ? 1 : 0
+
+  # ...add a route into the network private RT
+  route_table_id         = module.vpc-eks.private_route_table_ids[0]
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = data.terraform_remote_state.tgw[0].outputs.tgw_id
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/network_vpc_peering_accepter_vault_hvn.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/network_vpc_peering_accepter_vault_hvn.tf
@@ -1,0 +1,35 @@
+#
+# VPC Peering Connection with Apps Dev: Accepter Side
+#
+resource "aws_vpc_peering_connection_accepter" "with_vault_hvn" {
+  count = var.vpc_vault_hvn_created == true ? 1 : 0
+
+  vpc_peering_connection_id = var.vpc_vault_hvn_peering_connection_id
+  auto_accept               = true
+
+  tags = merge({ "Name" = "accepter-shared-from-vault-hvn" }, local.tags)
+}
+
+#
+# Update Route Tables to go through the VPC Peering Connection
+# ---
+# Both private and public subnets traffic will be routed and permitted through VPC Peerings (filtered by Private Inbound NACLs)
+# If strictly needed private subnets must be exposed via Load Balancers (NLBs || ALBs)
+# reducing public IPs exposure whenever possible.
+# read more: https://github.com/binbashar/le-tf-infra-aws/issues/49
+#
+resource "aws_route" "priv_route_table_1_to_vault_hvn_vpc" {
+  count = var.vpc_vault_hvn_created == true ? 1 : 0
+
+  route_table_id            = element(module.vpc-eks.private_route_table_ids, 0)
+  destination_cidr_block    = var.vpc_vault_hvn_cidr
+  vpc_peering_connection_id = var.vpc_vault_hvn_peering_connection_id
+}
+
+resource "aws_route" "pub_route_table_1_to_vault_hvn_vpc" {
+  count = var.vpc_vault_hvn_created == true ? 1 : 0
+
+  route_table_id            = element(module.vpc-eks.public_route_table_ids, 0)
+  destination_cidr_block    = var.vpc_vault_hvn_cidr
+  vpc_peering_connection_id = var.vpc_vault_hvn_peering_connection_id
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/outputs.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/outputs.tf
@@ -1,0 +1,64 @@
+# VPC ID
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc-eks.vpc_id
+}
+
+output "cluster_name" {
+  description = "EKS Cluster Name"
+  value       = local.cluster_name
+}
+
+#
+# VPC Module
+#
+output "vpc_name" {
+  description = "VPC Name"
+  value       = local.vpc_name
+}
+
+output "vpc_cidr_block" {
+  description = "VPC CIDR Block"
+  value       = local.vpc_cidr_block
+}
+
+output "availability_zones" {
+  description = "List of availability zones"
+  value       = local.azs
+}
+
+# Subnets
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.vpc-eks.private_subnets
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc-eks.public_subnets
+}
+
+output "private_subnets_cidr" {
+  description = "List of IDs of private subnets"
+  value       = local.private_subnets_cidr
+}
+
+output "public_subnets_cidr" {
+  description = "List of IDs of public subnets"
+  value       = local.public_subnets_cidr
+}
+
+output "nat_gateway_ids" {
+  description = "NAT Gateway IDs"
+  value       = module.vpc-eks.natgw_ids
+}
+
+output "public_route_table_ids" {
+  description = "List of IDs of public route tables"
+  value       = module.vpc-eks.public_route_table_ids
+}
+
+output "private_route_table_ids" {
+  description = "List of IDs of private route tables"
+  value       = module.vpc-eks.private_route_table_ids
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/variables.tf
@@ -1,0 +1,68 @@
+#===========================================#
+# Networking                                #
+#===========================================#
+variable "vpc_shared_created" {
+  description = "true if Shared account EKS VPC exists and needs DNS association"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_apps_devstg_eks_dns_assoc" {
+  description = "true if Dev account EKS VPC exists and needs DNS association"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_vault_hvn_created" {
+  description = "true if the Hahicorp Vault Cloud HVN account VPC is created for Peering purposes"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_vault_hvn_peering_connection_id" {
+  description = "Hahicorp Vault Cloud HVN VPC peering ID"
+  type        = string
+  default     = "pcx-0c270c9be265da78d"
+}
+
+variable "vpc_vault_hvn_cidr" {
+  description = "Hahicorp Vault Cloud HVN VPC CIDR segment"
+  type        = string
+  default     = "172.25.16.0/20"
+}
+
+variable "vpc_enable_nat_gateway" {
+  description = "Enable NAT Gatewway"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_single_nat_gateway" {
+  description = "Single NAT Gatewway"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_enable_dns_hostnames" {
+  description = "Enable DNS HOSTNAME"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_enable_vpn_gateway" {
+  description = "Enable VPN Gateway"
+  type        = bool
+  default     = false
+}
+
+variable "enable_kms_endpoint" {
+  description = "Enable KMS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "enable_kms_endpoint_private_dns" {
+  description = "Enable KMS endpoint"
+  type        = bool
+  default     = false
+}

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/README.md
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/README.md
@@ -1,4 +1,4 @@
 # AWS EKS Reference Layer (module: terraform-aws-eks v1.17x)
 
-follow [README.md](../../us-east-1/k8s-eks-v1.17/README.md) 
+follow [README.md](../../us-east-1/k8s-eks-v1.17/README.md)
 

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/README.md
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/README.md
@@ -1,0 +1,4 @@
+# AWS EKS Reference Layer (module: terraform-aws-eks v1.17x)
+
+follow [README.md](../../us-east-1/k8s-eks-v1.17/README.md) 
+

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/network/locals.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/network/locals.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name = "${var.project}-${var.environment}-eks-v117-2ry"
 
-  vpc_name = "${var.project}-${var.environment}-vpc-eks-secondary"
+  vpc_name = "${var.project}-${var.environment}-vpc-eks-v117-2ry"
   # Ref: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.10.0.0&mask=16&division=15.7231
   vpc_cidr_block = "10.10.0.0/16"
   azs = [

--- a/shared/us-east-1/base-network/locals.tf
+++ b/shared/us-east-1/base-network/locals.tf
@@ -135,6 +135,12 @@ locals {
       bucket  = "${var.project}-apps-devstg-terraform-backend"
       key     = "apps-devstg/k8s-eks-v1.17/network/terraform.tfstate"
     }
+    apps-devstg-k8s-eks = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/k8s-eks/network/terraform.tfstate"
+    }
     apps-devstg-eks-demoapps = {
       region  = var.region
       profile = "${var.project}-apps-devstg-devops"


### PR DESCRIPTION
### What?

#### Commits on Jun 30, 2022

- [Completing k8s-eks-v1.17 README.mds](https://github.com/binbashar/le-tf-infra-aws/commit/f5a4bbda0edf70efcffb5f727fdbe14a2c4372b3) - @[exequielrafaela](https://github.com/binbashar/le-tf-infra-aws/commits?author=exequielrafaela)

- [updating network local definitions to include k8s-eks-v117 and k8s-eks vpcs to be used in VPC peerings and DNS associations](https://github.com/binbashar/le-tf-infra-aws/commit/49dd340cd99196c94f53260c0e5a55734c55dc7b) - @[exequielrafaela](https://github.com/binbashar/le-tf-infra-aws/commits?author=exequielrafaela)

- [Upgrading k8s-eks-v117 module to a newer version](https://github.com/binbashar/le-tf-infra-aws/commit/5b1bbd007ef8c438c4c1d25239731f6dc8e85fb8) - @[exequielrafaela](https://github.com/binbashar/le-tf-infra-aws/commits?author=exequielrafaela)
  
- [apps-devstg/us-east-1/k8s-eks/network layer created, including vpc, peerings and dns assoc](https://github.com/binbashar/le-tf-infra-aws/commit/153ce0c3d2e684768d8a017561ac60802c1ffdab) - @[exequielrafaela](https://github.com/binbashar/le-tf-infra-aws/commits?author=exequielrafaela)
exequielrafaela committed 25 seconds ago

### Why?
Complements Feature/ structuring code to support both k8s-eks-v1.17 (module) and latest k8-eks version Feature/ structuring code to support both k8s-eks-v1.17 (module) and latest k8-eks version  #397 (Feature/ structuring code to support both k8s-eks-v1.17 (module) and latest k8-eks version  #397)

### Screenshots

<img width="857" alt="image" src="https://user-images.githubusercontent.com/18539704/176722655-969f685c-9ea9-4a2b-aeda-3e7767b3152b.png">

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/18539704/176723125-f5738e75-df54-4cbb-9ef9-0a193c70a885.png">

