### PR TITLE
FEATURE/ can set permissions on topic for allowing aws budgets to use it

### DIFF
--- a/apps-devstg/us-east-1/notifications/README.md
+++ b/apps-devstg/us-east-1/notifications/README.md
@@ -26,17 +26,18 @@ kms_key_arn = "${aws_kms_key.this.arn}"
 create_with_kms_key = true
 ```
 
-### Consideration
+### SOPS file
 
-In order to get the necessary `secrets.dec.tf` file referenced at `plaintext = local.secrets.slack_webhook_monitoring`
-please execute `make decrypt` in this same path
+You need to store your URLs in `secrets.enc.yaml`, note this is an encrypted version of a yaml file with the corresponding URLs.
 
-```
-╭─delivery at delivery-ops in ~/Binbash/repos/Flex/devops-tf-infra/shared/notifications on master✔ 20-10-21 - 9:27:51
-╰─⠠⠵ make decrypt
-ansible-vault decrypt --output secrets.dec.tf secrets.enc
-Vault password:
-Decryption successful
+You should be able to do something like (after creating the `secrets.yaml` file):
+
+``` shell
+export AWS_PROFILE=yourprofile
+sops --encrypt --kms arn:aws:kms:region:account:key/key-id secrets.yaml > secrets.enc.yaml
 ```
 
+Note the key must be the same used later in the tf files.
+
+You can use the `leverage` shell mounting sops, more info [here](https://leverage.binbash.co/user-guide/leverage-cli/reference/shell/).
 

--- a/apps-devstg/us-east-1/notifications/config.tf
+++ b/apps-devstg/us-east-1/notifications/config.tf
@@ -13,7 +13,7 @@ terraform {
   required_version = "~> 1.3"
 
   required_providers {
-    aws   = "~> 4.10"
+    aws = "~> 4.10"
     sops = {
       source  = "carlpett/sops"
       version = "~> 0.7"

--- a/apps-devstg/us-east-1/notifications/config.tf
+++ b/apps-devstg/us-east-1/notifications/config.tf
@@ -7,27 +7,17 @@ provider "aws" {
 }
 
 #=============================#
-# Vault Provider Settings     #
-#=============================#
-provider "vault" {
-  address = var.vault_address
-
-  /*
-  Vault token that will be used by Terraform to authenticate.
- admin token from https://portal.cloud.hashicorp.com/.
- */
-  token = var.vault_token
-}
-
-#=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.2.7"
+  required_version = "~> 1.3"
 
   required_providers {
     aws   = "~> 4.10"
-    vault = "~> 3.6.0"
+    sops = {
+      source  = "carlpett/sops"
+      version = "~> 0.7"
+    }
   }
 
   backend "s3" {
@@ -53,6 +43,6 @@ data "terraform_remote_state" "keys" {
   }
 }
 
-data "vault_generic_secret" "slack_hook_url_monitoring" {
-  path = "secrets/${var.project}/${var.environment}/notifications"
+data "sops_file" "secrets" {
+  source_file = "secrets.enc.yaml"
 }

--- a/apps-devstg/us-east-1/notifications/secrets.enc.yaml
+++ b/apps-devstg/us-east-1/notifications/secrets.enc.yaml
@@ -1,0 +1,17 @@
+slack_webhook_monitoring: ENC[AES256_GCM,data:AJxYkA7oWsBL6g==,iv:8IsXIg22aFJ9rY/cQNGV+RGaHpZ+s9ixcRie7r4MmlA=,tag:4IWiL54536NCG+0Z1H9Faw==,type:str]
+slack_webhook_monitoring_sec: ENC[AES256_GCM,data:bJqeutDJ9FOfRoYL8g==,iv:jmyl/b9M0FyISumnDXMuJWxbOoneCe4EIH6q+hMpPHw=,tag:9RAOGs62XKjJe4nNivwCQQ==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:us-east-1:523857393444:key/63c14fe9-c3e7-4d3d-9856-ce372cf961b7
+          created_at: "2024-03-05T15:06:27Z"
+          enc: AQICAHgYJ9/Sba2T+y3OSwWMo6A15BR68fqueyUjU1extUF/hQFM+q9w1Rtd9QNaOPGdppQ8AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdZlvLd4gA3wjznkNAgEQgDu03IMYxQNS9cmX6m8P4ZGegySpZcmPVykXRuIHVFQAc7HCyJjOXJGchHmBb9EZkBqiLkSDvk/w2mb0bg==
+          aws_profile: bb-apps-devstg-devops
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-03-05T15:06:28Z"
+    mac: ENC[AES256_GCM,data:PGdkYXYAOsn0ZrYky320OxZASUgAAzhXAilx2HqOcj+Xp+GkvuAGqKDcJySGyQSXE5eSdT3cZrjXFqu+d4JtK1IKMs6iQ4AAiT5jM2Zma3XF00pO27Y+IqTH19GN5AdMLSLnwihcQBYV+thjiBYNupzeQ/7A4tHnx7tL7VgOBf0=,iv:VdEVJd2RjrXZWSzcI3tyOp6Gag7gjDxFtP5pBhmGK1Q=,tag:FdakUy7pCgDXIpI0ihM3cw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
@@ -56,25 +56,6 @@ data "aws_iam_policy_document" "sns-topic-policy" {
 
   statement {
     actions = [
-      "SNS:Publish",
-    ]
-
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["budgets.amazonaws.com"]
-    }
-
-    resources = [
-      module.notify_slack_monitoring.slack_topic_arn
-    ]
-
-    sid = "_budgets_service_access_ID"
-  }
-
-  statement {
-    actions = [
       "SNS:Subscribe",
       "SNS:SetTopicAttributes",
       "SNS:RemovePermission",

--- a/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
@@ -50,7 +50,7 @@ resource "aws_sns_topic_policy" "default" {
 }
 
 data "aws_iam_policy_document" "sns-topic-policy" {
-  count  = var.add_budget_service_permission == true ? 1 : 0
+  count = var.add_budget_service_permission == true ? 1 : 0
 
   policy_id = "publish_to_topic_policy"
 

--- a/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/apps-devstg/us-east-1/notifications/slack_tools_monitoring.tf
@@ -2,7 +2,7 @@
 # https://www.terraform.io/docs/state/sensitive-data.html
 
 resource "aws_kms_ciphertext" "slack_url_monitoring" {
-  plaintext = data.vault_generic_secret.slack_hook_url_monitoring.data["slack_webhook_monitoring"]
+  plaintext = data.sops_file.secrets.data["slack_webhook_monitoring"]
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/apps-devstg/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/apps-devstg/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -2,7 +2,7 @@
 # https://www.terraform.io/docs/state/sensitive-data.html
 
 resource "aws_kms_ciphertext" "slack_url_monitoring_sec" {
-  plaintext = data.vault_generic_secret.slack_hook_url_monitoring.data["slack_webhook_monitoring_sec"]
+  plaintext = data.sops_file.secrets.data["slack_webhook_monitoring_sec"]
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/apps-devstg/us-east-1/notifications/variables.tf
+++ b/apps-devstg/us-east-1/notifications/variables.tf
@@ -18,3 +18,9 @@ variable "sns_topic_name_monitoring_sec" {
   description = ""
   default     = "sns-topic-slack-notify-monitoring-sec"
 }
+
+variable "add_budget_service_permission" {
+  type        = bool
+  description = "Add permission to allow AWS budget to publish into this topic"
+  default     = false
+}


### PR DESCRIPTION
## What?
* Add chance to set AWS Budget publish permission on the topic

## Why?
* As per [this](https://github.com/binbashar/terraform-aws-cost-budget/issues/5#issuecomment-532327325) post, the way AWS manages the access of AWS Budget to topics has changed. So this permission is necessary.
* When this notification topic will be used as a target for `cost-mngm` layer, this permission is needed, and since we use the former layer a lot it is worth adding this here

## References
* [post](https://github.com/binbashar/terraform-aws-cost-budget/issues/5#issuecomment-532327325)

