### PR TITLE
Add AWS secret retrieval for ArgoCD

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/cicd-argo.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/cicd-argo.tf
@@ -6,6 +6,17 @@ data "aws_secretsmanager_secret_version" "demo_google_microservices_deploy_key" 
   secret_id = "/repositories/demo-google-microservices/deploy_key"
 }
 
+
+# argocd_admin_password
+data "aws_secretsmanager_secret" "argocd_admin_password" {
+  name = "/k8s-eks-demoapps/argocdserveradminpassword"
+}
+
+# Get the latest secret version
+data "aws_secretsmanager_secret_version" "argocd_admin_password" {
+  secret_id = data.aws_secretsmanager_secret.argocd_admin_password.id
+}
+
 resource "helm_release" "argocd" {
   count = var.enable_cicd ? 1 : 0
 
@@ -24,8 +35,8 @@ resource "helm_release" "argocd" {
     yamlencode({
       configs = {
         secret = {
-          # TODO Get this from Secrets Manager
-          argocdServerAdminPassword = "$2b$12$RrGivbnGu1F3Kxyt4tkLy.agL3H0K7lufq94MELnVQ5dtgIflrVmq"
+          # Get argocd admin password from AWS Secrets Manager
+          argocdServerAdminPassword = data.aws_secretsmanager_secret_version.argocd_admin_password.secret_string
         }
         repositories = {
           demo-google-microservices = {


### PR DESCRIPTION
## What?

This PR updates the Terraform configuration to retrieve the Argo Cd Server Admin Password from AWS Secrets Manager and use it in the Helm deployment of Argo CD.

## Why?
To enhance security by managing sensitive passwords through AWS Secrets Manager, ensuring centralized secret management and adherence to best practices.