### PR TITLE
Unpin patches version restriction

### DIFF
--- a/apps-devstg/global/base-identities/config.tf
+++ b/apps-devstg/global/base-identities/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/apps-prd/global/base-identities/config.tf
+++ b/apps-prd/global/base-identities/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/management/global/base-identities/config.tf
+++ b/management/global/base-identities/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/network/global/base-identities/config.tf
+++ b/network/global/base-identities/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/security/global/base-identities/config.tf
+++ b/security/global/base-identities/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/shared/global/base-identities/config.tf
+++ b/shared/global/base-identities/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/shared/us-east-1/container-registry/config.tf
+++ b/shared/us-east-1/container-registry/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"

--- a/shared/us-east-1/tools-costs-notifications/config.tf
+++ b/shared/us-east-1/tools-costs-notifications/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws   = "~> 4.10"

--- a/shared/us-east-2/container-registry/config.tf
+++ b/shared/us-east-2/container-registry/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.3.5"
+  required_version = "~> 1.3"
 
   required_providers {
     aws = "~> 4.10"


### PR DESCRIPTION
## What?
The leverage CLI and ref-arch are compatible with both 1.3.5 and 1.5.0 terraform versions.

## Why?
With the current pins, we are locking the layers to 1.3.(x >= 5) only.

## Ref
https://github.com/binbashar/leverage/issues/272