### PR TITLE
Feature | Add AWS Guardduty Kubernetes and Malware Protection

### DIFF
--- a/management/global/organizations/organization.tf
+++ b/management/global/organizations/organization.tf
@@ -4,6 +4,7 @@
 resource "aws_organizations_organization" "main" {
   # Not needed at first, might be needed later: https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAWSServiceAccess.html
   aws_service_access_principals = [
+    "malware-protection.guardduty.amazonaws.com",
     "guardduty.amazonaws.com",
     "access-analyzer.amazonaws.com",
     "aws-artifact-account-sync.amazonaws.com",

--- a/management/us-east-1/security-monitoring/.terraform.lock.hcl
+++ b/management/us-east-1/security-monitoring/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.31.0"
+  constraints = "~> 4.31.0"
+  hashes = [
+    "h1:Ib7NTl1AX+17AP1QHbCTl6G2lIjdrlCSSmu8itTTVmk=",
+    "zh:14169119237a7ae174ea19f13edf34ed4de963ab97d937fee9d1f1ddd706f883",
+    "zh:24276942da2b858c2dd9eb0428cfd82b46e758fa00ae38685f05380f75034a8f",
+    "zh:378f1a9f603995bb76827b703ace8bf5212a9c7b96a106f4a87a9871249c885f",
+    "zh:38e992e1137d2e8dc203edd659432c21c87c7cbf99439b68253afdb82a079ead",
+    "zh:56ff847dd504d4098ff4ea7501c8d5ffae4e1ba0dacb85f658d992de474c8fec",
+    "zh:5b2ab38ba7d04e0d3c5bf0a0ab1aafe806faaa9be228480b772606bd32d41620",
+    "zh:6e6c6b10f05018691ef767efadc60fe3cd38adb2e66e65a74fa2be0ce3d7f49d",
+    "zh:90e9fb656d7c19cf702834d7da275b65fc40fbef10224f6f8295a40ca2acb43b",
+    "zh:92b5eaca47b3ab1829cf4cd96dc144f456bc023329f3e20cf3d5fdc913e6e5e3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad782fb8ead528a0d8c7c77d1a417f4d8ceaaefbfc0a0c34993ba92e6dc5ff41",
+    "zh:b121595f53c85bdbb59504b255628d219c42586cb258f0d4cf8a532a98f766e5",
+  ]
+}

--- a/management/us-east-1/security-monitoring/config.tf
+++ b/management/us-east-1/security-monitoring/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.3"
 
   required_providers {
-    aws = "~> 3.27"
+    aws = "~> 4.31.0"
   }
 
   backend "s3" {

--- a/management/us-east-1/security-monitoring/guardduty.tf
+++ b/management/us-east-1/security-monitoring/guardduty.tf
@@ -5,9 +5,11 @@
 # Also designate Security account as GuardDuty's delegated admin
 #
 module "guardduty" {
-  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/delegated-admin?ref=v0.1.0"
+  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/delegated-admin?ref=v0.2.0"
 
-  guarduty_enabled                     = true
-  guarduty_s3_protection_enabled       = true
-  guardduty_delegated_admin_account_id = var.accounts.security.id
+  guarduty_enabled                       = true
+  guarduty_s3_protection_enabled         = true
+  guarduty_kubernetes_protection_enabled = false
+  guarduty_malware_protection_enabled    = false
+  guardduty_delegated_admin_account_id   = var.accounts.security.id
 }

--- a/management/us-east-2/security-monitoring --/config.tf
+++ b/management/us-east-2/security-monitoring --/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.3"
 
   required_providers {
-    aws = "~> 3.27"
+    aws = "~> 4.31.0"
   }
 
   backend "s3" {

--- a/management/us-east-2/security-monitoring --/guardduty.tf
+++ b/management/us-east-2/security-monitoring --/guardduty.tf
@@ -5,9 +5,11 @@
 # Also designate Security account as GuardDuty's delegated admin
 #
 module "guardduty" {
-  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/delegated-admin?ref=v0.1.0"
+  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/delegated-admin?ref=v0.2.0"
 
-  guarduty_enabled                     = true
-  guarduty_s3_protection_enabled       = true
-  guardduty_delegated_admin_account_id = var.accounts.security.id
+  guarduty_enabled                       = true
+  guarduty_s3_protection_enabled         = true
+  guarduty_kubernetes_protection_enabled = false
+  guarduty_malware_protection_enabled    = false
+  guardduty_delegated_admin_account_id   = var.accounts.security.id
 }

--- a/security/us-east-1/security-monitoring/.terraform.lock.hcl
+++ b/security/us-east-1/security-monitoring/.terraform.lock.hcl
@@ -1,0 +1,77 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.31.0"
+  constraints = "~> 4.31.0"
+  hashes = [
+    "h1:Ib7NTl1AX+17AP1QHbCTl6G2lIjdrlCSSmu8itTTVmk=",
+    "zh:14169119237a7ae174ea19f13edf34ed4de963ab97d937fee9d1f1ddd706f883",
+    "zh:24276942da2b858c2dd9eb0428cfd82b46e758fa00ae38685f05380f75034a8f",
+    "zh:378f1a9f603995bb76827b703ace8bf5212a9c7b96a106f4a87a9871249c885f",
+    "zh:38e992e1137d2e8dc203edd659432c21c87c7cbf99439b68253afdb82a079ead",
+    "zh:56ff847dd504d4098ff4ea7501c8d5ffae4e1ba0dacb85f658d992de474c8fec",
+    "zh:5b2ab38ba7d04e0d3c5bf0a0ab1aafe806faaa9be228480b772606bd32d41620",
+    "zh:6e6c6b10f05018691ef767efadc60fe3cd38adb2e66e65a74fa2be0ce3d7f49d",
+    "zh:90e9fb656d7c19cf702834d7da275b65fc40fbef10224f6f8295a40ca2acb43b",
+    "zh:92b5eaca47b3ab1829cf4cd96dc144f456bc023329f3e20cf3d5fdc913e6e5e3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad782fb8ead528a0d8c7c77d1a417f4d8ceaaefbfc0a0c34993ba92e6dc5ff41",
+    "zh:b121595f53c85bdbb59504b255628d219c42586cb258f0d4cf8a532a98f766e5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "2.18.0"
+  constraints = "~> 2.18.0"
+  hashes = [
+    "h1:ebkgHY+/QlBAaU/uYSsIidvlsRel80u0lQzsDcKAIeA=",
+    "zh:23d0ae08554839844249689524c8b07195479ee3dd05700e7aa1c4e012e79f72",
+    "zh:33f4ceca11e3d2806d8ff6fc55c43a54402d28a0b3a1bc7fb038ea8f0969601a",
+    "zh:3b1e88302a41fbb4da068a3e809b92689daece97ac1dde3230e9dfe477be8b1f",
+    "zh:422ef259e4a8e171f96e3e21a6c1cf9043c4f6bdcbc0f50b8add5694c65450dd",
+    "zh:7588e76fe7650803f99ab3035e0990c9c865305f3adc693bc09bc5580cb1b97f",
+    "zh:8fe921fcd952597ddd971e0f697ea3f7720789c75abb1b69df497f558e1520be",
+    "zh:9a46a788534c6d8889f05b8f40487d93fab49fa0885e187c06fcb3551d278d28",
+    "zh:a3e9e47a52d763274b0406ec2e12e9963e70c12631676336cd4feb4d9f7e02a3",
+    "zh:ddbaf058988a27ec6ffc8e0d42a6d8a47012064cbe0bec36bb1399f4ac38f63f",
+    "zh:e847e836ab4d8bc451f55025213d184d85b8d3fdf0bc44d9914dae3b3e0d962f",
+  ]
+}

--- a/security/us-east-1/security-monitoring/config.tf
+++ b/security/us-east-1/security-monitoring/config.tf
@@ -23,10 +23,10 @@ provider "vault" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.3"
 
   required_providers {
-    aws   = "~> 3.2"
+    aws   = "~> 4.31.0"
     vault = "~> 2.18.0"
   }
 

--- a/security/us-east-1/security-monitoring/guardduty.tf
+++ b/security/us-east-1/security-monitoring/guardduty.tf
@@ -2,15 +2,19 @@
 # GuardDuty is enabled in this account as a delegated admin
 #
 module "guardduty" {
-  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/multiaccount-setup?ref=v0.1.0"
+  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/multiaccount-setup?ref=v0.2.0"
 
   # Activating Guardduty & S3 protection in this account (security-account).
-  guarduty_enabled               = true
-  guarduty_s3_protection_enabled = true
+  guarduty_enabled                       = true
+  guarduty_s3_protection_enabled         = true
+  guarduty_kubernetes_protection_enabled = false
+  guarduty_malware_protection_enabled    = false
 
   # New Org Accounts will have Guardduty & S3 Protection automatically enabled
-  guardduty_organization_members_auto_enable               = true
-  guardduty_organization_members_s3_protection_auto_enable = true
+  guardduty_organization_members_auto_enable                    = true
+  guardduty_organization_members_s3_protection_auto_enable      = true
+  guardduty_organization_members_kubernetes_protection_enable   = false
+  guardduty_organization_members_malware_protection_auto_enable = false
 
   # Pre-existing Org Accounts (already members) have to be declared below
   guardduty_member_accounts = {

--- a/security/us-east-2/security-monitoring --/config.tf
+++ b/security/us-east-2/security-monitoring --/config.tf
@@ -23,10 +23,10 @@ provider "vault" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.3"
 
   required_providers {
-    aws   = "~> 3.2"
+    aws   = "~> 4.31.0"
     vault = "~> 2.18.0"
   }
 

--- a/security/us-east-2/security-monitoring --/guardduty.tf
+++ b/security/us-east-2/security-monitoring --/guardduty.tf
@@ -2,15 +2,19 @@
 # GuardDuty is enabled in this account as a delegated admin
 #
 module "guardduty" {
-  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/multiaccount-setup?ref=v0.1.0"
+  source = "github.com/binbashar/terraform-aws-guardduty-multiaccount.git//modules/multiaccount-setup?ref=v0.2.0"
 
   # Activating Guardduty & S3 protection in this account (security-account).
-  guarduty_enabled               = true
-  guarduty_s3_protection_enabled = true
+  guarduty_enabled                       = true
+  guarduty_s3_protection_enabled         = true
+  guarduty_kubernetes_protection_enabled = false
+  guarduty_malware_protection_enabled    = false
 
   # New Org Accounts will have Guardduty & S3 Protection automatically enabled
-  guardduty_organization_members_auto_enable               = true
-  guardduty_organization_members_s3_protection_auto_enable = true
+  guardduty_organization_members_auto_enable                    = true
+  guardduty_organization_members_s3_protection_auto_enable      = true
+  guardduty_organization_members_kubernetes_protection_enable   = false
+  guardduty_organization_members_malware_protection_auto_enable = false
 
   # Pre-existing Org Accounts (already members) have to be declared below
   guardduty_member_accounts = {


### PR DESCRIPTION
## What?

- Upgrade AWS GuardDuty Module to the latest version ([Related Module](https://github.com/binbashar/terraform-aws-guardduty-multiaccount/pull/5))
  - Add Kubernetes Protection for Multi-account Setup
  - Add Malware for Multi-account Setup
    - Enable Malware Delegated Admin (Service Principal cross-organization)

## Why
- To enable/disable via Terraform GuardDuty Kubernetes Protection (multi-account setup)
- To enable/disable via Terraform GuardDuty Malware Protection (multi-account setup)