### PR TITLE
Remove null resource to delegate config to Security Account 

### DIFF
--- a/management/global/organizations/locals.tf
+++ b/management/global/organizations/locals.tf
@@ -95,4 +95,10 @@ locals {
       parent_ou = "bbl_data_science"
     }
   }
+
+  ## Delegated services to Security Account
+  delegated_services = [
+    "access-analyzer.amazonaws.com",
+    "config.amazonaws.com"
+  ]
 }

--- a/management/global/organizations/organization.tf
+++ b/management/global/organizations/organization.tf
@@ -28,18 +28,19 @@ resource "aws_organizations_organization" "main" {
 }
 
 #
-# Delegate administration of access analyzer to security account
+# Delegate administration of resources to security account
 #
-resource "aws_organizations_delegated_administrator" "access_analyzer_administrator" {
+resource "aws_organizations_delegated_administrator" "delegated_administrator" {
+  for_each          = toset(local.delegated_services)
   account_id        = aws_organizations_account.accounts["security"].id
-  service_principal = "access-analyzer.amazonaws.com"
+  service_principal = each.key
 
   depends_on = [
     aws_organizations_organization.main,
-    aws_organizations_account.accounts["security"]
   ]
 }
 
-resource "aws_iam_service_linked_role" "access_analyzer" {
-  aws_service_name = "access-analyzer.amazonaws.com"
+resource "aws_iam_service_linked_role" "linked_roles" {
+  for_each         = toset(local.delegated_services)
+  aws_service_name = each.key
 }

--- a/management/us-east-1/security-compliance/awsconfig_delegation.tf
+++ b/management/us-east-1/security-compliance/awsconfig_delegation.tf
@@ -1,5 +1,0 @@
-resource "null_resource" "config_delegation" {
-  provisioner "local-exec" {
-    command = "aws organizations register-delegated-administrator --account-id ${var.accounts.security.id} --service-principal config.amazonaws.com  --profile ${var.profile} --region ${var.region}"
-  }
-}


### PR DESCRIPTION
## What?
- Delegate AWS Config Administrator to Security Account using Terraform resources instead of null_resource

## Why?
* Now the resource is supported by Terraform

## References
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator
* https://docs.aws.amazon.com/organizations/latest/APIReference/API_RegisterDelegatedAdministrator.html

