### PR TITLE
Add Cluster Over-provisioning to EKS DemoApps

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.23.1"
-  constraints = ">= 4.36.0, >= 4.47.0, >= 5.0.0, ~> 5.0"
+  constraints = "~> 5.0"
   hashes = [
     "h1:OfNN1dWusOJXQFmQjEXwgVBBG1uUAZ6+Ecc0F0+ukPg=",
+    "h1:s23thJVPJHUdS7ESZHoeMkxNcTeaqWvg2usv8ylFVL4=",
     "zh:024a188ad3c979a9ec0d7d898aaa90a3867a8839edc8d3543ea6155e6e010064",
     "zh:05b73a04c58534a7527718ef55040577d5c573ea704e16a813e7d1b18a7f4c26",
     "zh:13932cdee2fa90f40ebaa783f033752864eb6899129e055511359f8d1ada3710",
@@ -26,9 +27,10 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.11.0"
-  constraints = "~> 2.5, >= 2.9.0"
+  constraints = "~> 2.5"
   hashes = [
     "h1:FGGkgKf12zBjPjrD0ANq7EhywWM00PvYYw7OTdT/Kq4=",
+    "h1:zxfRtgpWrVZwjkIBuI+7jc52+u1QBA/k7LQZiCiq3Z8=",
     "zh:013857c88f3e19a4b162344e21dc51891c4ac8b600da8391f7fb2b6d234961e1",
     "zh:044fffa233a93cdcf8384afbe9e1ab6c9d0b5b176cbae56ff465eb9611302975",
     "zh:208b7cdd4fa3a1b25ae817dc00a9198ef98be0ddc3a577b5b72bc0f006afb997",
@@ -46,9 +48,10 @@ provider "registry.terraform.io/hashicorp/helm" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.23.0"
-  constraints = "~> 2.10, >= 2.20.0"
+  constraints = "~> 2.10"
   hashes = [
     "h1:cMs2scNCSgQhGamomGT5Ag4i8ms/mql1AR7NJc2hmbA=",
+    "h1:xyFc77aYkPoU4Xt1i5t0B1IaS8TbTtp9aCSuQKDayII=",
     "zh:10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
     "zh:1102ba5ca1a595f880e67102bbf999cc8b60203272a078a5b1e896d173f3f34b",
     "zh:1347cf958ed3f3f80b3c7b3e23ddda3d6c6573a81847a8ee92b7df231c238bf6",
@@ -61,25 +64,5 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
     "zh:c57376d169875990ac68664d227fb69cd0037b92d0eba6921d757c3fd1879080",
     "zh:e6068e3f94f6943b5586557b73f109debe19d1a75ca9273a681d22d1ce066579",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/time" {
-  version     = "0.9.1"
-  constraints = ">= 0.9.0"
-  hashes = [
-    "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
-    "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
-    "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
-    "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8c8094689a2bed4bb597d24a418bbbf846e15507f08be447d0a5acea67c2265a",
-    "zh:a6d9206e95d5681229429b406bc7a9ba4b2d9b67470bda7df88fa161508ace57",
-    "zh:aa299ec058f23ebe68976c7581017de50da6204883950de228ed9246f309e7f1",
-    "zh:b129f00f45fba1991db0aa954a6ba48d90f64a738629119bfb8e9a844b66e80b",
-    "zh:ef6cecf5f50cda971c1b215847938ced4cb4a30a18095509c068643b14030b00",
-    "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
-    "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
-    "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
   ]
 }

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/namespaces.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/namespaces.tf
@@ -127,3 +127,12 @@ resource "kubernetes_namespace" "prometheus" {
     name   = "prometheus"
   }
 }
+
+resource "kubernetes_namespace" "scaling" {
+  count = var.enable_cluster_overprovisioning ? 1 : 0
+
+  metadata {
+    labels = local.labels
+    name   = "scaling"
+  }
+}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/scaling.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/scaling.tf
@@ -56,8 +56,8 @@ resource "helm_release" "cluster_overprovisioner" {
   repository = "https://charts.deliveryhero.io/"
   chart      = "cluster-overprovisioner"
   version    = "0.7.11"
-  values     = [
-  <<EOF
+  values = [
+    <<EOF
     deployments:
       - name: default
         replicaCount: 2
@@ -89,8 +89,8 @@ resource "helm_release" "cluster_proportional_autoscaler" {
   repository = "https://kubernetes-sigs.github.io/cluster-proportional-autoscaler"
   chart      = "cluster-proportional-autoscaler"
   version    = "1.1.0"
-  values     = [
-  <<EOF
+  values = [
+    <<EOF
     options:
       namespace: ${kubernetes_namespace.scaling[0].id}
       target: deployment/cluster-overprovisioner-default

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/scaling.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/scaling.tf
@@ -32,3 +32,77 @@ resource "helm_release" "cluster_autoscaling" {
     )
   ]
 }
+
+#------------------------------------------------------------------------------
+# Cluster Overprovisioning
+#------------------------------------------------------------------------------
+# This is useful when you have work loads that need to scale up quickly without
+# waiting for the new cluster nodes to be created and join the cluster.
+#------------------------------------------------------------------------------
+
+# The cluster overprovisioner lets you create empty boxes:
+#   - "replicaCount" controls how many of them
+#   - Resources requests & limits controls how big they are
+#
+# Also keep in mind that these pods won't be doing anything really, so they
+# will not use node resources; and they will be assigned the lowest priority,
+# which will make them easy candidates for eviction.
+# Another option is to start with one replica and then use the proportional
+# autoscaler to control the minimum number of replicas there.
+resource "helm_release" "cluster_overprovisioner" {
+  count      = var.enable_cluster_overprovisioning ? 1 : 0
+  name       = "cluster-overprovisioner"
+  namespace  = kubernetes_namespace.scaling[0].id
+  repository = "https://charts.deliveryhero.io/"
+  chart      = "cluster-overprovisioner"
+  version    = "0.7.11"
+  values     = [
+  <<EOF
+    deployments:
+      - name: default
+        replicaCount: 2
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 1000m
+            memory: 1000Mi
+EOF
+  ]
+}
+
+# This autoscaler can scale deployments (or replication controllers, or replica
+# sets) based on the number of nodes or cores, and using a linear or ladder
+# strategy.
+#  - First decide which strategy best suits your use case, and then set the
+#    cores or the nodes per replica to define how those values should define
+#    the number of replicas of your target.
+#  - Then, it is very important to factor in the instances on which the targets
+#    managed by the proportional autoscaler will run. That's because these
+#    targets must, as mush as possible, be assigned to a new node.
+#  - Also, don't forget about using proper values for the min and max settings.
+resource "helm_release" "cluster_proportional_autoscaler" {
+  count      = var.enable_cluster_overprovisioning ? 1 : 0
+  name       = "cluster-proportional-autoscaler"
+  namespace  = kubernetes_namespace.scaling[0].id
+  repository = "https://kubernetes-sigs.github.io/cluster-proportional-autoscaler"
+  chart      = "cluster-proportional-autoscaler"
+  version    = "1.1.0"
+  values     = [
+  <<EOF
+    options:
+      namespace: ${kubernetes_namespace.scaling[0].id}
+      target: deployment/cluster-overprovisioner-default
+    config:
+      linear:
+        coresPerReplica: 0
+        nodesPerReplica: 1
+        min: 2
+        max: 25
+        preventSinglePointFailure: true
+        includeUnschedulableNodes: true
+EOF
+  ]
+  depends_on = [helm_release.cluster_overprovisioner]
+}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
@@ -28,9 +28,10 @@ enable_external_secrets = true
 #------------------------------------------------------------------------------
 # Scaling
 #------------------------------------------------------------------------------
-enable_hpa_scaling         = false
-enable_vpa_scaling         = false
-enable_cluster_autoscaling = true
+enable_hpa_scaling              = false
+enable_vpa_scaling              = false
+enable_cluster_autoscaling      = true
+enable_cluster_overprovisioning = true
 
 #------------------------------------------------------------------------------
 # Monitoring

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/variables.tf
@@ -71,6 +71,11 @@ variable "enable_cluster_autoscaling" {
   default = false
 }
 
+variable "enable_cluster_overprovisioning" {
+  type    = bool
+  default = false
+}
+
 variable "enable_gatus" {
   type    = bool
   default = false


### PR DESCRIPTION
## What?
* Add Cluster Over-provisioning to EKS DemoApps

## Why?
* This is useful when you have workloads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.

## References
N/A

