### PR TITLE
Add SSO DevOps role as an admin of the DemoApps cluster

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -19,12 +19,12 @@ locals {
     {
       rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"
       username = "DevOps"
-      groups = ["system:masters"]
+      groups   = ["system:masters"]
     },
     {
       rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/AWSReservedSSO_DevOps_2b78d1d8a7818ab3"
       username = "DevOps"
-      groups = ["system:masters"]
+      groups   = ["system:masters"]
     },
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -22,10 +22,9 @@ locals {
       groups = ["system:masters"]
     },
     {
-      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_2b78d1d8a7818ab3"
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/AWSReservedSSO_DevOps_2b78d1d8a7818ab3"
       username = "DevOps"
       groups = ["system:masters"]
     },
-
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -19,8 +19,13 @@ locals {
     {
       rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DevOps"
       username = "DevOps"
-      groups = [
-      "system:masters"]
+      groups = ["system:masters"]
     },
+    {
+      rolearn  = "arn:aws:iam::${var.accounts.apps-devstg.id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_2b78d1d8a7818ab3"
+      username = "DevOps"
+      groups = ["system:masters"]
+    },
+
   ]
 }


### PR DESCRIPTION
## What?
* Add SSO DevOps role as an admin of the DemoApps cluster

## Why?
* Since we are mainly using the SSO integration for our daily ops, this update is essential.

## References
* N/A
