### PR TITLE
Use a custom VPC Flow Logs format on both EKS DevStg VPCs

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/network/network.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/network/network.tf
@@ -131,16 +131,3 @@ resource "aws_route" "private_rt_routes_to_tgw" {
   destination_cidr_block = "0.0.0.0/0"
   transit_gateway_id     = data.terraform_remote_state.tgw[0].outputs.tgw_id
 }
-
-# VPC flow logs
-module "vpc_flow_logs" {
-  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.17"
-
-  # enable
-  count = var.enable_vpc_flow_logs ? 1 : 0
-
-  vpc_id             = module.vpc-eks.vpc_id
-  bucket_name_prefix = local.vpc_name
-  tags               = local.tags
-  enable_versioning  = true
-}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/network/network_vpc_flow_logs.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/network/network_vpc_flow_logs.tf
@@ -1,0 +1,9 @@
+module "vpc_flow_logs" {
+  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.18"
+
+  count              = var.enable_vpc_flow_logs ? 1 : 0
+  vpc_id             = module.vpc-eks.vpc_id
+  bucket_name_prefix = local.vpc_name
+  log_format         = "$${version} $${vpc-id} $${subnet-id} $${instance-id} $${interface-id} $${account-id} $${type} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${pkt-srcaddr} $${pkt-dstaddr} $${protocol} $${bytes} $${packets} $${start} $${end} $${action} $${tcp-flags} $${log-status} $${region} $${az-id} $${sublocation-type} $${sublocation-id} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
+  tags               = local.tags
+}

--- a/apps-devstg/us-east-1/k8s-eks/network/config.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/config.tf
@@ -16,7 +16,7 @@ provider "aws" {
 # Backend Config (partial)
 #
 terraform {
-  required_version = "~> 1.2.7"
+  required_version = "~> 1.2"
 
   required_providers {
     aws = "~> 4.10"

--- a/apps-devstg/us-east-1/k8s-eks/network/network.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/network.tf
@@ -133,16 +133,3 @@ resource "aws_route" "private_rt_routes_to_tgw" {
   destination_cidr_block = "0.0.0.0/0"
   transit_gateway_id     = data.terraform_remote_state.tgw[0].outputs.tgw_id
 }
-
-# VPC flow logs
-module "vpc_flow_logs" {
-  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.17"
-
-  # enable
-  count = var.enable_vpc_flow_logs ? 1 : 0
-
-  vpc_id             = module.vpc-eks.vpc_id
-  bucket_name_prefix = local.vpc_name
-  tags               = local.tags
-  enable_versioning  = true
-}

--- a/apps-devstg/us-east-1/k8s-eks/network/network_vpc_flow_logs.tf
+++ b/apps-devstg/us-east-1/k8s-eks/network/network_vpc_flow_logs.tf
@@ -1,0 +1,9 @@
+module "vpc_flow_logs" {
+  source = "github.com/binbashar/terraform-aws-vpc-flowlogs.git?ref=v1.0.18"
+
+  count              = var.enable_vpc_flow_logs ? 1 : 0
+  vpc_id             = module.vpc-eks.vpc_id
+  bucket_name_prefix = local.vpc_name
+  log_format         = "$${version} $${vpc-id} $${subnet-id} $${instance-id} $${interface-id} $${account-id} $${type} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${pkt-srcaddr} $${pkt-dstaddr} $${protocol} $${bytes} $${packets} $${start} $${end} $${action} $${tcp-flags} $${log-status} $${region} $${az-id} $${sublocation-type} $${sublocation-id} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
+  tags               = local.tags
+}


### PR DESCRIPTION
## What?
* Use a custom VPC Flow Logs format on both EKS DevStg VPCs.

## Why?
* It is a good default to use the custom log format on EKS VPCs as it enhances your troubleshooting capabilities. E.g. you can understand which pods are generating which requests.

## References
N/A
