### PR TITLE
Create IAM role for Drata on Production

### DIFF
--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -237,3 +237,30 @@ module "iam_assumable_role_lambda_costs_explorer_access" {
 
   tags = local.tags
 }
+
+#
+# Drata Auditor (Compliance Provider)
+#
+module "iam_assumable_role_drata_auditor" {
+  source = "github.com/binbashar/terraform-aws-iam.git//modules/iam-assumable-role?ref=v5.3.3"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.external_accounts.drata.aws_account_id}:root"
+  ]
+
+  role_sts_externalid = [
+    var.external_accounts.drata.aws_external_id
+  ]
+
+  create_role      = true
+  role_name        = "DrataAutopilotRole"
+  role_description = "Cross-account read-only access for Drata Autopilot"
+  role_path        = "/"
+
+  role_requires_mfa = false
+  custom_role_policy_arns = [
+    "arn:aws:iam::aws:policy/SecurityAudit"
+  ]
+
+  tags = local.tags
+}

--- a/config/common-variables.tf
+++ b/config/common-variables.tf
@@ -72,7 +72,12 @@ variable "region_secondary" {
 
 variable "accounts" {
   type        = map(any)
-  description = "Accounts descriptions"
+  description = "Accounts Information"
+}
+
+variable "external_accounts" {
+  type        = map(any)
+  description = "External Accounts Information"
 }
 
 #=============================#

--- a/config/common-variables.tf
+++ b/config/common-variables.tf
@@ -78,6 +78,7 @@ variable "accounts" {
 variable "external_accounts" {
   type        = map(any)
   description = "External Accounts Information"
+  default     = {}
 }
 
 #=============================#

--- a/config/common.tfvars.example
+++ b/config/common.tfvars.example
@@ -42,10 +42,23 @@ accounts = {
   }
 }
 
+# External Accounts Integration
+external_accounts = {
+  drata = {
+    aws_account_id  = ""
+    aws_external_id = ""
+  }
+  scale = {
+    aws_account_id  = ""
+    aws_external_id = ""
+  }
+}
+
 # AWS SSO
 sso_enabled   = true
 sso_start_url = "https://leverage.awsapps.com/start"
 sso_region    = "us-east-1"
+
 
 # The following values will be moved to another config file in a future release
 #


### PR DESCRIPTION
## What?
* Create IAM role for Drata on Production

## Why?
* For now, we'll start our integration with Drata with the Production account
