### PR TITLE
Enhancement | Add networkmanager / firewall permissions to DevOps IAM Policy

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -41,6 +41,8 @@ data "aws_iam_policy_document" "devops" {
       "lambda:*",
       "lightsail:*",
       "logs:*",
+      "network-firewall:*",
+      "networkmanager:*",
       "ram:*",
       "rds:*",
       "redshift:*",


### PR DESCRIPTION
## What?
* Add allowed-actions to DevOps IAM Policy for list network-firewall related resources
