### PR TITLE
Fix EKS DemoApps Add-ons implementation which was failing at cluster …

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
@@ -171,11 +171,11 @@ module "cluster" {
     #   instance_types = ["t3.medium"]
     # }
     spot = {
-      desired_size = 1
-      max_size     = 6
-      min_size     = 1
-      capacity_type    = "SPOT"
-      instance_types   = ["t3.medium"]
+      desired_size   = 1
+      max_size       = 6
+      min_size       = 1
+      capacity_type  = "SPOT"
+      instance_types = ["t3.medium"]
     }
   }
 

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
@@ -155,8 +155,10 @@ module "cluster" {
     disk_size      = 50
     instance_types = ["t2.medium"]
     k8s_labels     = local.tags
-    # Not be necessary when using VPC CNI add-on + IRSA
-    iam_role_attach_cni_policy = false
+    # IMPORTANT: setting this to true is only necessary during the initial bootstrap
+    # of the cluster, otherwise the built-in VPC CNI won't start. Then, after you get
+    # the VPC CNI add-on installed, you can set this to false.
+    iam_role_attach_cni_policy = true
   }
 
   # Define all Managed Node Groups (MNG's)
@@ -169,9 +171,9 @@ module "cluster" {
     #   instance_types = ["t3.medium"]
     # }
     spot = {
-      desired_capacity = 1
-      max_capacity     = 6
-      min_capacity     = 1
+      desired_size = 1
+      max_size     = 6
+      min_size     = 1
       capacity_type    = "SPOT"
       instance_types   = ["t3.medium"]
     }
@@ -192,27 +194,8 @@ module "cluster" {
   ]
   cloudwatch_log_group_retention_in_days = var.cluster_log_retention_in_days
 
-  # EKS Add-ons
-  cluster_addons = {
-    coredns = {
-      addon_version     = "v1.8.7-eksbuild.4"
-      resolve_conflicts = "OVERWRITE"
-    }
-    kube-proxy = {
-      addon_version     = "v1.22.17-eksbuild.2"
-      resolve_conflicts = "OVERWRITE"
-    }
-    vpc-cni = {
-      addon_version            = "v1.12.6-eksbuild.2"
-      resolve_conflicts        = "OVERWRITE"
-      service_account_role_arn = data.terraform_remote_state.cluster-identities.outputs.eks_addons_vpc_cni
-    }
-    aws-ebs-csi-driver = {
-      addon_version            = "v1.18.0-eksbuild.1"
-      resolve_conflicts        = "OVERWRITE"
-      service_account_role_arn = data.terraform_remote_state.cluster-identities.outputs.eks_addons_ebs_csi
-    }
-  }
+  # EKS Managed Add-ons
+  cluster_addons = local.addons_enabled
 
   # Define tags (notice we are appending here tags required by the cluster autoscaler)
   tags = merge(local.tags,

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/locals.tf
@@ -27,4 +27,35 @@ locals {
       groups   = ["system:masters"]
     },
   ]
+
+  # ---------------------------------------------------------------------------
+  # IMPORTANT
+  # ---------------------------------------------------------------------------
+  # If you plan to use EKS managed add-ons keep in mind that some add-ons rely
+  # on IAM roles which need to be created/updated for them to work. Said roles
+  # are defined in the "identities" layer which needs to be applied only after
+  # the cluster is up and running. After that you should be able to install the
+  # managed add-ons on the cluster.
+  # ---------------------------------------------------------------------------
+  addons_available = {
+    coredns = {
+      addon_version     = "v1.8.7-eksbuild.4"
+      resolve_conflicts = "OVERWRITE"
+    }
+    kube-proxy = {
+      addon_version     = "v1.22.17-eksbuild.2"
+      resolve_conflicts = "OVERWRITE"
+    }
+    vpc-cni = {
+      addon_version            = "v1.12.6-eksbuild.2"
+      resolve_conflicts        = "OVERWRITE"
+      service_account_role_arn = data.terraform_remote_state.cluster-identities.outputs.eks_addons_vpc_cni
+    }
+    aws-ebs-csi-driver = {
+      addon_version            = "v1.18.0-eksbuild.1"
+      resolve_conflicts        = "OVERWRITE"
+      service_account_role_arn = data.terraform_remote_state.cluster-identities.outputs.eks_addons_ebs_csi
+    }
+  }
+  addons_enabled = var.use_managed_addons ? local.addons_available : {}
 }

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/variables.tf
@@ -43,3 +43,9 @@ variable "create_aws_auth" {
   description = "Whether to create the aws-auth configmap."
   default     = false
 }
+
+# WARNING: make sure you read the note about add-ons in the "locals.tf" file
+variable "use_managed_addons" {
+  description = "Whether to use EKS managed add-ons."
+  default     = false
+}


### PR DESCRIPTION
…bootstrap

## What?
* The previous EKS add-ons implementation I submitted was flawed, it fails during the initial bootstrap of the cluster.

## Why?
* EKS add-ons that require AWS credentials need the corresponding EKS IRSA roles provisioned before they can work. This PR makes the add-ons an optional step that can be applied after the cluster is up and running and after the identities layer has been created/updated.

## References
N/A