### PR TITLE
Feature | apps-devstg/databases-aurora/ Update versions constraint + Update modules version

### DIFF
--- a/apps-devstg/us-east-1/databases-aurora/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/databases-aurora/.terraform.lock.hcl
@@ -1,0 +1,83 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.25.0"
+  constraints = ">= 4.12.0, ~> 4.12"
+  hashes = [
+    "h1:0dYkCnmIGkx+TlvUy21GpK7/8cCfN/fiZjHV+AAt3Xw=",
+    "zh:51fddc33f289108f60c2de78537f758ae913b2614187abfc3f560f9dd277bc1a",
+    "zh:5a2bfa0725a8941f12e775eb9c44582ec237a664321a740d8283e9b56452f2ad",
+    "zh:6ca73a9f11c2a9ff8f55433c00a12c1b69c22131251cb0698d32c682229b1233",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aeafec22947a7be418adc3c6d1eddb719ed02b5e41b6e2cc9cbdca991e2140b8",
+    "zh:b043563789e32f6935bf51c3b4344482487c03cb084673f6181ce3443f956a3d",
+    "zh:b0693f4295d35ae6ce3656ee2294fd69eb732f601ba7d6eb28b7fded4471c3d2",
+    "zh:bccb9ec142aa11350a52142b71fd8f0332d36a94332207f45bd93ceb7297b922",
+    "zh:c353fd5060cf6d86e4505d0ade84a37f91d4d8774b17eaa1290a191d9da43729",
+    "zh:d07848da6940b2882b884fc24144741f7ce0442865c9833df26751c48429e11f",
+    "zh:d4feeb5c394ec9528d1633e2e2c133632d8d099f6c99654e2bbd2aa112b6a08e",
+    "zh:fb0a75edb943847354c759a665edb93fd7945b892be7d0511c6708785abf090c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.3.2"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:H5V+7iXol/EHB2+BUMzGlpIiCOdV74H8YjzCxnSAWcg=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "3.8.1"
+  constraints = "~> 3.8.0"
+  hashes = [
+    "h1:MD71uC9ZD29Y88lRPC2WrNl+qoJeZn3dgMzngSn134Q=",
+    "zh:020f7a4d53d0fe6739ca98db88f6ca119d7a8d2821a818e6f0e3253063fa70e1",
+    "zh:3315ced4e21d83dc9027f10c7776f7189138a20a68cadf4e2b2572a7c3e14a0d",
+    "zh:3adcb3f09ba5c7408ad84dcb178fc2e888e6df06ed00b093f7ac1324d705a232",
+    "zh:529b24a424f885758a334ec934023062cf9a9a94bc9a924bdba978df6212d98d",
+    "zh:5c594b1daa4761621c2b7d791a4c002b2c9389bc6796aed152e84203535343af",
+    "zh:5f5e7bae5801e1ad6096fc794f8c40652782ad10e29ddb5999bd90ea3fcc8c46",
+    "zh:76369b943889ae554f9421d8034014e52a251691ae5cdeecca761bb097c76378",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c1461f4131994adaa2d2b4aee60ce9e78cf3876acdd740cfb35dad2befd637fc",
+    "zh:c53c031146f6fd0da773b17a7cdb415a77f9e0bfd85fa6f99e1cab9409a39c4d",
+    "zh:e65654763270cacf493cc14dd0f9bab97d58538426eeda5fe634b48b427f3612",
+    "zh:f468f1cbf6a084eb8c320b35318f4cca5a0482ddbb4a5d8c891af36eb2f6ad60",
+  ]
+}
+
+provider "registry.terraform.io/winebarrel/mysql" {
+  version     = "1.10.6"
+  constraints = "1.10.6"
+  hashes = [
+    "h1:GaTA+SO0LMovBXBp0bnxgOSmH1ehLfX3fgzy/ZBgsug=",
+    "zh:1574e2ef747a186883f02fbfbcde418f6516a3b0597b5354aa7ff77d0cff7819",
+    "zh:30c9796f16d1c4c6dc3bc628046b11ddb9cfe6e91e13b02e6032f74f8fd964bd",
+    "zh:375163b2fc78fd7de8c2eef92cb52a178b1179d13219616e1914f40f8dbaa5ec",
+    "zh:3983db82333d4c03d00135712d623b7768dec6de1c8bc71ce4126355fc3f1718",
+    "zh:39d2b42d0456a634fed70d3f22defeb36df352ba20b55ba8118aea857cf381e2",
+    "zh:4a0b8ae7604dcabb21479111eb87abaab93358df3e529c52a982d49349d3787a",
+    "zh:669b6292dd8db76fe843f4745249aba71eb2ee8aa33cdab5c29ddc62387174ab",
+    "zh:71120d3707721f010f10be00f90c6ba7b8b3b1bf3ea3a77d823f11da144853e5",
+    "zh:782db3809bd7f9a4259a4e79a164ed28bd7cb147d7eeedab1ae8bf439a7f592c",
+    "zh:95ceb30ac9192d10db941b8ff43b83bcfd7dde1006f35bc069cff172ea900ec7",
+    "zh:9d5d9edab661329329a08c146e5d88144e1cab340726bf93c980785357b96cc0",
+    "zh:a5a09a35913c00ccf8c67af98146f638b5a46b808999c36c22e31f81b6c920e9",
+    "zh:dc278124518580d2426c585d01eb968f12f18e403e5e2f3e9d92715cc3038b35",
+  ]
+}

--- a/apps-devstg/us-east-1/databases-aurora/cluster_demoapps.tf
+++ b/apps-devstg/us-east-1/databases-aurora/cluster_demoapps.tf
@@ -1,16 +1,16 @@
 module "demoapps" {
-  source = "github.com/binbashar/terraform-aws-rds-aurora.git?ref=v3.7.0"
+  source = "github.com/binbashar/terraform-aws-rds-aurora.git?ref=v7.2.2"
 
   # General settings
   name           = "${var.project}-${var.environment}-binbash-aurora-mysql"
   engine         = "aurora-mysql"
   engine_mode    = "provisioned"
-  engine_version = "5.7.12"
+  engine_version = "5.7"
 
   # Initial database and credentials
   database_name          = "demoapps"
-  username               = "admin"
-  password               = data.vault_generic_secret.databases_aurora.data["administrator_password"]
+  master_username        = "admin"
+  master_password        = data.vault_generic_secret.databases_aurora.data["administrator_password"]
   create_random_password = false
 
   # VPC and Subnets
@@ -18,15 +18,18 @@ module "demoapps" {
   subnets = data.terraform_remote_state.vpc.outputs.private_subnets
 
   # Instance type and desired instances
-  instance_type = "db.t3.small"
-  replica_count = 1
+  instance_class = "db.t3.small"
+  instances = {
+    one = {}
+  }
+
 
   # Autoscaling settings
-  replica_scale_enabled = false
-  # replica_scale_min         = 1
-  # replica_scale_max         = 3
-  # replica_scale_cpu         = 85
-  # replica_scale_connections = 200
+  autoscaling_enabled = false
+  # autoscaling_min_capacity        = 1
+  # autoscaling_max_capacity         = 3
+  # autoscaling_target_cpu         = 85
+  # autoscaling_target_connections = 200
 
   # Storage encrypted as default
   storage_encrypted = true

--- a/apps-devstg/us-east-1/databases-aurora/config.tf
+++ b/apps-devstg/us-east-1/databases-aurora/config.tf
@@ -20,23 +20,23 @@ provider "vault" {
 }
 
 provider "mysql" {
-  endpoint = module.demoapps.this_rds_cluster_endpoint
-  username = module.demoapps.this_rds_cluster_master_username
-  password = module.demoapps.this_rds_cluster_master_password
+  endpoint = module.demoapps.cluster_endpoint
+  username = module.demoapps.cluster_master_username
+  password = module.demoapps.cluster_master_password
 }
 
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.4"
+  required_version = "~> 1.1.3"
 
   required_providers {
-    aws   = ">= 3.8"
-    vault = "~> 2.20.0"
+    aws   = "~> 4.12"
+    vault = "~> 3.8.0"
     mysql = {
       source  = "winebarrel/mysql"
-      version = "1.10.4"
+      version = "1.10.6"
     }
   }
 

--- a/apps-devstg/us-east-1/databases-aurora/outputs.tf
+++ b/apps-devstg/us-east-1/databases-aurora/outputs.tf
@@ -1,60 +1,55 @@
 # aws_rds_cluster
-output "this_rds_cluster_id" {
+output "cluster_id" {
   description = "The ID of the cluster"
-  value       = module.demoapps.this_rds_cluster_id
+  value       = module.demoapps.cluster_id
 }
 
-output "this_rds_cluster_resource_id" {
+output "cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = module.demoapps.this_rds_cluster_resource_id
+  value       = module.demoapps.cluster_resource_id
 }
 
-output "this_rds_cluster_endpoint" {
+output "cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = module.demoapps.this_rds_cluster_endpoint
+  value       = module.demoapps.cluster_endpoint
 }
 
-output "this_rds_cluster_reader_endpoint" {
+output "cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = module.demoapps.this_rds_cluster_reader_endpoint
+  value       = module.demoapps.cluster_reader_endpoint
 }
 
-output "this_rds_cluster_database_name" {
+output "cluster_database_name" {
   description = "Name for an automatically created database on cluster creation"
-  value       = module.demoapps.this_rds_cluster_database_name
+  value       = module.demoapps.cluster_database_name
 }
 
-output "this_rds_cluster_master_password" {
+output "cluster_master_password" {
   description = "The master password"
-  value       = module.demoapps.this_rds_cluster_master_password
+  value       = module.demoapps.cluster_master_password
   sensitive   = true
 }
 
-output "this_rds_cluster_port" {
+output "cluster_port" {
   description = "The port"
-  value       = module.demoapps.this_rds_cluster_port
+  value       = module.demoapps.cluster_port
 }
 
-output "this_rds_cluster_master_username" {
+output "cluster_master_username" {
   description = "The master username"
-  value       = module.demoapps.this_rds_cluster_master_username
+  value       = module.demoapps.cluster_master_username
+  sensitive   = true
 }
 
-# aws_rds_cluster_instance
-output "this_rds_cluster_instance_endpoints" {
-  description = "A list of all cluster instance endpoints"
-  value       = module.demoapps.this_rds_cluster_instance_endpoints
-}
-
-output "this_rds_cluster_instance_ids" {
-  description = "A list of all cluster instance ids"
-  value       = module.demoapps.this_rds_cluster_instance_ids
+output "cluster_instances" {
+  description = "contains a map of all instances created and their attributes"
+  value       = module.demoapps.cluster_instances
 }
 
 # aws_security_group
-output "this_security_group_id" {
+output "security_group_id" {
   description = "The security group ID of the cluster"
-  value       = module.demoapps.this_security_group_id
+  value       = module.demoapps.security_group_id
 }
 
 output "demoapps_sockshop_username" {


### PR DESCRIPTION
## What?
* Update and test **Ref Architecture** layers  with tf latest versions, Leverage CLI latest version and SSO feature enabled.

## How?
* Update tf version constrains `~> v1.1.3`
* Update tf aws provider constrains  `~> v4.10`
* Update tf vault provider constrains  `~> v3.8`
* Update tf mysql provider version  `= v1.10.6`
* Update module version to the latest available
* Modify deprecated and unsupported arguments.
* Rename Outputs with the new format.



## Environment Versions
+ Leverage CLI : v1.7.2
+ Terraform:  v1.1.9
+ provider registry.terraform.io/hashicorp/aws v4.25.0
+ provider registry.terraform.io/hashicorp/random v3.3.2
+ provider registry.terraform.io/hashicorp/vault v3.8.1
+ provider registry.terraform.io/winebarrel/mysql v1.10.6


## Layers
**apps-devstg**/us-east-1/databases-aurora

## Why?
Keeping Leverage Reference Architecture up to date.

## References
GitHub issue https://github.com/binbashar/le-tf-infra-aws/issues/370


