### PR TITLE
Feature| security-audit / Update versions constraint + Update module version 

### DIFF
--- a/apps-devstg/us-east-1/security-audit/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/security-audit/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.36.0"
+  constraints = ">= 2.0.0, >= 3.0.0, ~> 4.10"
+  hashes = [
+    "h1:PbMwAG0+hC+ZGhgghol6IKWAV+dKCLqW02GxZ4Dr71Q=",
+    "zh:07f96a0f4a7b6c1a0f77e27c10b566fe95d77673eff0f0d55cda2ce736ef0ffa",
+    "zh:64d60fba58515708f06eb97b310951d1c021f4d7a25c74d82274acb61494a984",
+    "zh:6dbc3e14521013920228e1e689527d30ce3ff91b3102014dea4a90e94a25dd1b",
+    "zh:6e3eaf4d2b3a9fd934193202f5b1d2122cacfc0db83602d60933b50445d00457",
+    "zh:6e6d824b4911df25e90555c06a9330875796ddb14e4ea925ea8683530dcaad78",
+    "zh:8324c3f45662fb46ab2c194536f4c02e13927e8d08ab69abc610e938ce2742eb",
+    "zh:83d85aa05832db2ab7ada74f677148b62c155dd269e105945a613068656072db",
+    "zh:87e6d5c876ad5ac24029fab7b5f187ade00f7d93329d048a192c18b8d317be58",
+    "zh:886d5dbf8b71bbd7c6fac80e7df998961d1c1cd217e5314d8bcb5c7b7d44418b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aca15934b6e3631cbc846a4331e87ed37dfa4209cfd4552caf5ac6120219b2c4",
+    "zh:bc7b4b30b085f12b463ea13ad3878c6dd8d027520c8c0fd919bd688dfe118b39",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.2.3"
+  constraints = ">= 1.3.0"
+  hashes = [
+    "h1:m79NYOmoeeLZfRMRCmOoCe2bcCuCwuMppPpj1g5mHLU=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:PiFCGziZKS4Kgw3vDyTXyrFUeMQWBqsXhUzX2MgnOSs=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/apps-devstg/us-east-1/security-audit/config.tf
+++ b/apps-devstg/us-east-1/security-audit/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/apps-prd/us-east-1/security-audit/config.tf
+++ b/apps-prd/us-east-1/security-audit/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/management/us-east-1/security-audit/config.tf
+++ b/management/us-east-1/security-audit/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/network/us-east-1/security-audit/.terraform.lock.hcl
+++ b/network/us-east-1/security-audit/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.36.0"
+  constraints = ">= 2.0.0, >= 3.0.0, ~> 4.10"
+  hashes = [
+    "h1:22Ha2jCqtHjc2MRsGQZWggDDb61kKgI98I5ddho8rq0=",
+    "zh:07f96a0f4a7b6c1a0f77e27c10b566fe95d77673eff0f0d55cda2ce736ef0ffa",
+    "zh:64d60fba58515708f06eb97b310951d1c021f4d7a25c74d82274acb61494a984",
+    "zh:6dbc3e14521013920228e1e689527d30ce3ff91b3102014dea4a90e94a25dd1b",
+    "zh:6e3eaf4d2b3a9fd934193202f5b1d2122cacfc0db83602d60933b50445d00457",
+    "zh:6e6d824b4911df25e90555c06a9330875796ddb14e4ea925ea8683530dcaad78",
+    "zh:8324c3f45662fb46ab2c194536f4c02e13927e8d08ab69abc610e938ce2742eb",
+    "zh:83d85aa05832db2ab7ada74f677148b62c155dd269e105945a613068656072db",
+    "zh:87e6d5c876ad5ac24029fab7b5f187ade00f7d93329d048a192c18b8d317be58",
+    "zh:886d5dbf8b71bbd7c6fac80e7df998961d1c1cd217e5314d8bcb5c7b7d44418b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aca15934b6e3631cbc846a4331e87ed37dfa4209cfd4552caf5ac6120219b2c4",
+    "zh:bc7b4b30b085f12b463ea13ad3878c6dd8d027520c8c0fd919bd688dfe118b39",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.2.3"
+  constraints = ">= 1.3.0"
+  hashes = [
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/network/us-east-1/security-audit/config.tf
+++ b/network/us-east-1/security-audit/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/security/us-east-1/security-audit/config.tf
+++ b/security/us-east-1/security-audit/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/shared/us-east-1/security-audit/.terraform.lock.hcl
+++ b/shared/us-east-1/security-audit/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.36.0"
+  constraints = ">= 2.0.0, >= 3.0.0, ~> 4.10"
+  hashes = [
+    "h1:22Ha2jCqtHjc2MRsGQZWggDDb61kKgI98I5ddho8rq0=",
+    "zh:07f96a0f4a7b6c1a0f77e27c10b566fe95d77673eff0f0d55cda2ce736ef0ffa",
+    "zh:64d60fba58515708f06eb97b310951d1c021f4d7a25c74d82274acb61494a984",
+    "zh:6dbc3e14521013920228e1e689527d30ce3ff91b3102014dea4a90e94a25dd1b",
+    "zh:6e3eaf4d2b3a9fd934193202f5b1d2122cacfc0db83602d60933b50445d00457",
+    "zh:6e6d824b4911df25e90555c06a9330875796ddb14e4ea925ea8683530dcaad78",
+    "zh:8324c3f45662fb46ab2c194536f4c02e13927e8d08ab69abc610e938ce2742eb",
+    "zh:83d85aa05832db2ab7ada74f677148b62c155dd269e105945a613068656072db",
+    "zh:87e6d5c876ad5ac24029fab7b5f187ade00f7d93329d048a192c18b8d317be58",
+    "zh:886d5dbf8b71bbd7c6fac80e7df998961d1c1cd217e5314d8bcb5c7b7d44418b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aca15934b6e3631cbc846a4331e87ed37dfa4209cfd4552caf5ac6120219b2c4",
+    "zh:bc7b4b30b085f12b463ea13ad3878c6dd8d027520c8c0fd919bd688dfe118b39",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.2.3"
+  constraints = ">= 1.3.0"
+  hashes = [
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/shared/us-east-1/security-audit/config.tf
+++ b/shared/us-east-1/security-audit/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.1.9"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {


### PR DESCRIPTION
## What?
* Update and test **Ref Architecture** layers  with tf latest versions, Leverage CLI latest version and SSO feature enabled.


## How?
* Update tf version constrains `~> v1.1.9`
* Update tf aws provider constrains  `~> v4.10`
* Update module version to the latest available


## Environment Versions
+ Leverage CLI : v1.7.2
+ Terraform:  v1.1.9
+ provider registry.terraform.io/hashicorp/aws v4.25.0


## Layers
**apps-devstg**/us-east-1/security-audit
**apps-prod**/us-east-1/security-audit
**management**/us-east-1/security-audit
**network**/us-east-1/security-audit
**security**/us-east-1/security-audit
**shared**/us-east-1/security-audit


## Why?
Keeping Leverage Reference Architecture up to date.


## References
GitHub issue https://github.com/binbashar/le-tf-infra-aws/issues/370

