### PR TITLE
Enhancement | Update AWS Required Providers & Update WAFv2 Module Version

### DIFF
--- a/apps-devstg/us-east-1/security-firewall --/config.tf
+++ b/apps-devstg/us-east-1/security-firewall --/config.tf
@@ -13,7 +13,7 @@ terraform {
   required_version = ">= 0.14.11"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = "~> 4.10.0"
   }
 
   backend "s3" {

--- a/apps-devstg/us-east-1/security-firewall --/wafv2-regional.tf
+++ b/apps-devstg/us-east-1/security-firewall --/wafv2-regional.tf
@@ -2,10 +2,11 @@
 # Create a WAF v2 for EKS' ALB
 #
 module "wafv2_regional_alb" {
-  source = "github.com/binbashar/terraform-aws-waf-webaclv2.git?ref=3.0.1"
+  source = "github.com/binbashar/terraform-aws-waf-webaclv2.git?ref=3.8.1"
 
   name_prefix = "${var.environment}-wafv2-albs"
   scope       = "REGIONAL"
+  description = "WAFv2 ACL for ALB Ingress"
 
   # alb_arn     = module.alb.arn
   create_alb_association = false


### PR DESCRIPTION
## What?
* Update AWS Required Providers to ~> 4.10.0 
* Update WAFv2 Module to the latest version

## Why?
* To keep the WAFv2 reference code base up to date with the latest versions of providers and modules and to improve compatibility.