### PR TITLE
Fix | /shared/us-east-2/container-registry

### DIFF
--- a/shared/us-east-2/container-registry/config.tf
+++ b/shared/us-east-2/container-registry/config.tf
@@ -17,6 +17,6 @@ terraform {
   }
 
   backend "s3" {
-    key = "shared/container-registry/terraform.tfstate"
+    key = "shared/container-registry-dr/terraform.tfstate"
   }
 }


### PR DESCRIPTION
## What?
* fix backend bucket naming [shared/us-east-2/container-registry/config.tf](https://github.com/binbashar/le-tf-infra-aws/commit/30b5a04ce99b65ccf271d48cac6acd645d6dcc82)

## Why?
* fix backend bucket naming to avoid override statefile
* bucket naming would be suffixed with **dr** to indicate **Disaster Recovery**:
  * from container-registry to container-registry-dr

## References
* `closes #422` [Issue](https://github.com/binbashar/le-tf-infra-aws/issues/422)


