### PR TITLE
feature | updating cost management budget thresholds

### DIFF
--- a/management/global/cost-mgmt/variables.tf
+++ b/management/global/cost-mgmt/variables.tf
@@ -6,12 +6,12 @@
 #
 variable "monthly_billing_threshold_50" {
   description = "Monthly billing threshold in dollars"
-  default     = "50.0"
+  default     = "62.5"
 }
 
 variable "monthly_billing_threshold_100" {
   description = "Monthly billing threshold in dollars"
-  default     = "100.0"
+  default     = "125.0"
 }
 
 variable "currency" {


### PR DESCRIPTION
## What?
Update cost management thresholds.

## Why?
The threshold was too low generating false positive alerts.


