### PR TITLE
Fix the 'ConsoleSignInWithoutMfaCount' alarm when users access via SSO

### DIFF
--- a/security/us-east-1/security-audit/metrics.auto.tfvars
+++ b/security/us-east-1/security-audit/metrics.auto.tfvars
@@ -72,7 +72,7 @@ metrics = [
     metric_name       = "ConsoleSignInWithoutMfaCount"
     metric_value      = "1"
     alarm_description = "Alarms when a user logs into the console without MFA."
-    filter_pattern    = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
+    filter_pattern    = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\" && $.userIdentity.arn != \"*AWSReservedSSO*\") }"
   },
   {
     metric_name       = "RootAccountUsageCount"


### PR DESCRIPTION
## What?
* The "AWS CloudWatch notification - ConsoleSignInWithoutMfaCount-*" alarm was intended for users logging in via IAM but it gives false positives when users log in via SSO.

## Why?
* This is triggered when users access via SSO even if the MFA is enforced on the identity provider.