### PR TITLE
Feature | Workflow and layer to test CLI

### DIFF
--- a/.github/workflows/leverage-cli-test.yml
+++ b/.github/workflows/leverage-cli-test.yml
@@ -1,0 +1,59 @@
+name: Leverage CLI Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      leverage_branch:
+        description: "Reference to current Leverage branch to test"
+        required: true
+        type: string
+
+jobs:
+  test_leverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v3
+
+      - name: Clone Leverage
+        run: |
+          printf "[INFO] Cloning Leverage CLI's repo"
+          git clone git@github.com:binbashar/leverage.git
+
+      - name: Build Leverage CLI
+        run: |
+          printf "[INFO] Building Leverage CLI"
+          git checkout ${{ inputs.leverage_branch }}
+          make build
+          pip install -e .
+        working-directory: ./leverage
+
+      - name: Set up credentials
+        run: |
+          printf "[INFO] Setting up credentials"
+          mkdir -p  ~/.aws/bb
+          cat << EOF > ~/.aws/bb/credentials
+          [bb-apps-devstg-deploymaster]
+          aws_access_key_id = ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key = ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          EOF
+
+      - name: Test Reference Architecture
+        run: |
+          printf "[INFO] Initializing layer"
+          leverage tf init
+
+          printf "[INFO] Generating plan"
+          leverage tf plan
+
+          printf "[INFO] Applying changes"
+          leverage tf apply -auto-approve
+
+          printf "[INFO] Checking if all changes were applied"
+          leverage tf plan -detailed-exitcode
+          [[ $? -eq 2 ]] && printf "[WARN] There are still remaining changes"
+          [[ $? -eq 0 ]] && printf "[INFO] Apply checks out"
+
+          printf "[INFO] Destroying all generated created resources"
+          leverage tf destroy -auto-approve
+        working-directory: ./apps-devstg/global/cli-test-layer

--- a/apps-devstg/global/cli-test-layer/.terraform.lock.hcl
+++ b/apps-devstg/global/cli-test-layer/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.25.0"
+  constraints = ">= 3.34.0, ~> 4.10"
+  hashes = [
+    "h1:0dYkCnmIGkx+TlvUy21GpK7/8cCfN/fiZjHV+AAt3Xw=",
+    "zh:51fddc33f289108f60c2de78537f758ae913b2614187abfc3f560f9dd277bc1a",
+    "zh:5a2bfa0725a8941f12e775eb9c44582ec237a664321a740d8283e9b56452f2ad",
+    "zh:6ca73a9f11c2a9ff8f55433c00a12c1b69c22131251cb0698d32c682229b1233",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aeafec22947a7be418adc3c6d1eddb719ed02b5e41b6e2cc9cbdca991e2140b8",
+    "zh:b043563789e32f6935bf51c3b4344482487c03cb084673f6181ce3443f956a3d",
+    "zh:b0693f4295d35ae6ce3656ee2294fd69eb732f601ba7d6eb28b7fded4471c3d2",
+    "zh:bccb9ec142aa11350a52142b71fd8f0332d36a94332207f45bd93ceb7297b922",
+    "zh:c353fd5060cf6d86e4505d0ade84a37f91d4d8774b17eaa1290a191d9da43729",
+    "zh:d07848da6940b2882b884fc24144741f7ce0442865c9833df26751c48429e11f",
+    "zh:d4feeb5c394ec9528d1633e2e2c133632d8d099f6c99654e2bbd2aa112b6a08e",
+    "zh:fb0a75edb943847354c759a665edb93fd7945b892be7d0511c6708785abf090c",
+  ]
+}

--- a/apps-devstg/global/cli-test-layer/common-variables.tf
+++ b/apps-devstg/global/cli-test-layer/common-variables.tf
@@ -1,0 +1,1 @@
+../../../config/common-variables.tf

--- a/apps-devstg/global/cli-test-layer/config.tf
+++ b/apps-devstg/global/cli-test-layer/config.tf
@@ -1,0 +1,22 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+#=============================#
+# Backend Config (partial)    #
+#=============================#
+terraform {
+  required_version = ">= 1.1.3"
+
+  required_providers {
+    aws = "~> 4.10"
+  }
+
+  backend "s3" {
+    key = "apps-devstg/cli-test-layer/terraform.tfstate"
+  }
+}

--- a/apps-devstg/global/cli-test-layer/locals.tf
+++ b/apps-devstg/global/cli-test-layer/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  tags = {
+    Terraform   = "true"
+    Environment = var.environment
+  }
+}

--- a/apps-devstg/global/cli-test-layer/policies.tf
+++ b/apps-devstg/global/cli-test-layer/policies.tf
@@ -1,0 +1,29 @@
+#
+# Policies attached to Roles
+#
+
+#
+# Leverage CLI Testing Policy: Bogus Policy
+#
+resource "aws_iam_policy" "leverage_test" {
+  name        = "leverage_test"
+  description = "Bogus policy for testing Leverage CLI"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "BogusPolicyForTesting",
+            "Effect": "Allow",
+            "Action": [
+                "vpc:*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/apps-devstg/global/cli-test-layer/roles.tf
+++ b/apps-devstg/global/cli-test-layer/roles.tf
@@ -1,0 +1,28 @@
+#
+# IAM Roles
+#
+
+#
+# Assumable Role Cross-Account: Leverage Test
+#
+module "iam_assumable_role_leverage_test" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v4.7.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.accounts.security.id}:root"
+  ]
+
+  create_role = true
+  role_name   = "LeverageTest"
+  role_path   = "/"
+
+  #
+  # MFA setup
+  #
+  role_requires_mfa = false
+  custom_role_policy_arns = [
+    aws_iam_policy.leverage_test.arn
+  ]
+
+  tags = local.tags
+}


### PR DESCRIPTION
## What?
* Create a dummy layer with the express purpose of testing Leverage CLI.
* Add a workflow to build and test Leverage CLI.

## Why?
* Testing how Leverage CLI behaves when managing a real Ref Arch.

## References
* binbashar/leverage/issues/40