### PR TITLE
Fix | global config variables fixed

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/monitoring-logging.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/monitoring-logging.tf
@@ -43,7 +43,7 @@ resource "helm_release" "fluentd_awses" {
   version    = "11.12.0"
   values = [
     templatefile("chart-values/fluentd-elasticsearch-aws.yaml", {
-      roleArn = "arn:aws:iam::${var.shared_account_id}:role/aws-es-proxy"
+      roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/aws-es-proxy"
     })
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks/k8s-workloads/demoapps.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-workloads/demoapps.tf
@@ -36,7 +36,7 @@ resource "helm_release" "sockshop" {
   version    = "0.2.0"
   values = [
     templatefile("chart-values/demoapps-sockshop.yaml", {
-      accountid = var.shared_account_id,
+      accountid = var.accounts.shared.id,
       region    = var.region
     })
   ]


### PR DESCRIPTION
## What? 

### Commits on Jul 14, 2022
- :octocat:  [global config variables fixed](https://github.com/binbashar/le-tf-infra-aws/commit/35aa2bad94380cc9b79e84af11ee53be9a9f7b6f) - @[exequielrafaela](https://github.com/binbashar/le-tf-infra-aws/commits?author=exequielrafaela)

- ✅ Example of the fixed var [apps-devstg/us-east-1/k8s-eks/k8s-components/monitoring-logging.tf](https://github.com/binbashar/le-tf-infra-aws/compare/feature/terraform-aws-eks-k8s-components?expand=1#diff-359ba8ade15530aa2e0126107d4acb3350f188fb7bc527a8647f1ea462462e08)

```
@@ -43,7 +43,7 @@ resource "helm_release" "fluentd_awses" {
  version    = "11.12.0"
  values = [
    templatefile("chart-values/fluentd-elasticsearch-aws.yaml", {
     -  roleArn = "arn:aws:iam::${var.shared_account_id}:role/aws-es-proxy"
      + roleArn = "arn:aws:iam::${var.accounts.shared.id}:role/aws-es-proxy"
    })
  ]
}
```