### PR TITLE
Enhacement  | tools-cloud-nuke: Update versions constraint

### DIFF
--- a/apps-devstg/us-east-1/tools-cloud-nuke/config.tf
+++ b/apps-devstg/us-east-1/tools-cloud-nuke/config.tf
@@ -10,10 +10,10 @@ provider "aws" {
 # Backend Config (partial)
 #
 terraform {
-  required_version = ">= 0.14.11"
+  required_version = "~> 1.3"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.10"
   }
 
   backend "s3" {


### PR DESCRIPTION
## What?
* Update and test **Ref Architecture** layers  with tf latest versions, Leverage CLI latest version and SSO feature enabled.


## How?
* Update tf version constrains `~> v1.3`
* Update tf aws provider constrains  `~> v4.10`


## Environment Versions
+ Leverage CLI : v1.9.2
+ binbash/leverage-toolbox: v1.3.5-0.1.4
+ Terraform:  v1.3.5
+ provider registry.terraform.io/hashicorp/aws v4.59.0


## Layers
/**apps-devstg**/us-east-1/tools-cloud-nuke


## Why?
Keeping Leverage Reference Architecture up to date.


## References
GitHub issue https://github.com/binbashar/le-tf-infra-aws/issues/474

