### PR TITLE
Fix | ConsoleSignInWithoutMfaCount false positive on Management Account

### DIFF
--- a/management/us-east-1/security-audit/metrics.auto.tfvars
+++ b/management/us-east-1/security-audit/metrics.auto.tfvars
@@ -72,7 +72,7 @@ metrics = [
     metric_name       = "ConsoleSignInWithoutMfaCount"
     metric_value      = "1"
     alarm_description = "Alarms when a user logs into the console without MFA."
-    filter_pattern    = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
+    filter_pattern    = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\")  && $.userIdentity.arn != \"*AWSReservedSSO*\" }"
   },
   {
     metric_name       = "RootAccountUsageCount"


### PR DESCRIPTION
## What?
* Add `$.userIdentity.arn != \"*AWSReservedSSO*\"` to ConsoleSignInWithoutMfaCount filter patern.

## Why?
* The "AWS CloudWatch notification - ConsoleSignInWithoutMfaCount-*" alarm gives false positives when users log in via SSO.

## Terraform plan

```
Terraform will perform the following actions:

  # module.cloudtrail_api_alarms.aws_cloudwatch_dashboard.combined[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_cloudwatch_dashboard" "combined" {
    }

  # module.cloudtrail_api_alarms.aws_cloudwatch_dashboard.individual[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_cloudwatch_dashboard" "individual" {
    }

  # module.cloudtrail_api_alarms.aws_cloudwatch_log_metric_filter.default["ConsoleSignInWithoutMfaCount-root-account"] will be updated in-place
  ~ resource "aws_cloudwatch_log_metric_filter" "default" {
        id             = "ConsoleSignInWithoutMfaCount"
        name           = "ConsoleSignInWithoutMfaCount"
      ~ pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }" -> "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\")  && $.userIdentity.arn != \"*AWSReservedSSO*\" }"
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 2 to destroy.
```

(*) Terraform destroy actions to reconcile state for resources outside this PR are hidden