### PR TITLE
Grant SSO Devops role permissions on SecretsManager

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -58,6 +58,7 @@ data "aws_iam_policy_document" "devops" {
       "route53resolver:*",
       "s3:*",
       "ses:*",
+      "secretsmanager:*",
       "shield:*",
       "sns:*",
       "sqs:*",

--- a/shared/us-east-1/secrets-manager/secrets.tf
+++ b/shared/us-east-1/secrets-manager/secrets.tf
@@ -23,6 +23,7 @@ data "aws_iam_policy_document" "secrets_policy" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::${var.accounts.shared.id}:role/DevOps",
+        "arn:aws:iam::${var.accounts.shared.id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_DevOps_40ba147128d7f4be",
       ]
     }
   }


### PR DESCRIPTION
## What?
* Grant SSO Devops role permissions on SecretsManager.

## Why?
* Otherwise said role can't access DemoApps secrets.