### PR TITLE
Create DeployMaster role in Security

### DIFF
--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -78,6 +78,7 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",
+                "arn:aws:iam::${var.accounts.security.id}:role/DeployMaster",
                 "arn:aws:iam::${var.accounts.network.id}:role/DeployMaster",
                 "arn:aws:iam::${var.accounts.apps-devstg.id}:role/DeployMaster",
                 "arn:aws:iam::${var.accounts.apps-prd.id}:role/DeployMaster"

--- a/security/global/base-identities/role_policies.tf
+++ b/security/global/base-identities/role_policies.tf
@@ -163,3 +163,63 @@ data "aws_iam_policy_document" "lambda_costs_explorer_access" {
     ]
   }
 }
+
+#
+# Customer Managed Policy: DeployMaster
+#
+resource "aws_iam_policy" "deploy_master_access" {
+  name        = "deploy_master_access"
+  description = "Services enabled for DeployMaster role"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "athena:*",
+                "budgets:*",
+                "cloudfront:*",
+                "cloudtrail:*",
+                "cloudwatch:*",
+                "config:*",
+                "ecr:*",
+                "elasticloadbalancing:*",
+                "iam:*",
+                "dynamodb:*",
+                "ec2:*",
+                "ecr:*",
+                "glue:*",
+                "iam:*",
+                "logs:*",
+                "route53:*",
+                "route53domains:*",
+                "s3:*",
+                "sns:*",
+                "ssm:*",
+                "sqs:*",
+                "vpc:*",
+                "waf:*",
+                "wafv2:*",
+                "waf-regional:*",
+                "kms:*",
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestedRegion": [
+                        "us-east-1",
+                        "us-east-2",
+                        "us-west-2"
+                    ]
+                }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/security/global/base-identities/roles.tf
+++ b/security/global/base-identities/roles.tf
@@ -184,3 +184,30 @@ module "iam_assumable_role_lambda_costs_explorer_access" {
 
   tags = local.tags
 }
+
+#
+# Assumable Role Cross-Account: DeployMaster
+#
+module "iam_assumable_role_deploy_master" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v5.9.2"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.accounts.security.id}:root",
+  ]
+
+  create_role = true
+  role_name   = "DeployMaster"
+  role_path   = "/"
+
+  #
+  # MFA setup
+  #
+  role_requires_mfa    = false
+  mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
+  max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
+  custom_role_policy_arns = [
+    aws_iam_policy.deploy_master_access.arn
+  ]
+
+  tags = local.tags
+}


### PR DESCRIPTION
## What?
* Create DeployMaster role in the Security account

## Why?
* This is needed for the NATGW workflows fix

## References
* Relates to https://github.com/binbashar/le-devops-workflows/pull/45


