### PR TITLE
Enhancement | Shared/ container-registry bump modules version

### DIFF
--- a/shared/us-east-1/container-registry/.terraform.lock.hcl
+++ b/shared/us-east-1/container-registry/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:x0gluX9ZKEmz+JJW3Ut5GgWDFOq/lhs2vkqJ+xt57zs=",
+    "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
+    "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
+    "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
+    "zh:48ec39685541e4ddd8ddd196e2cfb72516b87f471d86ac3892bc11f83c573199",
+    "zh:707b9c8775efd6962b6226d914ab25f308013bba1f68953daa77adca99ff6807",
+    "zh:72bd9f4609a827afa366c6f119c7dec7d73a35d712dad1457c0497d87bf8d160",
+    "zh:930e3ae3d0cb152e17ee5a8aee5cb47f7613d6421bc7c22e7f50c19da484a100",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a19bf49b80101a0f0272b994153eeff8f8c206ecc592707bfbce7563355b6882",
+    "zh:a34b5d2bbaf52285b0c9a8df6258f4789f4d927ff777e126bdc77e7887abbeaa",
+    "zh:caad6fd5e79eae33e6d74e38c3b15c28a5482f2a1a8ca46cc1ee70089de61adb",
+    "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/shared/us-east-1/container-registry/config.tf
+++ b/shared/us-east-1/container-registry/config.tf
@@ -13,10 +13,10 @@ terraform {
   required_version = ">= 0.14.11"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 3.27"
   }
 
   backend "s3" {
-    key = "shared/containers/terraform.tfstate"
+    key = "shared/container-registry/terraform.tfstate"
   }
 }

--- a/shared/us-east-1/container-registry/ecr_repositories.tf
+++ b/shared/us-east-1/container-registry/ecr_repositories.tf
@@ -4,7 +4,7 @@
 module "ecr_repositories" {
   for_each = local.repository_list
 
-  source = "github.com/binbashar/terraform-aws-ecr-cross-account.git?ref=1.0.2"
+  source = "github.com/binbashar/terraform-aws-ecr-cross-account.git?ref=1.1.0"
 
   #
   # Repository name

--- a/shared/us-east-1/container-registry/lifecycle_policy.tf
+++ b/shared/us-east-1/container-registry/lifecycle_policy.tf
@@ -2,7 +2,7 @@
 # ECR Lifecycle Policy: keep only the latest 20 images (no tag filtering)
 #
 module "ecr_lifecycle_rule_default_policy_bycount" {
-  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.0.0"
+  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.1.0"
 
   tag_status   = "any"
   count_type   = "imageCountMoreThan"
@@ -14,7 +14,7 @@ module "ecr_lifecycle_rule_default_policy_bycount" {
 # ECR Lifecycle Policy: expire any (no tag filtering) images older than 90 days
 #
 module "ecr_lifecycle_rule_default_policy_bydate" {
-  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.0.0"
+  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.1.0"
 
   tag_status   = "any"
   count_type   = "sinceImagePushed"

--- a/shared/us-east-2/container-registry/.terraform.lock.hcl
+++ b/shared/us-east-2/container-registry/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:x0gluX9ZKEmz+JJW3Ut5GgWDFOq/lhs2vkqJ+xt57zs=",
+    "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
+    "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
+    "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
+    "zh:48ec39685541e4ddd8ddd196e2cfb72516b87f471d86ac3892bc11f83c573199",
+    "zh:707b9c8775efd6962b6226d914ab25f308013bba1f68953daa77adca99ff6807",
+    "zh:72bd9f4609a827afa366c6f119c7dec7d73a35d712dad1457c0497d87bf8d160",
+    "zh:930e3ae3d0cb152e17ee5a8aee5cb47f7613d6421bc7c22e7f50c19da484a100",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a19bf49b80101a0f0272b994153eeff8f8c206ecc592707bfbce7563355b6882",
+    "zh:a34b5d2bbaf52285b0c9a8df6258f4789f4d927ff777e126bdc77e7887abbeaa",
+    "zh:caad6fd5e79eae33e6d74e38c3b15c28a5482f2a1a8ca46cc1ee70089de61adb",
+    "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/shared/us-east-2/container-registry/config.tf
+++ b/shared/us-east-2/container-registry/config.tf
@@ -13,10 +13,10 @@ terraform {
   required_version = ">= 0.14.11"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 3.27"
   }
 
   backend "s3" {
-    key = "shared/container-registry-dr/terraform.tfstate"
+    key = "shared/container-registry/terraform.tfstate"
   }
 }

--- a/shared/us-east-2/container-registry/ecr_repositories.tf
+++ b/shared/us-east-2/container-registry/ecr_repositories.tf
@@ -4,7 +4,7 @@
 module "ecr_repositories" {
   for_each = local.repository_list
 
-  source = "github.com/binbashar/terraform-aws-ecr-cross-account.git?ref=1.0.2"
+  source = "github.com/binbashar/terraform-aws-ecr-cross-account.git?ref=1.1.0"
 
   #
   # Repository name

--- a/shared/us-east-2/container-registry/lifecycle_policy.tf
+++ b/shared/us-east-2/container-registry/lifecycle_policy.tf
@@ -2,7 +2,7 @@
 # ECR Lifecycle Policy: keep only the latest 20 images (no tag filtering)
 #
 module "ecr_lifecycle_rule_default_policy_bycount" {
-  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.0.0"
+  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.1.0"
 
   tag_status   = "any"
   count_type   = "imageCountMoreThan"
@@ -14,7 +14,7 @@ module "ecr_lifecycle_rule_default_policy_bycount" {
 # ECR Lifecycle Policy: expire any (no tag filtering) images older than 90 days
 #
 module "ecr_lifecycle_rule_default_policy_bydate" {
-  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.0.0"
+  source = "github.com/binbashar/terraform-aws-ecr-lifecycle-policy-rule.git?ref=1.1.0"
 
   tag_status   = "any"
   count_type   = "sinceImagePushed"


### PR DESCRIPTION
## What?

* Tackle deprecated terraform function by bumping module to a newer tag.
  * [shared/us-east-1/container-registry/ecr_repositories.tf](https://github.com/binbashar/le-tf-infra-aws/commit/0a406abed502c68bc226ffd6f6c9edaea9bf5b78)
  * [shared/us-east-1/container-registry/lifecycle_policy.tf](https://github.com/binbashar/le-tf-infra-aws/commit/0a406abed502c68bc226ffd6f6c9edaea9bf5b78)
  * [shared/us-east-2/container-registry/ecr_repositories.tf](https://github.com/binbashar/le-tf-infra-aws/commit/0a406abed502c68bc226ffd6f6c9edaea9bf5b78)
  * [shared/us-east-2/container-registry/lifecycle_policy.tf](https://github.com/binbashar/le-tf-infra-aws/commit/0a406abed502c68bc226ffd6f6c9edaea9bf5b78)
* Normalized layer naming and bumped provider version to last known working version for both zones
  * [shared/us-east-1/container-registry/config.tf](https://github.com/binbashar/le-tf-infra-aws/commit/0a406abed502c68bc226ffd6f6c9edaea9bf5b78)
  * [shared/us-east-2/container-registry/config.tf](https://github.com/binbashar/le-tf-infra-aws/commit/0a406abed502c68bc226ffd6f6c9edaea9bf5b78)


## Why?
* Terraform deprecated function obstructed successful resource creation
* Old function was removed [here](https://github.com/binbashar/terraform-aws-ecr-cross-account/compare/1.0.2...1.1.0)

## References
* [Link for reference.](https://github.com/binbashar/terraform-aws-ecr-cross-account/releases/tag/1.1.0)

