### PR TITLE
FEATURE/ AWS Cloudwatch Synthetics layer added

### DIFF
--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/README.md
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/README.md
@@ -1,0 +1,66 @@
+# AWS Cloudwatch Synthetics
+
+## Overview
+
+This module creates `canaries` to check endpoints.
+
+`canaries` is how AWS Cloudwatch Synthetics calls the Lambdas that will check endpoints.
+
+More documentation [here](https://docs.aws.amazon.com/AmazonSynthetics/latest/APIReference/Welcome.html).
+
+## Dependencies
+
+This module uses a fork of [this module](https://github.com/clouddrove/terraform-aws-cloudwatch-synthetics) hosted on `binbashar` space to add a few modifications.
+
+## Notifications
+
+Same as with the original module, `alarm_email` can be set when calling the module to set the email that will suscribe to the SNS topic.
+
+As per the `binbash Leverage` needs, this email can be set to null, so later the [notifications](https://github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/notifications) module can be used to suscribe to this topic. For this an output is added with the topic name.
+
+### Setting `notifications` layer
+
+Add the remote state for the `synthetics` layer.
+
+``` json
+data "terraform_remote_state" "aws-cloudwatch-synthetics" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/aws-cloudwatch-synthetics/terraform.tfstate"
+  }
+}
+```
+
+Extract the topic name:
+
+``` json
+  arn_array = split(":", data.terraform_remote_state.aws-cloudwatch-synthetics.outputs.topic_target_canary)
+  topic_name = local.arn_array[length(local.arn_array) - 1]
+```
+
+Set the topic to not be created:
+
+``` json
+  create_sns_topic = false
+```
+
+And set the topic name from the `synthetics` layer:
+
+``` json
+  sns_topic_name       = local.topic_name
+```
+
+## IAM permission
+
+Note if you are using the default `binbash Leverage` configuration, and you are using *DevOps* profile with SSO, maybe you'll have to add this permission to your *DevOps* policy:
+
+``` json
+synthetics:*
+```
+
+*(or something more specific if you want to narrow the permission set)*
+

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/README.md
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/README.md
@@ -10,7 +10,7 @@ More documentation [here](https://docs.aws.amazon.com/AmazonSynthetics/latest/AP
 
 ## Dependencies
 
-This module uses a fork of [this module](https://github.com/clouddrove/terraform-aws-cloudwatch-synthetics) hosted on `binbashar` space to add a few modifications.
+This module uses a fork of [this module](https://github.com/clouddrove/terraform-aws-cloudwatch-synthetics) hosted in `binbashar` space to add a few modifications.
 
 ## Notifications
 

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/README.md
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/README.md
@@ -64,3 +64,19 @@ synthetics:*
 
 *(or something more specific if you want to narrow the permission set)*
 
+## Known issues
+
+If a canary in a private subnet is created, and then it is moved out from that subnet, e.g. you created the private canary, then comment out these lines:
+
+``` json
+  #subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
+  #security_group_ids        = [aws_security_group.target-canary-sg.id]
+```
+
+...and re apply.
+
+In this case there is a chance the ENIs the canary took in first place in the private subnet remain attached even if they are not being used.
+
+E.g., if you want to destroy this infra the ENIs can not be detached even if the Lambda does not exist anymore.
+
+In this case, wait for 24hs, AWS should recognize the unused ENIs and will detach them automagically.

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -12,9 +12,13 @@ module "target-canary" {
   managedby           = "managedby@binbash.co"
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
 
+  create_topic       = false
+  #existent_topic_arn = "arn:aws:sns:us-east-1:523857393444:sns-topic-slack-notify-monitoring"
+  existent_topic_arn = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
+
   # what networks it has to work in?
-  subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
-  security_group_ids        = [aws_security_group.target-canary-sg.id]
+  #subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
+  #security_group_ids        = [aws_security_group.target-canary-sg.id]
 
   tags = local.tags
 

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -1,6 +1,5 @@
 module "target-canary" {
-  source = "git::https://github.com/binbashar/terraform-aws-cloudwatch-synthetics.git?ref=FEATURE/improving-module"
-  #version             = "1.3.1"
+  source = "github.com/binbashar/terraform-aws-cloudwatch-synthetics.git?ref=1.4.0"
 
   name_prefix = "${var.project}-${var.environment}"
   environment = var.environment

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -12,7 +12,7 @@ module "target-canary" {
   managedby           = "managedby@binbash.co"
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
 
-  create_topic       = false
+  create_topic = false
   #existent_topic_arn = "arn:aws:sns:us-east-1:523857393444:sns-topic-slack-notify-monitoring"
   existent_topic_arn = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
 

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -12,7 +12,6 @@ module "target-canary" {
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
 
   create_topic = false
-  #existent_topic_arn = "arn:aws:sns:us-east-1:523857393444:sns-topic-slack-notify-monitoring"
   existent_topic_arn = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
 
   # what networks it has to work in?

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -11,7 +11,7 @@ module "target-canary" {
   managedby           = "managedby@binbash.co"
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
 
-  create_topic = false
+  create_topic       = false
   existent_topic_arn = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
 
   # what networks it has to work in?

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -8,7 +8,7 @@ module "target-canary" {
   schedule_expression = "rate(5 minutes)"
   s3_artifact_bucket  = module.target_canary_s3_bucket.s3_bucket_id # must pre-exist
   alarm_email         = null                                        # an email or null value
-  endpoints           = { "target-group" = { url = "http://costenginetool.basemates.co/" } }
+  endpoints           = { "target-group" = { url = "http://www.binbash.co/" } }
   managedby           = "managedby@binbash.co"
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
 

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -1,13 +1,13 @@
 module "target-canary" {
-  source              = "git::https://github.com/binbashar/terraform-aws-cloudwatch-synthetics.git?ref=FEATURE/improving-module"
+  source = "git::https://github.com/binbashar/terraform-aws-cloudwatch-synthetics.git?ref=FEATURE/improving-module"
   #version             = "1.3.1"
 
-  name_prefix         = "${var.project}-${var.environment}"
-  environment         = var.environment
+  name_prefix = "${var.project}-${var.environment}"
+  environment = var.environment
 
   schedule_expression = "rate(5 minutes)"
-  s3_artifact_bucket  = module.target_canary_s3_bucket.s3_bucket_id              # must pre-exist
-  alarm_email         = null # an email or null value
+  s3_artifact_bucket  = module.target_canary_s3_bucket.s3_bucket_id # must pre-exist
+  alarm_email         = null                                        # an email or null value
   endpoints           = { "target-group" = { url = "http://costenginetool.basemates.co/" } }
   managedby           = "managedby@binbash.co"
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
@@ -16,7 +16,7 @@ module "target-canary" {
   #subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
   #security_group_ids        = [resource.aws_security_group.target-canary-sg.id]
 
-  tags                = local.tags
+  tags = local.tags
 
   depends_on = [module.target_canary_s3_bucket]
 }

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -13,10 +13,10 @@ module "target-canary" {
   repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
 
   # what networks it has to work in?
-  #subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
-  #security_group_ids        = [resource.aws_security_group.target-canary-sg.id]
+  subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
+  security_group_ids        = [aws_security_group.target-canary-sg.id]
 
   tags = local.tags
 
-  depends_on = [module.target_canary_s3_bucket]
+  depends_on = [module.target_canary_s3_bucket, aws_security_group.target-canary-sg]
 }

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/canaries.tf
@@ -1,0 +1,22 @@
+module "target-canary" {
+  source              = "git::https://github.com/binbashar/terraform-aws-cloudwatch-synthetics.git?ref=FEATURE/improving-module"
+  #version             = "1.3.1"
+
+  name_prefix         = "${var.project}-${var.environment}"
+  environment         = var.environment
+
+  schedule_expression = "rate(5 minutes)"
+  s3_artifact_bucket  = module.target_canary_s3_bucket.s3_bucket_id              # must pre-exist
+  alarm_email         = null # an email or null value
+  endpoints           = { "target-group" = { url = "http://costenginetool.basemates.co/" } }
+  managedby           = "managedby@binbash.co"
+  repository          = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
+
+  # what networks it has to work in?
+  #subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
+  #security_group_ids        = [resource.aws_security_group.target-canary-sg.id]
+
+  tags                = local.tags
+
+  depends_on = [module.target_canary_s3_bucket]
+}

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/common-variables.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/common-variables.tf
@@ -1,0 +1,1 @@
+../../../config/common-variables.tf

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/config.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/config.tf
@@ -38,3 +38,14 @@ data "terraform_remote_state" "local-vpcs" {
   }
 }
 
+
+data "terraform_remote_state" "notifications" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/notifications/terraform.tfstate"
+  }
+}

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/config.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/config.tf
@@ -1,0 +1,40 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+#=============================#
+# Backend Config (partial)    #
+#=============================#
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    aws = "~> 4.10"
+  }
+
+  backend "s3" {
+    key = "apps-devstg/aws-cloudwatch-synthetics/terraform.tfstate"
+  }
+}
+
+#=============================#
+# Data sources                #
+#=============================#
+
+# VPC remote states for this account
+data "terraform_remote_state" "local-vpcs" {
+
+  backend = "s3"
+
+  config = {
+    region  = lookup(local.local-vpc.local-base, "region")
+    profile = lookup(local.local-vpc.local-base, "profile")
+    bucket  = lookup(local.local-vpc.local-base, "bucket")
+    key     = lookup(local.local-vpc.local-base, "key")
+  }
+}
+

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/locals.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  tags = {
+    Terraform   = "true"
+    Environment = var.environment
+  }
+  # network
+  local-vpc = {
+    local-base = {
+      region  = var.region
+      profile = "${var.project}-apps-devstg-devops"
+      bucket  = "${var.project}-apps-devstg-terraform-backend"
+      key     = "apps-devstg/network/terraform.tfstate"
+    }
+  }
+
+}

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/outputs.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/outputs.tf
@@ -1,0 +1,3 @@
+output "topic_target_canary" {
+  value = module.target-canary.topic_arn
+}

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/s3.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/s3.tf
@@ -1,0 +1,13 @@
+module "target_canary_s3_bucket" {
+
+  source        = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.14.0"
+
+  bucket        = "${var.project}-${var.environment}-target-canary"
+
+  force_destroy = true
+
+  control_object_ownership = true
+  object_ownership = "BucketOwnerEnforced"
+
+  tags          = local.tags
+}

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/s3.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/s3.tf
@@ -1,13 +1,13 @@
 module "target_canary_s3_bucket" {
 
-  source        = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.14.0"
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.14.0"
 
-  bucket        = "${var.project}-${var.environment}-target-canary"
+  bucket = "${var.project}-${var.environment}-target-canary"
 
   force_destroy = true
 
   control_object_ownership = true
-  object_ownership = "BucketOwnerEnforced"
+  object_ownership         = "BucketOwnerEnforced"
 
-  tags          = local.tags
+  tags = local.tags
 }

--- a/apps-devstg/us-east-1/aws-cloudwatch-synthetics/sg.tf
+++ b/apps-devstg/us-east-1/aws-cloudwatch-synthetics/sg.tf
@@ -1,0 +1,24 @@
+# Security group for granting access from canary to targets
+#
+resource "aws_security_group" "target-canary-sg" {
+  name        = "${var.project}-${var.environment}-target-canary-sg"
+  description = "Allow TLS outbound traffic"
+  vpc_id      = data.terraform_remote_state.local-vpcs.outputs.vpc_id
+
+  #ingress {
+  #  description = "TLS from VPC"
+  #  from_port   = 443
+  #  to_port     = 443
+  #  protocol    = "tcp"
+  #  cidr_blocks = ["0.0.0.0/0"]
+  #}
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
## What?
* Add AWS Cloudwatch Synthetics layer
* This layer will:
  * create a series of canaries fot the given targets
  * create an SNS Topic for notification
  * create a Bucket for storing both the code for the Lambda and the screenshots it takes
  * optionally subscribe an email address to the topic
  * create an output with the topic ARN so it can be used later by the `notifications` layer

## Why?
* It was a request to monitor internal URLs (i.e. inside private subnets), and this AWS Cloudwatch Synthetics came up as the best solution.


