### PR TITLE
Feature | storage/s3-bucket-demo/ Update versions constraint + Update modules version

### DIFF
--- a/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.23.0"
+  constraints = ">= 4.5.0, ~> 4.10"
+  hashes = [
+    "h1:JDJLmKK61GLw8gHQtCzmvlwPNZIu46/M5uBg/TDlBa0=",
+    "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
+    "zh:23d8956b031d78466de82a3d2bbe8c76cc58482c931af311580b8eaef4e6a38f",
+    "zh:343fe19e9a9f3021e26f4af68ff7f4828582070f986b6e5e5b23d89df5514643",
+    "zh:6b8ff83d884b161939b90a18a4da43dd464c4b984f54b5f537b2870ce6bd94bc",
+    "zh:7777d614d5e9d589ad5508eecf4c6d8f47d50fcbaf5d40fa7921064240a6b440",
+    "zh:82f4578861a6fd0cde9a04a1926920bd72d993d524e5b34d7738d4eff3634c44",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a08fefc153bbe0586389e814979cf7185c50fcddbb2082725991ed02742e7d1e",
+    "zh:ae789c0e7cb777d98934387f8888090ccb2d8973ef10e5ece541e8b624e1fb00",
+    "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
+    "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
+    "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
+  ]
+}

--- a/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_demo_files.tf
+++ b/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_demo_files.tf
@@ -2,7 +2,7 @@
 # Pre-req: Logs bucket
 #
 module "log_bucket_demo_files" {
-  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v2.4.0"
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.3.0"
 
   bucket        = "${local.bucket_name}-logs"
   acl           = "log-delivery-write"
@@ -64,7 +64,7 @@ module "log_bucket_demo_files" {
 # S3 Bucket Module Instantiation        #
 #=======================================#
 module "s3_bucket_demo_files" {
-  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v2.4.0"
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.3.0"
 
   bucket        = local.bucket_name
   acl           = "private"
@@ -80,6 +80,8 @@ module "s3_bucket_demo_files" {
       {
         id     = "ReplicationRule"
         status = "Enabled"
+
+        delete_marker_replication = false
 
         source_selection_criteria = {
           sse_kms_encrypted_objects = {
@@ -180,7 +182,7 @@ module "s3_bucket_demo_files" {
 # S3 Bucket Module Instantiation Replica #
 #========================================#
 module "s3_bucket_demo_files_replica" {
-  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v2.4.0"
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.3.0"
 
   providers = {
     aws = aws.secondary_region

--- a/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/config.tf
+++ b/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/config.tf
@@ -7,20 +7,19 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias                   = "secondary_region"
-  region                  = var.region_secondary
-  profile                 = var.profile
-  shared_credentials_file = "~/.aws/bb/config"
+  alias   = "secondary_region"
+  region  = var.region_secondary
+  profile = var.profile
 }
 
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.1.3"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = "~> 4.10"
   }
 
   backend "s3" {
@@ -66,4 +65,3 @@ data "terraform_remote_state" "security-identities" {
     key     = "security/identities/terraform.tfstate"
   }
 }
-


### PR DESCRIPTION
## What?
* Update and test **Ref Architecture** layers  with tf latest versions, Leverage CLI latest version and SSO feature enabled.

## How?
* Update tf version constrains `~> v1.1.3`
* Update tf aws provider constrains  `~> v4.10`
* Update module version to the latest available
* Add 'delete_marker_replication' argument in order to avoid errors during tf apply


## Environment Versions
+ Leverage CLI : v1.7.2
+ Terraform:  v1.1.9
+ provider registry.terraform.io/hashicorp/aws v4.23.0


## Layers
**apps-devstg**/us-east-1/storage/s3-bucket-demo-files

## Why?
Keeping Leverage Reference Architecture up to date.

## References
GitHub issue https://github.com/binbashar/le-tf-infra-aws/issues/370


