### PR TITLE
Enhancement | wafv2 fix rules and add outputs

### DIFF
--- a/apps-devstg/us-east-1/security-firewall --/outputs.tf
+++ b/apps-devstg/us-east-1/security-firewall --/outputs.tf
@@ -1,0 +1,4 @@
+output "wafv2_regional_alb_arn" {
+  description = "The ARN of the WAFv2 WebACL"
+  value       = module.wafv2_regional_alb.web_acl_arn
+}

--- a/apps-devstg/us-east-1/security-firewall --/wafv2-regional.tf
+++ b/apps-devstg/us-east-1/security-firewall --/wafv2-regional.tf
@@ -58,7 +58,7 @@ module "wafv2_regional_alb" {
     },
     {
       name     = "SQLiRulesByAWS"
-      priority = "2"
+      priority = "3"
 
       override_action = "count"
 


### PR DESCRIPTION
## What?
* Fix duplicated Rule Priority for SQLiRulesByAWS Rule
* Add outputs.tf file and WAFv2 ARN to the available outputs

## Why?
* It is not allowed to have duplicate priority rules, this produces an error during the terraform plan stage.
* Allow consumption of WAFv2 RNA from another layer if needed 