### PR TITLE
Add Kube Prometheus Stack to the DemoApps

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/config.tf
@@ -16,11 +16,11 @@ provider "kubernetes" {
 # Backend Config (partial)
 #
 terraform {
-  required_version = "~> 1.1.9"
+  required_version = "~> 1.2"
 
   required_providers {
-    aws        = "~> 4.11.0"
-    kubernetes = "~> 2.11.0"
+    aws        = "~> 4.11"
+    kubernetes = "~> 2.11"
   }
 
   backend "s3" {

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
@@ -164,14 +164,14 @@ module "cluster" {
     #   max_size       = 6
     #   desired_size   = 1
     #   capacity_type  = "ON_DEMAND"
-    #   instance_types = ["t2.medium", "t3.medium"]
+    #   instance_types = ["t3.medium"]
     # }
     spot = {
       desired_capacity = 1
       max_capacity     = 6
       min_capacity     = 1
       capacity_type    = "SPOT"
-      instance_types   = ["t2.medium", "t3.medium"]
+      instance_types   = ["t3.medium"]
     }
   }
 

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/identities/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/identities/config.tf
@@ -16,10 +16,10 @@ provider "aws" {
 # Backend Config (partial)
 #
 terraform {
-  required_version = "~> 1.1.9"
+  required_version = "~> 1.2"
 
   required_providers {
-    aws = "~> 4.11.0"
+    aws = "~> 4.11"
   }
 
   backend "s3" {

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/monitoring-metrics.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/monitoring-metrics.tf
@@ -36,3 +36,16 @@ resource "helm_release" "metrics_server" {
   version    = "5.8.4"
   values     = [file("chart-values/metrics-server.yaml")]
 }
+
+#------------------------------------------------------------------------------
+# Prometheus Stack
+#------------------------------------------------------------------------------
+resource "helm_release" "kube_prometheus_stack" {
+  count      = var.enable_prometheus_stack ? 1 : 0
+  name       = "kube-prometheus-stack"
+  namespace  = kubernetes_namespace.prometheus[0].id
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  version    = "43.2.1"
+  values     = [file("chart-values/kube-prometheus-stack.yaml")]
+}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/namespaces.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/namespaces.tf
@@ -118,3 +118,12 @@ resource "kubernetes_namespace" "velero" {
     name   = "velero"
   }
 }
+
+resource "kubernetes_namespace" "prometheus" {
+  count = var.enable_prometheus_stack ? 1 : 0
+
+  metadata {
+    labels = local.labels
+    name   = "prometheus"
+  }
+}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
@@ -47,6 +47,7 @@ logging = {
   ]
 }
 # metrics
+enable_prometheus_stack        = true
 enable_prometheus_dependencies = false
 enable_grafana_dependencies    = false
 # datadog

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/variables.tf
@@ -86,6 +86,11 @@ variable "enable_ingressmonitorcontroller" {
   default = false
 }
 
+variable "enable_prometheus_stack" {
+  type    = bool
+  default = false
+}
+
 variable "enable_prometheus_dependencies" {
   type    = bool
   default = false

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/network/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/network/config.tf
@@ -16,10 +16,10 @@ provider "aws" {
 # Backend Config (partial)
 #
 terraform {
-  required_version = "~> 1.1.9"
+  required_version = "~> 1.2"
 
   required_providers {
-    aws = "~> 4.11.0"
+    aws = "~> 4.11"
   }
 
   backend "s3" {

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -54,6 +54,7 @@ data "aws_iam_policy_document" "devops" {
       "route53resolver:*",
       "s3:*",
       "ses:*",
+      "secretsmanager:*",
       "shield:*",
       "sns:*",
       "sqs:*",


### PR DESCRIPTION
## What?
* Add [Kube Prometheus Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) to the DemoApps

## Why?
* It provides a simple metrics-based, in-cluster monitoring stack -- in other words, we can showcase Prometheus & Grafana very easily with this

## References
* Closes https://github.com/binbashar/le-devops-workflows/issues/10

