### PR TITLE
Enhacement | security-keys: Update versions constraint + Update module version 

### DIFF
--- a/apps-devstg/us-east-1/security-keys/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/apps-devstg/us-east-1/security-keys/config.tf
+++ b/apps-devstg/us-east-1/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/apps-devstg/us-east-1/security-keys/kms.tf
+++ b/apps-devstg/us-east-1/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/apps-devstg/us-east-2/security-keys/.terraform.lock.hcl
+++ b/apps-devstg/us-east-2/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/apps-devstg/us-east-2/security-keys/config.tf
+++ b/apps-devstg/us-east-2/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/apps-devstg/us-east-2/security-keys/kms.tf
+++ b/apps-devstg/us-east-2/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key_dr" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/apps-prd/us-east-1/security-keys/.terraform.lock.hcl
+++ b/apps-prd/us-east-1/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/apps-prd/us-east-1/security-keys/config.tf
+++ b/apps-prd/us-east-1/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/apps-prd/us-east-1/security-keys/kms.tf
+++ b/apps-prd/us-east-1/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/config/common-variables.tf
+++ b/config/common-variables.tf
@@ -13,6 +13,11 @@ variable "region" {
   description = "AWS Region"
 }
 
+variable "region_primary" {
+  type        = string
+  description = "AWS Region"
+}
+
 variable "profile" {
   type        = string
   description = "AWS Profile (required by the backend but also used for other resources)"

--- a/management/us-east-1/security-keys/config.tf
+++ b/management/us-east-1/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/management/us-east-1/security-keys/kms.tf
+++ b/management/us-east-1/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/network/us-east-1/security-keys/.terraform.lock.hcl
+++ b/network/us-east-1/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/network/us-east-1/security-keys/config.tf
+++ b/network/us-east-1/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/network/us-east-1/security-keys/kms.tf
+++ b/network/us-east-1/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key_dr" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/network/us-east-2/security-keys/.terraform.lock.hcl
+++ b/network/us-east-2/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/network/us-east-2/security-keys/config.tf
+++ b/network/us-east-2/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/network/us-east-2/security-keys/kms.tf
+++ b/network/us-east-2/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key_dr" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/security/us-east-1/security-keys/config.tf
+++ b/security/us-east-1/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/security/us-east-1/security-keys/kms.tf
+++ b/security/us-east-1/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.11.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/shared/us-east-1/security-keys/.terraform.lock.hcl
+++ b/shared/us-east-1/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/shared/us-east-1/security-keys/config.tf
+++ b/shared/us-east-1/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/shared/us-east-1/security-keys/kms.tf
+++ b/shared/us-east-1/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project

--- a/shared/us-east-2/security-keys/.terraform.lock.hcl
+++ b/shared/us-east-2/security-keys/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.64.0, ~> 4.10"
+  hashes = [
+    "h1:EZB4OgvytV38JpWyye9zoMQ0bfT9yB9xSXM5NY3Lrws=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/shared/us-east-2/security-keys/config.tf
+++ b/shared/us-east-2/security-keys/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = ">= 1.0.9"
+  required_version = "~> 1.2.7"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = "~> 4.10"
   }
 
   backend "s3" {

--- a/shared/us-east-2/security-keys/kms.tf
+++ b/shared/us-east-2/security-keys/kms.tf
@@ -1,5 +1,5 @@
 module "kms_key_dr" {
-  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.10.0"
+  source = "github.com/binbashar/terraform-aws-kms-key.git?ref=0.12.1"
 
   enabled                 = true
   namespace               = var.project


### PR DESCRIPTION
## What?
* Update and test **Ref Architecture** layers  with tf latest versions, Leverage CLI latest version and SSO feature enabled.


## How?
* Update tf version constrains `~> v1.2.7`
* Update tf aws provider constrains  `~> v4.10`
* Update module version to the latest available


## Environment Versions
+ Leverage CLI : v1.8
+ Terraform:  v1.2.7
+ provider registry.terraform.io/hashicorp/aws v4.46.0


## Why?
Keeping Leverage Reference Architecture up to date.


## References
GitHub issue https://github.com/binbashar/le-tf-infra-aws/issues/370

