### PR TITLE
Enhancement |  Refactor common.tfvars account vars

### DIFF
--- a/apps-devstg/global/base-identities/roles.tf
+++ b/apps-devstg/global/base-identities/roles.tf
@@ -118,7 +118,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.accounts.root.id}:root"
+    "arn:aws:iam::${var.accounts.management.id}:root"
   ]
 
   create_role           = true

--- a/apps-devstg/global/base-identities/roles.tf
+++ b/apps-devstg/global/base-identities/roles.tf
@@ -118,7 +118,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.root_account_id}:root"
+    "arn:aws:iam::${var.accounts.root.id}:root"
   ]
 
   create_role           = true

--- a/apps-devstg/global/base-identities/roles.tf
+++ b/apps-devstg/global/base-identities/roles.tf
@@ -9,7 +9,7 @@ module "iam_assumable_role_devops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true
@@ -36,7 +36,7 @@ module "iam_assumable_role_admin" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role           = true
@@ -62,7 +62,7 @@ module "iam_assumable_role_auditor" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role            = true
@@ -90,7 +90,7 @@ module "iam_assumable_role_deploy_master" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root",
+    "arn:aws:iam::${var.accounts.security.id}:root",
     "arn:aws:iam::${var.shared_account_id}:root"
   ]
 

--- a/apps-devstg/global/base-identities/roles.tf
+++ b/apps-devstg/global/base-identities/roles.tf
@@ -91,7 +91,7 @@ module "iam_assumable_role_deploy_master" {
 
   trusted_role_arns = [
     "arn:aws:iam::${var.accounts.security.id}:root",
-    "arn:aws:iam::${var.shared_account_id}:root"
+    "arn:aws:iam::${var.accounts.shared.id}:root"
   ]
 
   create_role = true
@@ -144,7 +144,7 @@ module "iam_assumable_role_grafana" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.shared_account_id}:root"
+    "arn:aws:iam::${var.accounts.shared.id}:root"
   ]
 
   create_role = true

--- a/apps-devstg/us-east-1/databases-aurora/rds-export-to-s3/main.tf
+++ b/apps-devstg/us-east-1/databases-aurora/rds-export-to-s3/main.tf
@@ -27,7 +27,7 @@ module "rds_export_to_s3" {
   snapshots_bucket_arn  = module.bucket.s3_bucket_arn
 
   # The SNS topic that will receive notifications about exported snapshots events
-  notifications_topic_arn = "arn:aws:sns:us-east-1:${var.appsdevstg_account_id}:sns-topic-slack-notify-monitoring-sec"
+  notifications_topic_arn = "arn:aws:sns:us-east-1:${var.accounts.apps-devstg.id}:sns-topic-slack-notify-monitoring-sec"
 
   # A logging level which is useful for debugging
   log_level = "DEBUG"

--- a/apps-devstg/us-east-1/databases-aurora/rds-export-to-s3/variables.tf
+++ b/apps-devstg/us-east-1/databases-aurora/rds-export-to-s3/variables.tf
@@ -61,31 +61,6 @@ variable "region_secondary" {
   description = "AWS Scondary Region for HA"
 }
 
-variable "root_account_id" {
-  type        = string
-  description = "Account: Root"
-}
-
-variable "security_account_id" {
-  type        = string
-  description = "Account: Security & Users Management"
-}
-
-variable "shared_account_id" {
-  type        = string
-  description = "Account: Shared Resources"
-}
-
-variable "appsdevstg_account_id" {
-  type        = string
-  description = "Account: Dev Modules & Libs"
-}
-
-variable "appsprd_account_id" {
-  type        = string
-  description = "Account: Prod Modules & Libs"
-}
-
 variable "network_account_id" {
   type        = string
   description = "Account: Network"

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -10,7 +10,7 @@ locals {
   map_accounts = [
     # var.accounts.security.id, # security
     # var.accounts.shared.id, # shared
-    # var.appsdevstg_account_id, # apps-devstg
+    # var.accounts.apps-devstg.id, # apps-devstg
   ]
 
   # Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format
@@ -35,7 +35,7 @@ locals {
     # Github Actions Workflow will assume this role in order to be able to destroy the cluster
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster"
       username = "DeployMaster"
       groups = [
       "system:masters"]
@@ -44,7 +44,7 @@ locals {
     # Allow DevOps role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"
       username = "DevOps"
       groups = [
       "system:masters"]

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -8,7 +8,7 @@ locals {
   # Additional AWS account numbers to add to the aws-auth configmap
   #
   map_accounts = [
-    # var.security_account_id, # security
+    # var.accounts.security.id, # security
     # var.shared_account_id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
@@ -17,12 +17,12 @@ locals {
   #
   map_users = [
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/jane.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/jane.doe"
     #   username = "jane.doe"
     #   groups   = ["system:masters"]
     # },
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/john.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/john.doe"
     #   username = "john.doe"
     #   groups   = ["system:masters"]
     # },

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -9,7 +9,7 @@ locals {
   #
   map_accounts = [
     # var.accounts.security.id, # security
-    # var.shared_account_id, # shared
+    # var.accounts.shared.id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
 

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/monitoring_logging.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/monitoring_logging.tf
@@ -22,7 +22,7 @@ resource "helm_release" "fluentd_awses" {
   values = [
     templatefile("chart-values/fluentd-elasticsearch-aws.yaml",
       {
-        roleArn = "arn:aws:iam::${var.shared_account_id}:role/demoapps-aws-es-proxy"
+        roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/demoapps-aws-es-proxy"
       }
     )
   ]

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/networking.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/networking.tf
@@ -36,7 +36,7 @@ resource "helm_release" "externaldns_private" {
   version    = "4.6.0"
   values = [
     templatefile("chart-values/externaldns-private.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-demoapps-externaldns-private"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-demoapps-externaldns-private"
     })
   ]
 }
@@ -53,7 +53,7 @@ resource "helm_release" "externaldns_public" {
   version    = "4.6.0"
   values = [
     templatefile("chart-values/externaldns-public.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-demoapps-externaldns-public"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-demoapps-externaldns-public"
     })
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/scaling.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/scaling.tf
@@ -27,7 +27,7 @@ resource "helm_release" "cluster_autoscaling" {
       {
         aws_region   = var.region,
         cluster_name = data.terraform_remote_state.eks-demoapps-cluster.outputs.cluster_name
-        roleArn      = "arn:aws:iam::${var.appsdevstg_account_id}:role/appsdevstg-demoapps-cluster-autoscaler"
+        roleArn      = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/appsdevstg-demoapps-cluster-autoscaler"
       }
     )
   ]

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/security.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/security.tf
@@ -11,7 +11,7 @@ resource "helm_release" "certmanager" {
   values = [
     templatefile("chart-values/certmanager.yaml",
       {
-        roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-demoapps-certmanager"
+        roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-demoapps-certmanager"
       }
     )
   ]

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-workloads/demoapps.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-workloads/demoapps.tf
@@ -36,7 +36,7 @@ resource "helm_release" "sockshop" {
   version    = "0.2.0"
   values = [
     templatefile("chart-values/demoapps-sockshop.yaml", {
-      accountid = var.shared_account_id,
+      accountid = var.accounts.shared.id,
       region    = var.region
     })
   ]

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/locals.tf
@@ -8,7 +8,7 @@ locals {
   # Additional AWS account numbers to add to the aws-auth configmap
   #
   map_accounts = [
-    # var.security_account_id, # security
+    # var.accounts.security.id, # security
     # var.shared_account_id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
@@ -17,12 +17,12 @@ locals {
   #
   map_users = [
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/jane.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/jane.doe"
     #   username = "jane.doe"
     #   groups   = ["system:masters"]
     # },
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/john.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/john.doe"
     #   username = "john.doe"
     #   groups   = ["system:masters"]
     # },

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/locals.tf
@@ -9,7 +9,7 @@ locals {
   #
   map_accounts = [
     # var.accounts.security.id, # security
-    # var.shared_account_id, # shared
+    # var.accounts.shared.id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
 

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/cluster/locals.tf
@@ -10,7 +10,7 @@ locals {
   map_accounts = [
     # var.accounts.security.id, # security
     # var.accounts.shared.id, # shared
-    # var.appsdevstg_account_id, # apps-devstg
+    # var.accounts.apps-devstg.id, # apps-devstg
   ]
 
   # Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format
@@ -35,7 +35,7 @@ locals {
     # Github Actions Workflow will assume this role in order to be able to destroy the cluster
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster"
       username = "DeployMaster"
       groups = [
       "system:masters"]
@@ -44,7 +44,7 @@ locals {
     # Allow DevOps role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"
       username = "DevOps"
       groups = [
       "system:masters"]
@@ -53,7 +53,7 @@ locals {
     # Allow DevOps SSO role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_5e0501636a32f9c4"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_5e0501636a32f9c4"
       username = "DevOps"
       groups = [
       "system:masters"]

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/monitoring_logging.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/monitoring_logging.tf
@@ -21,7 +21,7 @@ resource "helm_release" "fluentd_awses" {
   version    = "11.12.0"
   values = [
     templatefile("chart-values/fluentd-elasticsearch-aws.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/aws-es-proxy"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/aws-es-proxy"
     })
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/networking.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/networking.tf
@@ -36,7 +36,7 @@ resource "helm_release" "externaldns_private" {
   version    = "6.5.3"
   values = [
     templatefile("chart-values/externaldns-private.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-externaldns-private"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-externaldns-private"
     })
   ]
 }
@@ -53,7 +53,7 @@ resource "helm_release" "externaldns_public" {
   version    = "4.6.0"
   values = [
     templatefile("chart-values/externaldns-public.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-externaldns-public"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-externaldns-public"
     })
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/scaling.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/scaling.tf
@@ -27,7 +27,7 @@ resource "helm_release" "cluster_autoscaling" {
       {
         aws_region   = var.region,
         cluster_name = data.terraform_remote_state.eks-cluster.outputs.cluster_name,
-        roleArn      = "arn:aws:iam::${var.appsdevstg_account_id}:role/appsdevstg-cluster-autoscaler"
+        roleArn      = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/appsdevstg-cluster-autoscaler"
       }
     )
   ]

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/security.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/security.tf
@@ -10,7 +10,7 @@ resource "helm_release" "certmanager" {
   version    = "1.1.0"
   values = [
     templatefile("chart-values/certmanager.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-certmanager"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-certmanager"
     })
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-workloads/demoapps.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-workloads/demoapps.tf
@@ -36,7 +36,7 @@ resource "helm_release" "sockshop" {
   version    = "0.2.0"
   values = [
     templatefile("chart-values/demoapps-sockshop.yaml", {
-      accountid = var.shared_account_id,
+      accountid = var.accounts.shared.id,
       region    = var.region
     })
   ]

--- a/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf
@@ -8,7 +8,7 @@ locals {
   # Additional AWS account numbers to add to the aws-auth configmap
   #
   map_accounts = [
-    # var.security_account_id, # security
+    # var.accounts.security.id, # security
     # var.shared_account_id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
@@ -17,12 +17,12 @@ locals {
   #
   map_users = [
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/jane.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/jane.doe"
     #   username = "jane.doe"
     #   groups   = ["system:masters"]
     # },
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/john.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/john.doe"
     #   username = "john.doe"
     #   groups   = ["system:masters"]
     # },

--- a/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf
@@ -9,7 +9,7 @@ locals {
   #
   map_accounts = [
     # var.accounts.security.id, # security
-    # var.shared_account_id, # shared
+    # var.accounts.shared.id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
 

--- a/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks/cluster/locals.tf
@@ -10,7 +10,7 @@ locals {
   map_accounts = [
     # var.accounts.security.id, # security
     # var.accounts.shared.id, # shared
-    # var.appsdevstg_account_id, # apps-devstg
+    # var.accounts.apps-devstg.id, # apps-devstg
   ]
 
   # Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format
@@ -35,7 +35,7 @@ locals {
     # Github Actions Workflow will assume this role in order to be able to destroy the cluster
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster"
       username = "DeployMaster"
       groups = [
       "system:masters"]
@@ -44,7 +44,7 @@ locals {
     # Allow DevOps role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"
       username = "DevOps"
       groups = [
       "system:masters"]
@@ -53,7 +53,7 @@ locals {
     # Allow DevOps SSO role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_5e0501636a32f9c4"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_5e0501636a32f9c4"
       username = "DevOps"
       groups = [
       "system:masters"]

--- a/apps-devstg/us-east-1/k8s-kind/k8s-resources/networking.tf
+++ b/apps-devstg/us-east-1/k8s-kind/k8s-resources/networking.tf
@@ -37,7 +37,7 @@ resource "helm_release" "external_dns_private" {
   values = [
     templatefile("chart-values/externaldns-private.yaml",
       {
-        roleArn = "arn:aws:iam::${var.shared_account_id}:role/demoapps-external-dns-private"
+        roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/demoapps-external-dns-private"
       }
     )
   ]
@@ -56,7 +56,7 @@ resource "helm_release" "external_dns_public" {
   values = [
     templatefile("chart-values/externaldns-public.yaml",
       {
-        roleArn = "arn:aws:iam::${var.shared_account_id}:role/demoapps-external-dns-public"
+        roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/demoapps-external-dns-public"
       }
     )
   ]

--- a/apps-devstg/us-east-1/k8s-kind/k8s-resources/security.tf
+++ b/apps-devstg/us-east-1/k8s-kind/k8s-resources/security.tf
@@ -11,7 +11,7 @@ resource "helm_release" "cert_manager" {
   values = [
     templatefile("chart-values/certmanager.yaml",
       {
-        roleArn = "arn:aws:iam::${var.shared_account_id}:role/demoapps-cert-manager"
+        roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/demoapps-cert-manager"
       }
     )
   ]

--- a/apps-devstg/us-east-1/k8s-kops --/1-prerequisites/variables.tf
+++ b/apps-devstg/us-east-1/k8s-kops --/1-prerequisites/variables.tf
@@ -61,36 +61,6 @@ variable "region_secondary" {
   description = "AWS Scondary Region for HA"
 }
 
-variable "root_account_id" {
-  type        = string
-  description = "Account: Root"
-}
-
-variable "security_account_id" {
-  type        = string
-  description = "Account: Security & Users Management"
-}
-
-variable "shared_account_id" {
-  type        = string
-  description = "Account: Shared Resources"
-}
-
-variable "network_account_id" {
-  type        = string
-  description = "Account: Networking Resources"
-}
-
-variable "appsdevstg_account_id" {
-  type        = string
-  description = "Account: Dev Modules & Libs"
-}
-
-variable "appsprd_account_id" {
-  type        = string
-  description = "Account: Prod Modules & Libs"
-}
-
 #===========================================#
 # DNS                                       #
 #===========================================#

--- a/apps-devstg/us-east-1/security-audit/awscloudtrail.tf
+++ b/apps-devstg/us-east-1/security-audit/awscloudtrail.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.appsdevstg_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.apps-devstg.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.appsdevstg_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.apps-devstg.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/apps-devstg/us-east-1/security-keys/kms.tf
+++ b/apps-devstg/us-east-1/security-keys/kms.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "kms" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${var.appsdevstg_account_id}:root",
-        "arn:aws:iam::${var.security_account_id}:user/${data.terraform_remote_state.security-identities.outputs.user_s3_demo_name}"
+        "arn:aws:iam::${var.accounts.security.id}:user/${data.terraform_remote_state.security-identities.outputs.user_s3_demo_name}"
       ]
     }
   }

--- a/apps-devstg/us-east-1/security-keys/kms.tf
+++ b/apps-devstg/us-east-1/security-keys/kms.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.appsdevstg_account_id}:root",
+        "arn:aws:iam::${var.accounts.apps-devstg.id}:root",
         "arn:aws:iam::${var.accounts.security.id}:user/${data.terraform_remote_state.security-identities.outputs.user_s3_demo_name}"
       ]
     }
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region}:${var.appsdevstg_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region}:${var.accounts.apps-devstg.id}:*"]
     }
   }
 }

--- a/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_policies.tf
+++ b/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_policies.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 
       principals {
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.security_account_id}:user/${statement.value["user"]}"]
+        identifiers = ["arn:aws:iam::${var.accounts.security.id}:user/${statement.value["user"]}"]
       }
 
       actions = [

--- a/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_policies.tf
+++ b/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_policies.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps"]
+      identifiers = ["arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"]
     }
 
     actions = [

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/cluster/locals.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/cluster/locals.tf
@@ -8,7 +8,7 @@ locals {
   # Additional AWS account numbers to add to the aws-auth configmap
   #
   map_accounts = [
-    # var.security_account_id, # security
+    # var.accounts.security.id, # security
     # var.shared_account_id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
@@ -17,12 +17,12 @@ locals {
   #
   map_users = [
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/jane.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/jane.doe"
     #   username = "jane.doe"
     #   groups   = ["system:masters"]
     # },
     # {
-    #   userarn  = "arn:aws:iam:${var.security_account_id}:user/john.doe"
+    #   userarn  = "arn:aws:iam:${var.accounts.security.id}:user/john.doe"
     #   username = "john.doe"
     #   groups   = ["system:masters"]
     # },

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/cluster/locals.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/cluster/locals.tf
@@ -9,7 +9,7 @@ locals {
   #
   map_accounts = [
     # var.accounts.security.id, # security
-    # var.shared_account_id, # shared
+    # var.accounts.shared.id, # shared
     # var.appsdevstg_account_id, # apps-devstg
   ]
 

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/cluster/locals.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/cluster/locals.tf
@@ -10,7 +10,7 @@ locals {
   map_accounts = [
     # var.accounts.security.id, # security
     # var.accounts.shared.id, # shared
-    # var.appsdevstg_account_id, # apps-devstg
+    # var.accounts.apps-devstg.id, # apps-devstg
   ]
 
   # Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format
@@ -35,7 +35,7 @@ locals {
     # Github Actions Workflow will assume this role in order to be able to destroy the cluster
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster"
       username = "DeployMaster"
       groups = [
       "system:masters"]
@@ -44,7 +44,7 @@ locals {
     # Allow DevOps role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"
       username = "DevOps"
       groups = [
       "system:masters"]
@@ -53,7 +53,7 @@ locals {
     # Allow DevOps SSO role to become cluster admins
     #
     {
-      rolearn  = "arn:aws:iam::${var.appsdevstg_account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_5e0501636a32f9c4"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_5e0501636a32f9c4"
       username = "DevOps"
       groups = [
       "system:masters"]

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/demoapps.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/demoapps.tf
@@ -38,7 +38,7 @@ resource "helm_release" "sockshop" {
   version    = "0.2.0"
   values = [
     templatefile("chart-values/demoapps-sockshop.yaml", {
-      accountid = var.shared_account_id,
+      accountid = var.accounts.shared.id,
       region    = var.region_secondary
     })
   ]

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/monitoring_logging.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/monitoring_logging.tf
@@ -21,7 +21,7 @@ resource "helm_release" "fluentd_awses" {
   version    = "11.12.0"
   values = [
     templatefile("chart-values/fluentd-elasticsearch-aws.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/aws-es-proxy"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/aws-es-proxy"
     })
   ]
 }

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/networking.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/networking.tf
@@ -36,7 +36,7 @@ resource "helm_release" "externaldns_private" {
   version    = "6.5.3"
   values = [
     templatefile("chart-values/externaldns-private.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-dr-externaldns-private"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-dr-externaldns-private"
     })
   ]
 }
@@ -53,7 +53,7 @@ resource "helm_release" "externaldns_public" {
   version    = "4.6.0"
   values = [
     templatefile("chart-values/externaldns-public.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-dr-externaldns-public"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-dr-externaldns-public"
     })
   ]
 }

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/scaling.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/scaling.tf
@@ -27,7 +27,7 @@ resource "helm_release" "cluster_autoscaling" {
       {
         aws_region   = var.region,
         cluster_name = data.terraform_remote_state.eks-cluster.outputs.cluster_name,
-        roleArn      = "arn:aws:iam::${var.appsdevstg_account_id}:role/appsdevstg-dr-cluster-autoscaler"
+        roleArn      = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/appsdevstg-dr-cluster-autoscaler"
       }
     )
   ]

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/security.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/security.tf
@@ -10,7 +10,7 @@ resource "helm_release" "certmanager" {
   version    = "1.1.0"
   values = [
     templatefile("chart-values/certmanager.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/appsdevstg-dr-certmanager"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/appsdevstg-dr-certmanager"
     })
   ]
 }

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-workloads/common-variables.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-workloads/common-variables.tf
@@ -75,36 +75,6 @@ variable "accounts" {
   description = "Accounts descriptions"
 }
 
-variable "root_account_id" {
-  type        = string
-  description = "Account: Root"
-}
-
-variable "security_account_id" {
-  type        = string
-  description = "Account: Security & Users Management"
-}
-
-variable "shared_account_id" {
-  type        = string
-  description = "Account: Shared Resources"
-}
-
-variable "network_account_id" {
-  type        = string
-  description = "Account: Networking Resources"
-}
-
-variable "appsdevstg_account_id" {
-  type        = string
-  description = "Account: Dev Modules & Libs"
-}
-
-variable "appsprd_account_id" {
-  type        = string
-  description = "Account: Prod Modules & Libs"
-}
-
 variable "vault_address" {
   type        = string
   description = "Vault Address"

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-workloads/demoapps.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-workloads/demoapps.tf
@@ -36,7 +36,7 @@ resource "helm_release" "sockshop" {
   version    = "0.2.0"
   values = [
     templatefile("chart-values/demoapps-sockshop.yaml", {
-      accountid = var.shared_account_id,
+      accountid = var.accounts.shared.id,
       region    = var.region
     })
   ]

--- a/apps-devstg/us-east-2/security-keys/kms.tf
+++ b/apps-devstg/us-east-2/security-keys/kms.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.appsdevstg_account_id}:root"
+        "arn:aws:iam::${var.accounts.apps-devstg.id}:root"
       ]
     }
   }
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region_secondary}:${var.appsdevstg_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region_secondary}:${var.accounts.apps-devstg.id}:*"]
     }
   }
 }

--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -117,7 +117,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.root_account_id}:root"
+    "arn:aws:iam::${var.accounts.root.id}:root"
   ]
 
   create_role           = true

--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -117,7 +117,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.accounts.root.id}:root"
+    "arn:aws:iam::${var.accounts.management.id}:root"
   ]
 
   create_role           = true

--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -9,7 +9,7 @@ module "iam_assumable_role_devops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true
@@ -36,7 +36,7 @@ module "iam_assumable_role_admin" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role           = true
@@ -62,7 +62,7 @@ module "iam_assumable_role_auditor" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role            = true
@@ -90,7 +90,7 @@ module "iam_assumable_role_deploy_master" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true

--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -143,7 +143,7 @@ module "iam_assumable_role_grafana" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.shared_account_id}:root"
+    "arn:aws:iam::${var.accounts.shared.id}:root"
   ]
 
   create_role = true

--- a/apps-prd/us-east-1/security-audit/awscloudtrail.tf
+++ b/apps-prd/us-east-1/security-audit/awscloudtrail.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.appsprd_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.apps-prd.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.appsprd_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.apps-prd.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/apps-prd/us-east-1/security-keys/kms.tf
+++ b/apps-prd/us-east-1/security-keys/kms.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.appsprd_account_id}:root"]
+      identifiers = ["arn:aws:iam::${var.accounts.apps-prd.id}:root"]
     }
   }
 
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region}:${var.appsprd_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region}:${var.accounts.apps-prd.id}:*"]
     }
   }
 }

--- a/config/common-variables.tf
+++ b/config/common-variables.tf
@@ -75,36 +75,6 @@ variable "accounts" {
   description = "Accounts descriptions"
 }
 
-variable "root_account_id" {
-  type        = string
-  description = "Account: Root"
-}
-
-variable "security_account_id" {
-  type        = string
-  description = "Account: Security & Users Management"
-}
-
-variable "shared_account_id" {
-  type        = string
-  description = "Account: Shared Resources"
-}
-
-variable "network_account_id" {
-  type        = string
-  description = "Account: Networking Resources"
-}
-
-variable "appsdevstg_account_id" {
-  type        = string
-  description = "Account: Dev Modules & Libs"
-}
-
-variable "appsprd_account_id" {
-  type        = string
-  description = "Account: Prod Modules & Libs"
-}
-
 variable "vault_address" {
   type        = string
   description = "Vault Address"

--- a/config/common.tfvars.example
+++ b/config/common.tfvars.example
@@ -10,14 +10,6 @@ region_primary = "us-east-1"
 # AWS Region for DR replication (required by the backend but also used for other resources)
 region_secondary      = "us-east-2"
 
-# Account IDs
-root_account_id       = "111111111111"
-security_account_id   = "222222222222"
-shared_account_id     = "333333333333"
-network_account_id    = "444444444444"
-appsdevstg_account_id = "555555555555"
-appsprd_account_id    = "666666666666"
-
 # Accounts
 accounts = {
   root = {

--- a/config/common.tfvars.example
+++ b/config/common.tfvars.example
@@ -12,7 +12,7 @@ region_secondary      = "us-east-2"
 
 # Accounts
 accounts = {
-  root = {
+  management = {
     email = "aws+root@binbash.com.ar",
     id    = 111111111111
   },

--- a/management/global/base-identities/roles.tf
+++ b/management/global/base-identities/roles.tf
@@ -5,7 +5,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.root_account_id}:root"
+    "arn:aws:iam::${var.accounts.root.id}:root"
   ]
 
   create_role           = true

--- a/management/global/base-identities/roles.tf
+++ b/management/global/base-identities/roles.tf
@@ -5,7 +5,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.accounts.root.id}:root"
+    "arn:aws:iam::${var.accounts.management.id}:root"
   ]
 
   create_role           = true

--- a/management/global/cost-mgmt/main.tf
+++ b/management/global/cost-mgmt/main.tf
@@ -40,7 +40,7 @@ module "aws_cost_mgmt_budget_notif_75" {
   time_unit              = var.time_unit
   time_period_start      = var.time_period_start
   notification_threshold = var.notification_threshold_75
-  aws_sns_account_id     = var.accounts.root.id
+  aws_sns_account_id     = var.accounts.management.id
   create_sns_topic       = false
   sns_topic_arns         = [data.terraform_remote_state.notifications.outputs.sns_topic_arn_costs]
 }
@@ -55,7 +55,7 @@ module "aws_cost_mgmt_budget_notif_100" {
   time_unit              = var.time_unit
   time_period_start      = var.time_period_start
   notification_threshold = var.notification_threshold_100
-  aws_sns_account_id     = var.accounts.root.id
+  aws_sns_account_id     = var.accounts.management.id
   create_sns_topic       = false
   sns_topic_arns         = [data.terraform_remote_state.notifications.outputs.sns_topic_arn_costs]
 }

--- a/management/global/cost-mgmt/main.tf
+++ b/management/global/cost-mgmt/main.tf
@@ -40,7 +40,7 @@ module "aws_cost_mgmt_budget_notif_75" {
   time_unit              = var.time_unit
   time_period_start      = var.time_period_start
   notification_threshold = var.notification_threshold_75
-  aws_sns_account_id     = var.root_account_id
+  aws_sns_account_id     = var.accounts.root.id
   create_sns_topic       = false
   sns_topic_arns         = [data.terraform_remote_state.notifications.outputs.sns_topic_arn_costs]
 }
@@ -55,7 +55,7 @@ module "aws_cost_mgmt_budget_notif_100" {
   time_unit              = var.time_unit
   time_period_start      = var.time_period_start
   notification_threshold = var.notification_threshold_100
-  aws_sns_account_id     = var.root_account_id
+  aws_sns_account_id     = var.accounts.root.id
   create_sns_topic       = false
   sns_topic_arns         = [data.terraform_remote_state.notifications.outputs.sns_topic_arn_costs]
 }

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -27,7 +27,7 @@ module "account_assignments" {
       principal_name      = "AWS_Administrators"
     },
     {
-      account             = var.network_account_id,
+      account             = var.accounts.network.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -66,7 +66,7 @@ module "account_assignments" {
       principal_name      = "AWS_DevOps"
     },
     {
-      account             = var.network_account_id,
+      account             = var.accounts.network.id,
       permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
       permission_set_name = "DevOps",
       principal_type      = "GROUP",
@@ -116,7 +116,7 @@ module "account_assignments" {
       principal_name      = "AWS_SecOps"
     },
     {
-      account             = var.network_account_id,
+      account             = var.accounts.network.id,
       permission_set_arn  = module.permission_sets.permission_sets["SecOps"].arn,
       permission_set_name = "SecOps",
       principal_type      = "GROUP",
@@ -155,7 +155,7 @@ module "account_assignments" {
       principal_name      = "AWS_Guests"
     },
     {
-      account             = var.network_account_id,
+      account             = var.accounts.network.id,
       permission_set_arn  = module.permission_sets.permission_sets["ReadOnly"].arn,
       permission_set_name = "ReadOnly",
       principal_type      = "GROUP",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -41,7 +41,7 @@ module "account_assignments" {
       principal_name      = "AWS_Administrators"
     },
     {
-      account             = var.appsprd_account_id,
+      account             = var.accounts.apps-prd.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -80,7 +80,7 @@ module "account_assignments" {
       principal_name      = "AWS_DevOps"
     },
     {
-      account             = var.appsprd_account_id,
+      account             = var.accounts.apps-prd.id,
       permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
       permission_set_name = "DevOps",
       principal_type      = "GROUP",
@@ -130,7 +130,7 @@ module "account_assignments" {
       principal_name      = "AWS_SecOps"
     },
     {
-      account             = var.appsprd_account_id,
+      account             = var.accounts.apps-prd.id,
       permission_set_arn  = module.permission_sets.permission_sets["SecOps"].arn,
       permission_set_name = "SecOps",
       principal_type      = "GROUP",
@@ -169,7 +169,7 @@ module "account_assignments" {
       principal_name      = "AWS_Guests"
     },
     {
-      account             = var.appsprd_account_id,
+      account             = var.accounts.apps-prd.id,
       permission_set_arn  = module.permission_sets.permission_sets["ReadOnly"].arn,
       permission_set_name = "ReadOnly",
       principal_type      = "GROUP",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -20,7 +20,7 @@ module "account_assignments" {
       principal_name      = "AWS_Administrators"
     },
     {
-      account             = var.security_account_id,
+      account             = var.accounts.security.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -59,7 +59,7 @@ module "account_assignments" {
       principal_name      = "AWS_DevOps"
     },
     {
-      account             = var.security_account_id,
+      account             = var.accounts.security.id,
       permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
       permission_set_name = "DevOps",
       principal_type      = "GROUP",
@@ -109,7 +109,7 @@ module "account_assignments" {
       principal_name      = "AWS_SecOps"
     },
     {
-      account             = var.security_account_id,
+      account             = var.accounts.security.id,
       permission_set_arn  = module.permission_sets.permission_sets["SecOps"].arn,
       permission_set_name = "SecOps",
       principal_type      = "GROUP",
@@ -148,7 +148,7 @@ module "account_assignments" {
       principal_name      = "AWS_Guests"
     },
     {
-      account             = var.security_account_id,
+      account             = var.accounts.security.id,
       permission_set_arn  = module.permission_sets.permission_sets["ReadOnly"].arn,
       permission_set_name = "ReadOnly",
       principal_type      = "GROUP",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -34,7 +34,7 @@ module "account_assignments" {
       principal_name      = "AWS_Administrators"
     },
     {
-      account             = var.appsdevstg_account_id,
+      account             = var.accounts.apps-devstg.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -73,7 +73,7 @@ module "account_assignments" {
       principal_name      = "AWS_DevOps"
     },
     {
-      account             = var.appsdevstg_account_id,
+      account             = var.accounts.apps-devstg.id,
       permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
       permission_set_name = "DevOps",
       principal_type      = "GROUP",
@@ -123,7 +123,7 @@ module "account_assignments" {
       principal_name      = "AWS_SecOps"
     },
     {
-      account             = var.appsdevstg_account_id,
+      account             = var.accounts.apps-devstg.id,
       permission_set_arn  = module.permission_sets.permission_sets["SecOps"].arn,
       permission_set_name = "SecOps",
       principal_type      = "GROUP",
@@ -162,7 +162,7 @@ module "account_assignments" {
       principal_name      = "AWS_Guests"
     },
     {
-      account             = var.appsdevstg_account_id,
+      account             = var.accounts.apps-devstg.id,
       permission_set_arn  = module.permission_sets.permission_sets["ReadOnly"].arn,
       permission_set_name = "ReadOnly",
       principal_type      = "GROUP",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -6,7 +6,7 @@ module "account_assignments" {
     # AWS_Administrators Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.accounts.root.id,
+      account             = var.accounts.management.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -91,7 +91,7 @@ module "account_assignments" {
     # AWS_FinOps Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.accounts.root.id,
+      account             = var.accounts.management.id,
       permission_set_arn  = module.permission_sets.permission_sets["FinOps"].arn,
       permission_set_name = "FinOps",
       principal_type      = "GROUP",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -13,7 +13,7 @@ module "account_assignments" {
       principal_name      = "AWS_Administrators"
     },
     {
-      account             = var.shared_account_id,
+      account             = var.accounts.shared.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -52,7 +52,7 @@ module "account_assignments" {
     # AWS_DevOps Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.shared_account_id,
+      account             = var.accounts.shared.id,
       permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn,
       permission_set_name = "DevOps",
       principal_type      = "GROUP",
@@ -102,7 +102,7 @@ module "account_assignments" {
     # AWS_SecOps Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.shared_account_id,
+      account             = var.accounts.shared.id,
       permission_set_arn  = module.permission_sets.permission_sets["SecOps"].arn,
       permission_set_name = "SecOps",
       principal_type      = "GROUP",
@@ -141,7 +141,7 @@ module "account_assignments" {
     # AWS_Guests Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.shared_account_id,
+      account             = var.accounts.shared.id,
       permission_set_arn  = module.permission_sets.permission_sets["ReadOnly"].arn,
       permission_set_name = "ReadOnly",
       principal_type      = "GROUP",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -6,7 +6,7 @@ module "account_assignments" {
     # AWS_Administrators Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.root_account_id,
+      account             = var.accounts.root.id,
       permission_set_arn  = module.permission_sets.permission_sets["Administrator"].arn,
       permission_set_name = "Administrator",
       principal_type      = "GROUP",
@@ -91,7 +91,7 @@ module "account_assignments" {
     # AWS_FinOps Permissions
     # -------------------------------------------------------------------------
     {
-      account             = var.root_account_id,
+      account             = var.accounts.root.id,
       permission_set_arn  = module.permission_sets.permission_sets["FinOps"].arn,
       permission_set_name = "FinOps",
       principal_type      = "GROUP",

--- a/management/us-east-1/firewall-manager/fms.tf
+++ b/management/us-east-1/firewall-manager/fms.tf
@@ -1,4 +1,4 @@
 # Asssociate Firewall Manager Service adminidtator account
 resource "aws_fms_admin_account" "default" {
-  account_id = var.security_account_id
+  account_id = var.accounts.security.id
 }

--- a/management/us-east-1/notifications/costs_tools_monitoring.tf
+++ b/management/us-east-1/notifications/costs_tools_monitoring.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "sns-notify-costs" {
       variable = "AWS:SourceOwner"
 
       values = [
-        var.accounts.root.id,
+        var.accounts.management.id,
       ]
     }
 

--- a/management/us-east-1/notifications/costs_tools_monitoring.tf
+++ b/management/us-east-1/notifications/costs_tools_monitoring.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "sns-notify-costs" {
       variable = "AWS:SourceOwner"
 
       values = [
-        var.root_account_id,
+        var.accounts.root.id,
       ]
     }
 

--- a/management/us-east-1/notifications/policies.tf
+++ b/management/us-east-1/notifications/policies.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        var.accounts.root.id,
+        var.accounts.management.id,
       ]
     }
 

--- a/management/us-east-1/notifications/policies.tf
+++ b/management/us-east-1/notifications/policies.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        var.root_account_id,
+        var.accounts.root.id,
       ]
     }
 

--- a/management/us-east-1/security-audit/awscloudtrail.tf
+++ b/management/us-east-1/security-audit/awscloudtrail.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.root_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.root.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.root_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.root.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/management/us-east-1/security-audit/awscloudtrail.tf
+++ b/management/us-east-1/security-audit/awscloudtrail.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.accounts.root.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.management.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.accounts.root.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.management.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/management/us-east-1/security-compliance/awsconfig_delegation.tf
+++ b/management/us-east-1/security-compliance/awsconfig_delegation.tf
@@ -1,5 +1,5 @@
 resource "null_resource" "config_delegation" {
   provisioner "local-exec" {
-    command = "aws organizations register-delegated-administrator --account-id ${var.security_account_id} --service-principal config.amazonaws.com  --profile ${var.profile} --region ${var.region}"
+    command = "aws organizations register-delegated-administrator --account-id ${var.accounts.security.id} --service-principal config.amazonaws.com  --profile ${var.profile} --region ${var.region}"
   }
 }

--- a/management/us-east-1/security-keys/kms.tf
+++ b/management/us-east-1/security-keys/kms.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.root_account_id}:root"]
+      identifiers = ["arn:aws:iam::${var.accounts.root.id}:root"]
     }
   }
 
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region}:${var.root_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region}:${var.accounts.root.id}:*"]
     }
   }
 

--- a/management/us-east-1/security-keys/kms.tf
+++ b/management/us-east-1/security-keys/kms.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.accounts.root.id}:root"]
+      identifiers = ["arn:aws:iam::${var.accounts.management.id}:root"]
     }
   }
 
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region}:${var.accounts.root.id}:*"]
+      values   = ["arn:aws:logs:${var.region}:${var.accounts.management.id}:*"]
     }
   }
 

--- a/management/us-east-1/security-monitoring/guardduty.tf
+++ b/management/us-east-1/security-monitoring/guardduty.tf
@@ -9,5 +9,5 @@ module "guardduty" {
 
   guarduty_enabled                     = true
   guarduty_s3_protection_enabled       = true
-  guardduty_delegated_admin_account_id = var.security_account_id
+  guardduty_delegated_admin_account_id = var.accounts.security.id
 }

--- a/management/us-east-2/security-monitoring --/guardduty.tf
+++ b/management/us-east-2/security-monitoring --/guardduty.tf
@@ -9,5 +9,5 @@ module "guardduty" {
 
   guarduty_enabled                     = true
   guarduty_s3_protection_enabled       = true
-  guardduty_delegated_admin_account_id = var.security_account_id
+  guardduty_delegated_admin_account_id = var.accounts.security.id
 }

--- a/network/global/base-identities/roles.tf
+++ b/network/global/base-identities/roles.tf
@@ -145,7 +145,7 @@ module "iam_assumable_role_grafana" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.shared_account_id}:root"
+    "arn:aws:iam::${var.accounts.shared.id}:root"
   ]
 
   create_role = true

--- a/network/global/base-identities/roles.tf
+++ b/network/global/base-identities/roles.tf
@@ -118,7 +118,7 @@ module "iam_assumable_role_deploy_master" {
 
   trusted_role_arns = [
     "arn:aws:iam::${var.accounts.security.id}:root",
-    "arn:aws:iam::${var.network_account_id}:root"
+    "arn:aws:iam::${var.accounts.network.id}:root"
   ]
 
   create_role = true

--- a/network/global/base-identities/roles.tf
+++ b/network/global/base-identities/roles.tf
@@ -9,7 +9,7 @@ module "iam_assumable_role_devops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true
@@ -36,7 +36,7 @@ module "iam_assumable_role_secops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true
@@ -63,7 +63,7 @@ module "iam_assumable_role_admin" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role           = true
@@ -89,7 +89,7 @@ module "iam_assumable_role_auditor" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role            = true
@@ -117,7 +117,7 @@ module "iam_assumable_role_deploy_master" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root",
+    "arn:aws:iam::${var.accounts.security.id}:root",
     "arn:aws:iam::${var.network_account_id}:root"
   ]
 

--- a/network/us-east-1/security-audit/awscloudtrail.tf
+++ b/network/us-east-1/security-audit/awscloudtrail.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.network_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.network.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.network_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.network.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/network/us-east-1/security-keys/kms.tf
+++ b/network/us-east-1/security-keys/kms.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.network_account_id}:root"
+        "arn:aws:iam::${var.accounts.network.id}:root"
       ]
     }
   }

--- a/network/us-east-1/security-keys/kms.tf
+++ b/network/us-east-1/security-keys/kms.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region_secondary}:${var.appsdevstg_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region_secondary}:${var.accounts.apps-devstg.id}:*"]
     }
   }
 }

--- a/network/us-east-2/security-keys/kms.tf
+++ b/network/us-east-2/security-keys/kms.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.network_account_id}:root"
+        "arn:aws:iam::${var.accounts.network.id}:root"
       ]
     }
   }

--- a/network/us-east-2/security-keys/kms.tf
+++ b/network/us-east-2/security-keys/kms.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region_secondary}:${var.appsdevstg_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region_secondary}:${var.accounts.apps-devstg.id}:*"]
     }
   }
 }

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -23,7 +23,7 @@ resource "aws_iam_policy" "assume_devops_role" {
                 "arn:aws:iam::${var.accounts.network.id}:role/DevOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps",
-                "arn:aws:iam::${var.appsprd_account_id}:role/DevOps"
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/DevOps"
             ]
         }
     ]
@@ -52,7 +52,7 @@ resource "aws_iam_policy" "assume_secops_role" {
                 "arn:aws:iam::${var.accounts.network.id}:role/SecOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/SecOps",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/SecOps",
-                "arn:aws:iam::${var.appsprd_account_id}:role/SecOps"
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/SecOps"
             ]
         }
     ]
@@ -81,7 +81,7 @@ resource "aws_iam_policy" "assume_admin_role" {
                 "arn:aws:iam::${var.accounts.network.id}:role/Admin",
                 "arn:aws:iam::${var.accounts.security.id}:role/Admin",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Admin",
-                "arn:aws:iam::${var.appsprd_account_id}:role/Admin"
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/Admin"
             ]
         }
     ]
@@ -109,7 +109,7 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
                 "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
                 "arn:aws:iam::${var.accounts.network.id}:role/DeployMaster",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster",
-                "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster"
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/DeployMaster"
             ]
         }
     ]
@@ -138,7 +138,7 @@ resource "aws_iam_policy" "assume_auditor_role" {
                 "arn:aws:iam::${var.accounts.network.id}:role/Auditor",
                 "arn:aws:iam::${var.accounts.security.id}:role/Auditor",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Auditor",
-                "arn:aws:iam::${var.appsprd_account_id}:role/Auditor"
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/Auditor"
             ]
         }
     ]
@@ -166,7 +166,7 @@ resource "aws_iam_policy" "assume_finops_role" {
                 "arn:aws:iam::${var.accounts.shared.id}:role/FinOps",
                 "arn:aws:iam::${var.accounts.network.id}:role/FinOps",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/FinOps",
-                "arn:aws:iam::${var.appsprd_account_id}:role/FinOps"
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/FinOps"
             ]
         }
     ]

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "assume_devops_role" {
                 "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
                 "arn:aws:iam::${var.accounts.network.id}:role/DevOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DevOps"
             ]
         }
@@ -51,7 +51,7 @@ resource "aws_iam_policy" "assume_secops_role" {
                 "arn:aws:iam::${var.accounts.shared.id}:role/SecOps",
                 "arn:aws:iam::${var.accounts.network.id}:role/SecOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/SecOps",
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/SecOps",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/SecOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/SecOps"
             ]
         }
@@ -80,7 +80,7 @@ resource "aws_iam_policy" "assume_admin_role" {
                 "arn:aws:iam::${var.accounts.shared.id}:role/Admin",
                 "arn:aws:iam::${var.accounts.network.id}:role/Admin",
                 "arn:aws:iam::${var.accounts.security.id}:role/Admin",
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/Admin",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Admin",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Admin"
             ]
         }
@@ -108,7 +108,7 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
                 "arn:aws:iam::${var.accounts.network.id}:role/DeployMaster",
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster"
             ]
         }
@@ -137,7 +137,7 @@ resource "aws_iam_policy" "assume_auditor_role" {
                 "arn:aws:iam::${var.accounts.shared.id}:role/Auditor",
                 "arn:aws:iam::${var.accounts.network.id}:role/Auditor",
                 "arn:aws:iam::${var.accounts.security.id}:role/Auditor",
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Auditor",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Auditor"
             ]
         }
@@ -165,7 +165,7 @@ resource "aws_iam_policy" "assume_finops_role" {
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/FinOps",
                 "arn:aws:iam::${var.accounts.network.id}:role/FinOps",
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/FinOps",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/FinOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/FinOps"
             ]
         }

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -21,7 +21,7 @@ resource "aws_iam_policy" "assume_devops_role" {
             "Resource": [
                 "arn:aws:iam::${var.shared_account_id}:role/DevOps",
                 "arn:aws:iam::${var.network_account_id}:role/DevOps",
-                "arn:aws:iam::${var.security_account_id}:role/DevOps",
+                "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DevOps"
             ]
@@ -50,7 +50,7 @@ resource "aws_iam_policy" "assume_secops_role" {
             "Resource": [
                 "arn:aws:iam::${var.shared_account_id}:role/SecOps",
                 "arn:aws:iam::${var.network_account_id}:role/SecOps",
-                "arn:aws:iam::${var.security_account_id}:role/SecOps",
+                "arn:aws:iam::${var.accounts.security.id}:role/SecOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/SecOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/SecOps"
             ]
@@ -79,7 +79,7 @@ resource "aws_iam_policy" "assume_admin_role" {
             "Resource": [
                 "arn:aws:iam::${var.shared_account_id}:role/Admin",
                 "arn:aws:iam::${var.network_account_id}:role/Admin",
-                "arn:aws:iam::${var.security_account_id}:role/Admin",
+                "arn:aws:iam::${var.accounts.security.id}:role/Admin",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Admin",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Admin"
             ]
@@ -136,7 +136,7 @@ resource "aws_iam_policy" "assume_auditor_role" {
             "Resource": [
                 "arn:aws:iam::${var.shared_account_id}:role/Auditor",
                 "arn:aws:iam::${var.network_account_id}:role/Auditor",
-                "arn:aws:iam::${var.security_account_id}:role/Auditor",
+                "arn:aws:iam::${var.accounts.security.id}:role/Auditor",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Auditor"
             ]
@@ -255,9 +255,9 @@ data "aws_iam_policy_document" "restricted_iam_self_management" {
       "iam:ChangePassword"
     ]
     resources = [
-      "arn:aws:iam::${var.security_account_id}:user/*/$${aws:username}",
-      "arn:aws:iam::${var.security_account_id}:user/$${aws:username}",
-      "arn:aws:iam::${var.security_account_id}:mfa/$${aws:username}"
+      "arn:aws:iam::${var.accounts.security.id}:user/*/$${aws:username}",
+      "arn:aws:iam::${var.accounts.security.id}:user/$${aws:username}",
+      "arn:aws:iam::${var.accounts.security.id}:mfa/$${aws:username}"
     ]
   }
 
@@ -268,9 +268,9 @@ data "aws_iam_policy_document" "restricted_iam_self_management" {
       "iam:DeactivateMFADevice"
     ]
     resources = [
-      "arn:aws:iam::${var.security_account_id}:user/*/$${aws:username}",
-      "arn:aws:iam::${var.security_account_id}:user/$${aws:username}",
-      "arn:aws:iam::${var.security_account_id}:mfa/$${aws:username}"
+      "arn:aws:iam::${var.accounts.security.id}:user/*/$${aws:username}",
+      "arn:aws:iam::${var.accounts.security.id}:user/$${aws:username}",
+      "arn:aws:iam::${var.accounts.security.id}:mfa/$${aws:username}"
     ]
     condition {
       test     = "Bool"

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -19,7 +19,7 @@ resource "aws_iam_policy" "assume_devops_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.shared_account_id}:role/DevOps",
+                "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
                 "arn:aws:iam::${var.network_account_id}:role/DevOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
@@ -48,7 +48,7 @@ resource "aws_iam_policy" "assume_secops_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.shared_account_id}:role/SecOps",
+                "arn:aws:iam::${var.accounts.shared.id}:role/SecOps",
                 "arn:aws:iam::${var.network_account_id}:role/SecOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/SecOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/SecOps",
@@ -77,7 +77,7 @@ resource "aws_iam_policy" "assume_admin_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.shared_account_id}:role/Admin",
+                "arn:aws:iam::${var.accounts.shared.id}:role/Admin",
                 "arn:aws:iam::${var.network_account_id}:role/Admin",
                 "arn:aws:iam::${var.accounts.security.id}:role/Admin",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Admin",
@@ -106,7 +106,7 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.shared_account_id}:role/DeployMaster",
+                "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
                 "arn:aws:iam::${var.network_account_id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster"
@@ -134,7 +134,7 @@ resource "aws_iam_policy" "assume_auditor_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.shared_account_id}:role/Auditor",
+                "arn:aws:iam::${var.accounts.shared.id}:role/Auditor",
                 "arn:aws:iam::${var.network_account_id}:role/Auditor",
                 "arn:aws:iam::${var.accounts.security.id}:role/Auditor",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
@@ -163,7 +163,7 @@ resource "aws_iam_policy" "assume_finops_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.shared_account_id}:role/FinOps",
+                "arn:aws:iam::${var.accounts.shared.id}:role/FinOps",
                 "arn:aws:iam::${var.network_account_id}:role/FinOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/FinOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/FinOps"

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -20,7 +20,7 @@ resource "aws_iam_policy" "assume_devops_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
-                "arn:aws:iam::${var.network_account_id}:role/DevOps",
+                "arn:aws:iam::${var.accounts.network.id}:role/DevOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DevOps"
@@ -49,7 +49,7 @@ resource "aws_iam_policy" "assume_secops_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/SecOps",
-                "arn:aws:iam::${var.network_account_id}:role/SecOps",
+                "arn:aws:iam::${var.accounts.network.id}:role/SecOps",
                 "arn:aws:iam::${var.accounts.security.id}:role/SecOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/SecOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/SecOps"
@@ -78,7 +78,7 @@ resource "aws_iam_policy" "assume_admin_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/Admin",
-                "arn:aws:iam::${var.network_account_id}:role/Admin",
+                "arn:aws:iam::${var.accounts.network.id}:role/Admin",
                 "arn:aws:iam::${var.accounts.security.id}:role/Admin",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Admin",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Admin"
@@ -107,7 +107,7 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
-                "arn:aws:iam::${var.network_account_id}:role/DeployMaster",
+                "arn:aws:iam::${var.accounts.network.id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster",
                 "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster"
             ]
@@ -135,7 +135,7 @@ resource "aws_iam_policy" "assume_auditor_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/Auditor",
-                "arn:aws:iam::${var.network_account_id}:role/Auditor",
+                "arn:aws:iam::${var.accounts.network.id}:role/Auditor",
                 "arn:aws:iam::${var.accounts.security.id}:role/Auditor",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Auditor"
@@ -164,7 +164,7 @@ resource "aws_iam_policy" "assume_finops_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/FinOps",
-                "arn:aws:iam::${var.network_account_id}:role/FinOps",
+                "arn:aws:iam::${var.accounts.network.id}:role/FinOps",
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/FinOps",
                 "arn:aws:iam::${var.appsprd_account_id}:role/FinOps"
             ]

--- a/security/global/base-identities/roles.tf
+++ b/security/global/base-identities/roles.tf
@@ -9,7 +9,7 @@ module "iam_assumable_role_devops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true
@@ -36,7 +36,7 @@ module "iam_assumable_role_admin" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role           = true
@@ -63,7 +63,7 @@ module "iam_assumable_role_auditor" {
 
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role            = true
@@ -117,7 +117,7 @@ module "iam_assumable_role_secops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true

--- a/security/global/base-identities/roles.tf
+++ b/security/global/base-identities/roles.tf
@@ -91,7 +91,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.accounts.root.id}:root"
+    "arn:aws:iam::${var.accounts.management.id}:root"
   ]
 
   create_role           = true

--- a/security/global/base-identities/roles.tf
+++ b/security/global/base-identities/roles.tf
@@ -91,7 +91,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.root_account_id}:root"
+    "arn:aws:iam::${var.accounts.root.id}:root"
   ]
 
   create_role           = true

--- a/security/us-east-1/firewall-manager/fms.tf
+++ b/security/us-east-1/firewall-manager/fms.tf
@@ -46,7 +46,7 @@ module "fms" {
       resource_type_list          = ["AWS::ElasticLoadBalancingV2::LoadBalancer", "AWS::ApiGateway::Stage"]
       resource_type               = null
       resource_tags               = { "firewallManager" = "true" }
-      include_account_ids         = { accounts = [var.network_account_id, var.security_account_id] }
+      include_account_ids         = { accounts = [var.network_account_id, var.accounts.security.id] }
       exclude_account_ids         = {}
       logging_configuration       = null
 

--- a/security/us-east-1/firewall-manager/fms.tf
+++ b/security/us-east-1/firewall-manager/fms.tf
@@ -46,7 +46,7 @@ module "fms" {
       resource_type_list          = ["AWS::ElasticLoadBalancingV2::LoadBalancer", "AWS::ApiGateway::Stage"]
       resource_type               = null
       resource_tags               = { "firewallManager" = "true" }
-      include_account_ids         = { accounts = [var.network_account_id, var.accounts.security.id] }
+      include_account_ids         = { accounts = [var.accounts.network.id, var.accounts.security.id] }
       exclude_account_ids         = {}
       logging_configuration       = null
 
@@ -84,7 +84,7 @@ module "fms" {
       remediation_enabled         = true # Must be set to `true`
       resource_type_list          = ["AWS::EC2::VPC"]
       resource_tags               = null
-      include_account_ids         = { accounts = [var.network_account_id] }
+      include_account_ids         = { accounts = [var.accounts.network.id] }
       exclude_account_ids         = {}
 
       policy_data = {
@@ -110,7 +110,7 @@ module "fms" {
   #    remediation_enabled         = true
   #    resource_type_list          = ["AWS::ElasticLoadBalancingV2::LoadBalancer"]
   #    resource_tags               = null
-  #    include_account_ids         = { accounts = [var.network_account_id] }
+  #    include_account_ids         = { accounts = [var.accounts.network.id] }
   #    exclude_account_ids         = {}
   #  }
   #]
@@ -125,7 +125,7 @@ module "fms" {
       remediation_enabled         = true
       resource_type               = "AWS::EC2::VPC"
       resource_tags               = null
-      include_account_ids         = { accounts = [var.network_account_id] }
+      include_account_ids         = { accounts = [var.accounts.network.id] }
       exclude_account_ids         = {}
       logging_configuration       = null
       policy_data = {
@@ -159,7 +159,7 @@ module "fms_cloudfront" {
       remediation_enabled         = false
       resource_type               = "AWS::CloudFront::Distribution"
       resource_tags               = null
-      include_account_ids         = { accounts = [var.network_account_id] }
+      include_account_ids         = { accounts = [var.accounts.network.id] }
       exclude_account_ids         = {}
       logging_configuration       = null
 

--- a/security/us-east-1/security-audit/awscloudtrail.tf
+++ b/security/us-east-1/security-audit/awscloudtrail.tf
@@ -95,7 +95,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.security_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.security.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -104,7 +104,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.security_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.security.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -18,7 +18,7 @@ module "config_logs" {
     var.accounts.root.id,
     var.accounts.security.id,
     var.accounts.shared.id,
-    var.network_account_id,
+    var.accounts.network.id,
     var.appsdevstg_account_id,
     var.appsprd_account_id
   ]

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -20,7 +20,7 @@ module "config_logs" {
     var.accounts.shared.id,
     var.accounts.network.id,
     var.accounts.apps-devstg.id,
-    var.appsprd_account_id
+    var.accounts.apps-prd.id
   ]
 }
 

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -16,7 +16,7 @@ module "config_logs" {
   enable_versioning       = true
   config_accounts = [
     var.accounts.root.id,
-    var.security_account_id,
+    var.accounts.security.id,
     var.shared_account_id,
     var.network_account_id,
     var.appsdevstg_account_id,

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -15,7 +15,7 @@ module "config_logs" {
   s3_log_bucket_retention = 90
   enable_versioning       = true
   config_accounts = [
-    var.root_account_id,
+    var.accounts.root.id,
     var.security_account_id,
     var.shared_account_id,
     var.network_account_id,

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -17,7 +17,7 @@ module "config_logs" {
   config_accounts = [
     var.accounts.root.id,
     var.accounts.security.id,
-    var.shared_account_id,
+    var.accounts.shared.id,
     var.network_account_id,
     var.appsdevstg_account_id,
     var.appsprd_account_id

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -15,7 +15,7 @@ module "config_logs" {
   s3_log_bucket_retention = 90
   enable_versioning       = true
   config_accounts = [
-    var.accounts.root.id,
+    var.accounts.management.id,
     var.accounts.security.id,
     var.accounts.shared.id,
     var.accounts.network.id,

--- a/security/us-east-1/security-compliance --/awsconfig.tf
+++ b/security/us-east-1/security-compliance --/awsconfig.tf
@@ -19,7 +19,7 @@ module "config_logs" {
     var.accounts.security.id,
     var.accounts.shared.id,
     var.accounts.network.id,
-    var.appsdevstg_account_id,
+    var.accounts.apps-devstg.id,
     var.appsprd_account_id
   ]
 }

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "kms" {
         "arn:aws:cloudtrail:*:${var.accounts.network.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.apps-devstg.id}:trail/*",
-        "arn:aws:cloudtrail:*:${var.appsprd_account_id}:trail/*"
+        "arn:aws:cloudtrail:*:${var.accounts.apps-prd.id}:trail/*"
       ]
     }
   }

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "kms" {
         "arn:aws:cloudtrail:*:${var.security_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.shared_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.network_account_id}:trail/*",
-        "arn:aws:cloudtrail:*:${var.root_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.appsdevstg_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.appsprd_account_id}:trail/*"
       ]

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.security_account_id}:root"]
+      identifiers = ["arn:aws:iam::${var.accounts.security.id}:root"]
     }
   }
 
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "kms" {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:cloudtrail:arn"
       values = [
-        "arn:aws:cloudtrail:*:${var.security_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.accounts.security.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.shared_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.network_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region}:${var.security_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region}:${var.accounts.security.id}:*"]
     }
   }
 }

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "kms" {
         "arn:aws:cloudtrail:*:${var.accounts.security.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.shared.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.network.id}:trail/*",
-        "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.accounts.management.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.apps-devstg.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.apps-prd.id}:trail/*"
       ]

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "kms" {
       values = [
         "arn:aws:cloudtrail:*:${var.accounts.security.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.shared.id}:trail/*",
-        "arn:aws:cloudtrail:*:${var.network_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.accounts.network.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.appsdevstg_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.appsprd_account_id}:trail/*"

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "kms" {
         "arn:aws:cloudtrail:*:${var.accounts.shared.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.network.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
-        "arn:aws:cloudtrail:*:${var.appsdevstg_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.accounts.apps-devstg.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.appsprd_account_id}:trail/*"
       ]
     }

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "kms" {
       variable = "kms:EncryptionContext:aws:cloudtrail:arn"
       values = [
         "arn:aws:cloudtrail:*:${var.accounts.security.id}:trail/*",
-        "arn:aws:cloudtrail:*:${var.shared_account_id}:trail/*",
+        "arn:aws:cloudtrail:*:${var.accounts.shared.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.network_account_id}:trail/*",
         "arn:aws:cloudtrail:*:${var.accounts.root.id}:trail/*",
         "arn:aws:cloudtrail:*:${var.appsdevstg_account_id}:trail/*",

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -15,7 +15,7 @@ module "guardduty" {
   # Pre-existing Org Accounts (already members) have to be declared below
   guardduty_member_accounts = {
     root = {
-      account_id = var.root_account_id
+      account_id = var.accounts.root.id
       email      = "info@binbash.com.ar"
     },
     shared = {

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -23,7 +23,7 @@ module "guardduty" {
       email      = "binbash-aws-sr@binbash.com.ar"
     },
     network = {
-      account_id = var.network_account_id
+      account_id = var.accounts.network.id
       email      = "binbash-aws-net@binbash.com.ar"
     },
     appsdevstg = {

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -19,7 +19,7 @@ module "guardduty" {
       email      = "info@binbash.com.ar"
     },
     shared = {
-      account_id = var.shared_account_id
+      account_id = var.accounts.shared.id
       email      = "binbash-aws-sr@binbash.com.ar"
     },
     network = {

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -15,7 +15,7 @@ module "guardduty" {
   # Pre-existing Org Accounts (already members) have to be declared below
   guardduty_member_accounts = {
     root = {
-      account_id = var.accounts.root.id
+      account_id = var.accounts.management.id
       email      = "info@binbash.com.ar"
     },
     shared = {

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -31,7 +31,7 @@ module "guardduty" {
       email      = "binbash-aws-dev@binbash.com.ar"
     },
     appsprd = {
-      account_id = var.appsprd_account_id
+      account_id = var.accounts.apps-prd.id
       email      = "info+binbash-aws-prd@binbash.com.ar"
     }
   }

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -27,7 +27,7 @@ module "guardduty" {
       email      = "binbash-aws-net@binbash.com.ar"
     },
     appsdevstg = {
-      account_id = var.appsdevstg_account_id
+      account_id = var.accounts.apps-devstg.id
       email      = "binbash-aws-dev@binbash.com.ar"
     },
     appsprd = {

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -15,7 +15,7 @@ module "guardduty" {
   # Pre-existing Org Accounts (already members) have to be declared below
   guardduty_member_accounts = {
     root = {
-      account_id = var.root_account_id
+      account_id = var.accounts.root.id
       email      = "info@binbash.com.ar"
     },
     shared = {

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -23,7 +23,7 @@ module "guardduty" {
       email      = "binbash-aws-sr@binbash.com.ar"
     },
     network = {
-      account_id = var.network_account_id
+      account_id = var.accounts.network.id
       email      = "binbash-aws-net@binbash.com.ar"
     },
     appsdevstg = {

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -19,7 +19,7 @@ module "guardduty" {
       email      = "info@binbash.com.ar"
     },
     shared = {
-      account_id = var.shared_account_id
+      account_id = var.accounts.shared.id
       email      = "binbash-aws-sr@binbash.com.ar"
     },
     network = {

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -15,7 +15,7 @@ module "guardduty" {
   # Pre-existing Org Accounts (already members) have to be declared below
   guardduty_member_accounts = {
     root = {
-      account_id = var.accounts.root.id
+      account_id = var.accounts.management.id
       email      = "info@binbash.com.ar"
     },
     shared = {

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -31,7 +31,7 @@ module "guardduty" {
       email      = "binbash-aws-dev@binbash.com.ar"
     },
     appsprd = {
-      account_id = var.appsprd_account_id
+      account_id = var.accounts.apps-prd.id
       email      = "info+binbash-aws-prd@binbash.com.ar"
     }
   }

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -27,7 +27,7 @@ module "guardduty" {
       email      = "binbash-aws-net@binbash.com.ar"
     },
     appsdevstg = {
-      account_id = var.appsdevstg_account_id
+      account_id = var.accounts.apps-devstg.id
       email      = "binbash-aws-dev@binbash.com.ar"
     },
     appsprd = {

--- a/shared/global/base-identities/roles.tf
+++ b/shared/global/base-identities/roles.tf
@@ -9,7 +9,7 @@ module "iam_assumable_role_devops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role = true
@@ -36,7 +36,7 @@ module "iam_assumable_role_admin" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role           = true
@@ -62,7 +62,7 @@ module "iam_assumable_role_auditor" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role            = true
@@ -90,7 +90,7 @@ module "iam_assumable_role_deploy_master" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root",
+    "arn:aws:iam::${var.accounts.security.id}:root",
     "arn:aws:iam::${var.shared_account_id}:root"
   ]
 
@@ -119,7 +119,7 @@ module "iam_assumable_role_finops" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.security_account_id}:root"
+    "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
   create_role            = true

--- a/shared/global/base-identities/roles.tf
+++ b/shared/global/base-identities/roles.tf
@@ -148,7 +148,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.root_account_id}:root"
+    "arn:aws:iam::${var.accounts.root.id}:root"
   ]
 
   create_role           = true

--- a/shared/global/base-identities/roles.tf
+++ b/shared/global/base-identities/roles.tf
@@ -91,7 +91,7 @@ module "iam_assumable_role_deploy_master" {
 
   trusted_role_arns = [
     "arn:aws:iam::${var.accounts.security.id}:root",
-    "arn:aws:iam::${var.shared_account_id}:root"
+    "arn:aws:iam::${var.accounts.shared.id}:root"
   ]
 
   create_role = true

--- a/shared/global/base-identities/roles.tf
+++ b/shared/global/base-identities/roles.tf
@@ -148,7 +148,7 @@ module "iam_assumable_role_oaar" {
   source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.1.0"
 
   trusted_role_arns = [
-    "arn:aws:iam::${var.accounts.root.id}:root"
+    "arn:aws:iam::${var.accounts.management.id}:root"
   ]
 
   create_role           = true

--- a/shared/us-east-1/container-registry/locals.tf
+++ b/shared/us-east-1/container-registry/locals.tf
@@ -10,61 +10,61 @@ locals {
     weaveworksdemos_user = {
       create            = true
       name              = "weaveworksdemos/user"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_userdb = {
       create            = true
       name              = "weaveworksdemos/user-db"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_shipping = {
       create            = true
       name              = "weaveworksdemos/shipping"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_queuemaster = {
       create            = true
       name              = "weaveworksdemos/queue-master"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_payment = {
       create            = true
       name              = "weaveworksdemos/payment"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_orders = {
       create            = true
       name              = "weaveworksdemos/orders"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_frontend = {
       create            = true
       name              = "weaveworksdemos/front-end"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_catalogue = {
       create            = true
       name              = "weaveworksdemos/catalogue"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_cataloguedb = {
       create            = true
       name              = "weaveworksdemos/catalogue-db"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_carts = {
       create            = true
       name              = "weaveworksdemos/carts"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }

--- a/shared/us-east-1/secrets-manager --/secrets.tf
+++ b/shared/us-east-1/secrets-manager --/secrets.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "secret_policy" {
       identifiers = [
         "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps",
-        "arn:aws:iam::${var.appsprd_account_id}:role/DevOps",
+        "arn:aws:iam::${var.accounts.apps-prd.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.root.id}:role/OrganizationAccountAccessRole"
       ]

--- a/shared/us-east-1/secrets-manager --/secrets.tf
+++ b/shared/us-east-1/secrets-manager --/secrets.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "secret_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
-        "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
+        "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps",
         "arn:aws:iam::${var.appsprd_account_id}:role/DevOps",
         "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.root.id}:role/OrganizationAccountAccessRole"

--- a/shared/us-east-1/secrets-manager --/secrets.tf
+++ b/shared/us-east-1/secrets-manager --/secrets.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "secret_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.shared_account_id}:role/DevOps",
+        "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
         "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
         "arn:aws:iam::${var.appsprd_account_id}:role/DevOps",
         "arn:aws:iam::${var.accounts.security.id}:role/DevOps",

--- a/shared/us-east-1/secrets-manager --/secrets.tf
+++ b/shared/us-east-1/secrets-manager --/secrets.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "secret_policy" {
         "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.apps-prd.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
-        "arn:aws:iam::${var.accounts.root.id}:role/OrganizationAccountAccessRole"
+        "arn:aws:iam::${var.accounts.management.id}:role/OrganizationAccountAccessRole"
       ]
 
     }

--- a/shared/us-east-1/secrets-manager --/secrets.tf
+++ b/shared/us-east-1/secrets-manager --/secrets.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "secret_policy" {
         "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
         "arn:aws:iam::${var.appsprd_account_id}:role/DevOps",
         "arn:aws:iam::${var.security_account_id}:role/DevOps",
-        "arn:aws:iam::${var.root_account_id}:role/OrganizationAccountAccessRole"
+        "arn:aws:iam::${var.accounts.root.id}:role/OrganizationAccountAccessRole"
       ]
 
     }

--- a/shared/us-east-1/secrets-manager --/secrets.tf
+++ b/shared/us-east-1/secrets-manager --/secrets.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "secret_policy" {
         "arn:aws:iam::${var.shared_account_id}:role/DevOps",
         "arn:aws:iam::${var.appsdevstg_account_id}:role/DevOps",
         "arn:aws:iam::${var.appsprd_account_id}:role/DevOps",
-        "arn:aws:iam::${var.security_account_id}:role/DevOps",
+        "arn:aws:iam::${var.accounts.security.id}:role/DevOps",
         "arn:aws:iam::${var.accounts.root.id}:role/OrganizationAccountAccessRole"
       ]
 

--- a/shared/us-east-1/security-audit/awscloudtrail.tf
+++ b/shared/us-east-1/security-audit/awscloudtrail.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.shared_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.shared.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${var.shared_account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
+      "arn:aws:logs:${var.region}:${var.accounts.shared.id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*",
     ]
   }
 }

--- a/shared/us-east-1/security-keys/kms.tf
+++ b/shared/us-east-1/security-keys/kms.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.shared_account_id}:root"]
+      identifiers = ["arn:aws:iam::${var.accounts.shared.id}:root"]
     }
   }
 
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${var.region}:${var.shared_account_id}:*"]
+      values   = ["arn:aws:logs:${var.region}:${var.accounts.shared.id}:*"]
     }
   }
 }

--- a/shared/us-east-1/storage/object-file-shares-for-users-list --/identities_local.tf
+++ b/shared/us-east-1/storage/object-file-shares-for-users-list --/identities_local.tf
@@ -9,7 +9,7 @@ module "user_roles" {
   create_role             = true
   role_name               = "${var.prefix}-role-${each.key}"
   role_requires_mfa       = false
-  trusted_role_arns       = ["arn:aws:iam::${var.security_account_id}:root"]
+  trusted_role_arns       = ["arn:aws:iam::${var.accounts.security.id}:root"]
   custom_role_policy_arns = [aws_iam_policy.user_roles_policy[each.key].arn]
 }
 

--- a/shared/us-east-1/tools-jenkins --/iam.tf
+++ b/shared/us-east-1/tools-jenkins --/iam.tf
@@ -86,10 +86,10 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
 
     resources = [
       "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster",
-      "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster",
+      "arn:aws:iam::${var.accounts.apps-prd.id}:role/DeployMaster",
       "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
       "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Auditor",
-      "arn:aws:iam::${var.appsprd_account_id}:role/Auditor",
+      "arn:aws:iam::${var.accounts.apps-prd.id}:role/Auditor",
       "arn:aws:iam::${var.accounts.shared.id}:role/Auditor",
       "arn:aws:iam::${var.accounts.security.id}:role/Auditor"
     ]

--- a/shared/us-east-1/tools-jenkins --/iam.tf
+++ b/shared/us-east-1/tools-jenkins --/iam.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
       "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
       "arn:aws:iam::${var.appsprd_account_id}:role/Auditor",
       "arn:aws:iam::${var.shared_account_id}:role/Auditor",
-      "arn:aws:iam::${var.security_account_id}:role/Auditor"
+      "arn:aws:iam::${var.accounts.security.id}:role/Auditor"
     ]
 
     sid = "ec2AssumeRoleCrossAccountStatementID"

--- a/shared/us-east-1/tools-jenkins --/iam.tf
+++ b/shared/us-east-1/tools-jenkins --/iam.tf
@@ -85,10 +85,10 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster",
+      "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster",
       "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster",
       "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
-      "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
+      "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Auditor",
       "arn:aws:iam::${var.appsprd_account_id}:role/Auditor",
       "arn:aws:iam::${var.accounts.shared.id}:role/Auditor",
       "arn:aws:iam::${var.accounts.security.id}:role/Auditor"

--- a/shared/us-east-1/tools-jenkins --/iam.tf
+++ b/shared/us-east-1/tools-jenkins --/iam.tf
@@ -87,10 +87,10 @@ data "aws_iam_policy_document" "cross_org_instance_access" {
     resources = [
       "arn:aws:iam::${var.appsdevstg_account_id}:role/DeployMaster",
       "arn:aws:iam::${var.appsprd_account_id}:role/DeployMaster",
-      "arn:aws:iam::${var.shared_account_id}:role/DeployMaster",
+      "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
       "arn:aws:iam::${var.appsdevstg_account_id}:role/Auditor",
       "arn:aws:iam::${var.appsprd_account_id}:role/Auditor",
-      "arn:aws:iam::${var.shared_account_id}:role/Auditor",
+      "arn:aws:iam::${var.accounts.shared.id}:role/Auditor",
       "arn:aws:iam::${var.accounts.security.id}:role/Auditor"
     ]
 

--- a/shared/us-east-1/tools-managedeskibana --/main.tf
+++ b/shared/us-east-1/tools-managedeskibana --/main.tf
@@ -42,7 +42,7 @@ module "managed_elasticsearch_kibana" {
   domain_endpoint_options = {
     custom_endpoint_enabled         = false
     custom_endpoint                 = "es.aws.binbash.com.ar"
-    custom_endpoint_certificate_arn = "arn:aws:acm:us-east-1:${var.shared_account_id}:certificate/abcd1234"
+    custom_endpoint_certificate_arn = "arn:aws:acm:us-east-1:${var.accounts.shared.id}:certificate/abcd1234"
     enforce_https                   = true
   }
 
@@ -65,10 +65,10 @@ module "managed_elasticsearch_kibana" {
       "Action": "es:*",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::${var.shared_account_id}:role/demoapps-aws-es-proxy"
+          "arn:aws:iam::${var.accounts.shared.id}:role/demoapps-aws-es-proxy"
         ]
       },
-      "Resource": "arn:aws:es:${var.region}:${var.shared_account_id}:domain/${local.domain_name}/*"
+      "Resource": "arn:aws:es:${var.region}:${var.accounts.shared.id}:domain/${local.domain_name}/*"
     }
   ]
 }

--- a/shared/us-east-1/tools-prometheus --/security.tf
+++ b/shared/us-east-1/tools-prometheus --/security.tf
@@ -106,7 +106,7 @@ resource "aws_iam_policy" "prometheus_grafana_assume_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Grafana",
-                "arn:aws:iam::${var.appsprd_account_id}:role/Grafana",
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/Grafana",
                 "arn:aws:iam::${var.accounts.network.id}:role/Grafana"
             ]
         }

--- a/shared/us-east-1/tools-prometheus --/security.tf
+++ b/shared/us-east-1/tools-prometheus --/security.tf
@@ -105,7 +105,7 @@ resource "aws_iam_policy" "prometheus_grafana_assume_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/Grafana",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Grafana",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Grafana",
                 "arn:aws:iam::${var.accounts.network.id}:role/Grafana"
             ]

--- a/shared/us-east-1/tools-prometheus --/security.tf
+++ b/shared/us-east-1/tools-prometheus --/security.tf
@@ -107,7 +107,7 @@ resource "aws_iam_policy" "prometheus_grafana_assume_role" {
             "Resource": [
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Grafana",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Grafana",
-                "arn:aws:iam::${var.network_account_id}:role/Grafana"
+                "arn:aws:iam::${var.accounts.network.id}:role/Grafana"
             ]
         }
     ]

--- a/shared/us-east-2/container-registry/locals.tf
+++ b/shared/us-east-2/container-registry/locals.tf
@@ -10,61 +10,61 @@ locals {
     weaveworksdemos_user = {
       create            = true
       name              = "weaveworksdemos/user"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_userdb = {
       create            = true
       name              = "weaveworksdemos/user-db"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_shipping = {
       create            = true
       name              = "weaveworksdemos/shipping"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_queuemaster = {
       create            = true
       name              = "weaveworksdemos/queue-master"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_payment = {
       create            = true
       name              = "weaveworksdemos/payment"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_orders = {
       create            = true
       name              = "weaveworksdemos/orders"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_frontend = {
       create            = true
       name              = "weaveworksdemos/front-end"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_catalogue = {
       create            = true
       name              = "weaveworksdemos/catalogue"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_cataloguedb = {
       create            = true
       name              = "weaveworksdemos/catalogue-db"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     weaveworksdemos_carts = {
       create            = true
       name              = "weaveworksdemos/carts"
-      read_permissions  = ["arn:aws:iam::${var.appsdevstg_account_id}:root"]
+      read_permissions  = ["arn:aws:iam::${var.accounts.apps-devstg.id}:root"]
       write_permissions = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }

--- a/shared/us-east-2/security-keys/kms.tf
+++ b/shared/us-east-2/security-keys/kms.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.shared_account_id}:root"
+        "arn:aws:iam::${var.accounts.shared.id}:root"
       ]
     }
   }

--- a/shared/us-east-2/tools-prometheus --/security.tf
+++ b/shared/us-east-2/tools-prometheus --/security.tf
@@ -107,7 +107,7 @@ resource "aws_iam_policy" "prometheus_grafana_dr_assume_role" {
             "Resource": [
                 "arn:aws:iam::${var.appsdevstg_account_id}:role/Grafana",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Grafana",
-                "arn:aws:iam::${var.network_account_id}:role/Grafana"
+                "arn:aws:iam::${var.accounts.network.id}:role/Grafana"
             ]
         }
     ]

--- a/shared/us-east-2/tools-prometheus --/security.tf
+++ b/shared/us-east-2/tools-prometheus --/security.tf
@@ -105,7 +105,7 @@ resource "aws_iam_policy" "prometheus_grafana_dr_assume_role" {
                 "sts:AssumeRole"
             ],
             "Resource": [
-                "arn:aws:iam::${var.appsdevstg_account_id}:role/Grafana",
+                "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Grafana",
                 "arn:aws:iam::${var.appsprd_account_id}:role/Grafana",
                 "arn:aws:iam::${var.accounts.network.id}:role/Grafana"
             ]

--- a/shared/us-east-2/tools-prometheus --/security.tf
+++ b/shared/us-east-2/tools-prometheus --/security.tf
@@ -106,7 +106,7 @@ resource "aws_iam_policy" "prometheus_grafana_dr_assume_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/Grafana",
-                "arn:aws:iam::${var.appsprd_account_id}:role/Grafana",
+                "arn:aws:iam::${var.accounts.apps-prd.id}:role/Grafana",
                 "arn:aws:iam::${var.accounts.network.id}:role/Grafana"
             ]
         }


### PR DESCRIPTION
## What?
* Follow the current naming convention for AWS Organizations (use `management` instead of `root`)

* Remove old variable blocks. _Example:_  
```
variable "xxxx_account_id" {
  type        = string
  description = "Account: Xxxx"
}
```

* Update variables in all layers. _Example:_   
```
# Before:
  trusted_role_arns = [
    "arn:aws:iam::${var.root_account_id}:root"
  ]

# Now:
  trusted_role_arns = [
    "arn:aws:iam::${var.accounts.management.id}:root"
  ]
```

* Update `common.tfvars.example`

## Why?
Improve code readability and flexibility

