### PR TITLE
Chore: Update ArgoCD deployment definition to allow Web Terminal in UI

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/chart-values/argo-cd.yaml
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/chart-values/argo-cd.yaml
@@ -1,3 +1,7 @@
+configs:
+  cm:
+    exec.enabled: "${enableWebTerminal}"
+
 server:
   ingress:
     enabled: true

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/chart-values/argo-rollouts.yaml
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/chart-values/argo-rollouts.yaml
@@ -1,5 +1,5 @@
 dashboard:
-  enabled: true
+  enabled: ${enableDashboard}
 
   ingress:
     enabled: true

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/cicd-argo.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/cicd-argo.tf
@@ -2,7 +2,7 @@
 # ArgoCD: GitOps + CD
 #------------------------------------------------------------------------------
 resource "helm_release" "argocd" {
-  count = var.enable_cicd ? 1 : 0
+  count = var.argocd.enabled ? 1 : 0
 
   name       = "argocd"
   namespace  = kubernetes_namespace.argocd[0].id
@@ -11,8 +11,8 @@ resource "helm_release" "argocd" {
   version    = "5.4.3"
   values = [
     templatefile("chart-values/argo-cd.yaml", {
-      argoHost     = "argocd.${local.environment}.${local.private_base_domain}"
-      ingressClass = local.private_ingress_class
+      argoHost          = "argocd.${local.environment}.${local.private_base_domain}"
+      ingressClass      = local.private_ingress_class
     }),
     # We are using a different approach here because it is very tricky to render
     # properly the multi-line sshPrivateKey using 'templatefile' function
@@ -46,7 +46,7 @@ resource "helm_release" "argocd" {
 # ArgoCD Image Updater
 #------------------------------------------------------------------------------
 resource "helm_release" "argocd_image_updater" {
-  count      = var.enable_argocd_image_updater ? 1 : 0
+  count      = var.argocd.image_updater.enabled ? 1 : 0
   name       = "argocd-image-updater"
   namespace  = kubernetes_namespace.argocd[0].id
   repository = "https://argoproj.github.io/argo-helm"
@@ -79,7 +79,7 @@ resource "helm_release" "argocd_image_updater" {
 # Argo Rollouts
 #------------------------------------------------------------------------------
 resource "helm_release" "argo_rollouts" {
-  count = var.enable_argo_rollouts ? 1 : 0
+  count = var.argo_rollouts.enabled ? 1 : 0
 
   name       = "argo-rollouts"
   namespace  = kubernetes_namespace.argocd[0].id
@@ -88,8 +88,8 @@ resource "helm_release" "argo_rollouts" {
   version    = "2.19.0"
   values = [
     templatefile("chart-values/argo-rollouts.yaml", {
-      rolloutsHost = "rollouts.${local.environment}.${local.private_base_domain}"
-      ingressClass = local.private_ingress_class
+      rolloutsHost    = "rollouts.${local.environment}.${local.private_base_domain}"
+      ingressClass    = local.private_ingress_class
   })]
 
   depends_on = [

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/cicd-argo.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/cicd-argo.tf
@@ -88,6 +88,7 @@ resource "helm_release" "argo_rollouts" {
   version    = "2.19.0"
   values = [
     templatefile("chart-values/argo-rollouts.yaml", {
+      enableDashboard = var.argo_rollouts.dashboard.enabled
       rolloutsHost    = "rollouts.${local.environment}.${local.private_base_domain}"
       ingressClass    = local.private_ingress_class
   })]

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/cicd-argo.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/cicd-argo.tf
@@ -8,9 +8,10 @@ resource "helm_release" "argocd" {
   namespace  = kubernetes_namespace.argocd[0].id
   repository = "https://argoproj.github.io/argo-helm"
   chart      = "argo-cd"
-  version    = "5.4.3"
+  version    = "5.8.3"
   values = [
     templatefile("chart-values/argo-cd.yaml", {
+      enableWebTerminal = var.argocd.enableWebTerminal
       argoHost          = "argocd.${local.environment}.${local.private_base_domain}"
       ingressClass      = local.private_ingress_class
     }),

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/namespaces.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/namespaces.tf
@@ -80,7 +80,7 @@ resource "kubernetes_namespace" "external-secrets" {
 }
 
 resource "kubernetes_namespace" "argocd" {
-  count = var.enable_cicd || var.enable_argocd_image_updater || var.enable_argo_rollouts ? 1 : 0
+  count = var.argocd.enabled || var.argo_rollouts.enabled ? 1 : 0
 
   metadata {
     labels = local.labels

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/security.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/security.tf
@@ -99,7 +99,7 @@ resource "helm_release" "cluster_secrets_manager" {
   depends_on = [helm_release.external_secrets[0]]
 }
 
-resource "kubernetes_manifest" "cluster_parameter_store" {
+resource "helm_release" "cluster_parameter_store" {
   count = var.enable_external_secrets ? 1 : 0
 
   name       = "cluster-parameter-store"
@@ -109,20 +109,20 @@ resource "kubernetes_manifest" "cluster_parameter_store" {
   values = [
     <<-EOF
     resources:
-      apiVersion: external-secrets.io/v1beta1
-      kind: ClusterSecretStore
-      metadata:
-        name: cluster-parameter-store
-      spec:
-        provider:
-          aws:
-            service: ParameterStore
-            region: ${var.region}
-            auth:
-              jwt:
-                serviceAccountRef:
-                  name: external-secrets
-                  namespace: external-secrets
+      - apiVersion: external-secrets.io/v1beta1
+        kind: ClusterSecretStore
+        metadata:
+          name: cluster-parameter-store
+        spec:
+          provider:
+            aws:
+              service: ParameterStore
+              region: ${var.region}
+              auth:
+                jwt:
+                  serviceAccountRef:
+                    name: external-secrets
+                    namespace: external-secrets
     EOF
   ]
 

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
@@ -77,6 +77,8 @@ imc = {
 argocd = {
   enabled = true
 
+  enableWebTerminal = true
+
   image_updater = {
     enabled = false
   }

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
@@ -83,6 +83,10 @@ argocd = {
 }
 argo_rollouts = {
   enabled = false
+
+  dashboard = {
+    enabled = false
+  }
 }
 
 #------------------------------------------------------------------------------

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
@@ -74,9 +74,16 @@ imc = {
 #------------------------------------------------------------------------------
 # CICD | ArgoCD
 #------------------------------------------------------------------------------
-enable_cicd                 = true
-enable_argocd_image_updater = false
-enable_argo_rollouts        = false
+argocd = {
+  enabled = true
+
+  image_updater = {
+    enabled = false
+  }
+}
+argo_rollouts = {
+  enabled = false
+}
 
 #------------------------------------------------------------------------------
 # Backups

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/variables.tf
@@ -41,19 +41,14 @@ variable "enable_external_secrets" {
   default = false
 }
 
-variable "enable_cicd" {
-  type    = bool
-  default = false
+variable "argocd" {
+  type    = map(any)
+  default = {}
 }
 
-variable "enable_argocd_image_updater" {
-  type    = bool
-  default = false
-}
-
-variable "enable_argo_rollouts" {
-  type    = bool
-  default = false
+variable "argo_rollouts" {
+  type    = map(any)
+  default = {}
 }
 
 variable "enable_hpa_scaling" {


### PR DESCRIPTION
## What?
* Allow toggling of web terminal deployment to allow connection to application containers through ArgoCD UI
* Allow toggling of Argo Rollouts Dashboard deployment
* Reorganize input variables for ArgoCD deployment into map form
* Extra: fix helm_release resource definition for Cluster Secret Store

## Why?
* -
## References
* -
