### PR TITLE
FEATURE/ start stop module pointed to binbash modified one

### DIFF
--- a/shared/us-east-1/tools-cloud-scheduler-stop-start/main.tf
+++ b/shared/us-east-1/tools-cloud-scheduler-stop-start/main.tf
@@ -7,7 +7,7 @@
 # Stop
 #
 module "schedule_ec2_stop_daily_midnight" {
-  source = "github.com/binbashar/terraform-aws-lambda-scheduler-stop-start?ref=3.1.3"
+  source = "github.com/binbashar/terraform-aws-lambda-scheduler-stop-start?ref=3.5.1_0"
   name   = "${var.project}-${var.environment}-schedule-stop-ec2"
 
   # Define the aws cloudwatch event rule schedule expression,
@@ -36,14 +36,18 @@ module "schedule_ec2_stop_daily_midnight" {
 # Start
 #
 module "schedule_ec2_start_daily_morning" {
-  source = "github.com/binbashar/terraform-aws-lambda-scheduler-stop-start?ref=3.1.3"
+  source = "github.com/binbashar/terraform-aws-lambda-scheduler-stop-start?ref=3.5.1_0"
   name   = "${var.project}-${var.environment}-schedule-start-ec2"
 
   # Define the aws cloudwatch event rule schedule expression,
   # eg1: monday to friday at 22hs cron(0 22 ? * MON-FRI *)
   # eg2: once a week every friday at 00hs cron(0 00 ? * FRI *)
   # eg3: everyday at 00hs cron(0 00 * * ? *)
-  cloudwatch_schedule_expression = "cron(0 9 * * ? *)"
+  # none: do not create a schedule (e.g. http endpoints enabled)
+  cloudwatch_schedule_expression = "none"
+
+  # Create an http endpoint to trigger lambda
+  http_trigger = true
 
   # Define schedule action to apply on resources
   schedule_action = "start"

--- a/shared/us-east-1/tools-cloud-scheduler-stop-start/outputs.tf
+++ b/shared/us-east-1/tools-cloud-scheduler-stop-start/outputs.tf
@@ -1,9 +1,9 @@
 output "start_http_endpoint" {
   description = "The http endpoint to trigger start"
-  value = module.schedule_ec2_start_daily_morning.http_trigger
+  value       = module.schedule_ec2_start_daily_morning.http_trigger
 }
 
 output "stop_http_endpoint" {
   description = "The http endpoint to trigger stop"
-  value = module.schedule_ec2_stop_daily_midnight.http_trigger
+  value       = module.schedule_ec2_stop_daily_midnight.http_trigger
 }

--- a/shared/us-east-1/tools-cloud-scheduler-stop-start/outputs.tf
+++ b/shared/us-east-1/tools-cloud-scheduler-stop-start/outputs.tf
@@ -1,0 +1,9 @@
+output "start_http_endpoint" {
+  description = "The http endpoint to trigger start"
+  value = module.schedule_ec2_start_daily_morning.http_trigger
+}
+
+output "stop_http_endpoint" {
+  description = "The http endpoint to trigger stop"
+  value = module.schedule_ec2_stop_daily_midnight.http_trigger
+}

--- a/shared/us-east-1/tools-costs-notifications/README.md
+++ b/shared/us-east-1/tools-costs-notifications/README.md
@@ -9,7 +9,7 @@ The AWS Cost Summary Report Script with Terraform is a comprehensive solution fo
 - **Name**: `monthly-services-usage-lambdarole`
 - **Description**: IAM role for the Lambda function responsible for generating cost reports.
 - **Assume Role Policy**: Allows Lambda to assume this role.
-  
+
 ### `aws_iam_policy` - `monthly_services_usage_lambda_role_policy`
 
 - **Name**: `MonthlyServicesUsageLambdaRolePolicy`

--- a/shared/us-east-1/tools-costs-notifications/variables.tf
+++ b/shared/us-east-1/tools-costs-notifications/variables.tf
@@ -25,7 +25,7 @@ variable "recipient_emails" {
 }
 
 # JSON encoded list of cost allocation tags (Max 3)
-# For example: 
+# For example:
 # default     = {
 #     "cost-center" = "machine-learning",
 #     "environment" = "production"


### PR DESCRIPTION
## What?
* Module to start/stop instances pointed to the one updated by binbash
* Added configurations to create HTTP endpoints instead of schedules (both can be created)

## Why?
* To add the ability to create HTTP endpoints besides schedules
* The target module, modified by binbash, has a PR created against main upstream, until it is approved a tag was created in binbash's fork to take advantage of the new feature

## References
* binbash fork tag: https://github.com/binbashar/terraform-aws-lambda-scheduler-stop-start/releases/tag/3.5.1_0
* upstream PR: https://github.com/diodonfrost/terraform-aws-lambda-scheduler-stop-start/pull/56

