### PR TITLE
Enhancement | Upgrade node-exporter version and add Security Group Rules

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/monitoring_metrics.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-resources/monitoring_metrics.tf
@@ -20,7 +20,7 @@ resource "helm_release" "node_exporter" {
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "node-exporter"
-  version    = "2.2.4"
+  version    = "3.1.4"
   values     = [file("chart-values/node-exporter.yaml")]
 }
 

--- a/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/monitoring_metrics.tf
+++ b/apps-devstg/us-east-1/k8s-eks-v1.17/k8s-resources/monitoring_metrics.tf
@@ -20,7 +20,7 @@ resource "helm_release" "node_exporter" {
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "node-exporter"
-  version    = "2.2.4"
+  version    = "3.1.4"
   values     = [file("chart-values/node-exporter.yaml")]
 }
 

--- a/apps-devstg/us-east-1/k8s-eks/cluster/eks-managed-nodes.tf
+++ b/apps-devstg/us-east-1/k8s-eks/cluster/eks-managed-nodes.tf
@@ -73,6 +73,30 @@ module "cluster" {
       type                          = "ingress"
       source_cluster_security_group = true
     },
+    ingress_alb_ingress_metrics_tcp = {
+      description                   = "Cluster API to ALB Ingress Metrics"
+      protocol                      = "tcp"
+      from_port                     = 8080
+      to_port                       = 8080
+      type                          = "ingress"
+      source_cluster_security_group = true
+    },
+    ingress_certmanager_metrics_tcp = {
+      description                   = "Cluster API to CertManager Metrics"
+      protocol                      = "tcp"
+      from_port                     = 9402
+      to_port                       = 9402
+      type                          = "ingress"
+      source_cluster_security_group = true
+    },
+    ingress_node_exporter_metrics_tcp = {
+      description                   = "Cluster API to Node Exporter Metrics"
+      protocol                      = "tcp"
+      from_port                     = 9100
+      to_port                       = 9100
+      type                          = "ingress"
+      source_cluster_security_group = true
+    },
     #
     # DNS communication with the Internet
     #

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/monitoring-metrics.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/monitoring-metrics.tf
@@ -20,7 +20,7 @@ resource "helm_release" "node_exporter" {
   namespace  = kubernetes_namespace.monitoring_metrics[0].id
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "node-exporter"
-  version    = "2.2.4"
+  version    = "3.1.4"
   values     = [file("chart-values/node-exporter.yaml")]
 }
 

--- a/apps-devstg/us-east-1/k8s-kind/k8s-resources/monitoring_metrics.tf
+++ b/apps-devstg/us-east-1/k8s-kind/k8s-resources/monitoring_metrics.tf
@@ -20,7 +20,7 @@ resource "helm_release" "node_exporter" {
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "node-exporter"
-  version    = "2.2.4"
+  version    = "3.1.4"
   values     = [file("chart-values/node-exporter.yaml")]
 }
 

--- a/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/monitoring_metrics.tf
+++ b/apps-devstg/us-east-2/k8s-eks-v1.17/k8s-resources/monitoring_metrics.tf
@@ -20,7 +20,7 @@ resource "helm_release" "node_exporter" {
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "node-exporter"
-  version    = "2.2.4"
+  version    = "3.1.4"
   values     = [file("chart-values/node-exporter.yaml")]
 }
 


### PR DESCRIPTION
## What?
* Upgrade Node-Exporter to latest version
* Add rule in EKS API Security Group for Cert-Manager and Node-Exporter metrics, required for Prometheus/Grafana.