### PR TITLE
Added KEDA and KEDA-HTTP-Addon to k8s-components

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/namespaces.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/namespaces.tf
@@ -145,3 +145,12 @@ resource "kubernetes_namespace" "scaling" {
     name   = "scaling"
   }
 }
+
+resource "kubernetes_namespace" "keda" {
+  count = var.enable_keda ? 1 : 0
+
+  metadata {
+    labels = local.labels
+    name   = "keda"
+  }
+}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/scaling.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/scaling.tf
@@ -106,3 +106,36 @@ EOF
   ]
   depends_on = [helm_release.cluster_overprovisioner]
 }
+
+
+
+#------------------------------------------------------------------------------
+# KEDA: autoscaling k8s pods
+#------------------------------------------------------------------------------
+#
+# Kubernetes, a powerful container orchestration platform, revolutionized the way
+# applications are deployed and managed. However, scaling applications to meet
+# fluctuating workloads can be a complex task. KEDA, a Kubernetes-based
+# Event-Driven Autoscaler, provides a simple yet effective solution to
+# automatically scale Kubernetes Pods based on various metrics, including
+# resource utilization, custom metrics, and external events.
+#------------------------------------------------------------------------------
+resource "helm_release" "keda" {
+  count      = var.enable_keda ? 1 : 0
+  name       = "keda"
+  namespace  = kubernetes_namespace.keda[0].id
+  repository = "https://kedacore.github.io/charts"
+  chart      = "keda"
+  version    = "2.15.0"
+  values = []
+}
+
+resource "helm_release" "keda_http_add_on" {
+  count      = var.enable_keda && var.enable_keda_http_add_on ? 1 : 0
+  name       = "http-add-on"
+  namespace  = kubernetes_namespace.keda[0].id
+  repository = "https://kedacore.github.io/charts"
+  chart      = "keda-add-ons-http"
+  version    = "0.8.0"
+  values = []
+}

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
@@ -32,8 +32,8 @@ enable_hpa_scaling              = false
 enable_vpa_scaling              = false
 enable_cluster_autoscaling      = true
 enable_cluster_overprovisioning = false
-enable_keda                = true
-enable_keda_http_add_on    = true
+enable_keda                     = true
+enable_keda_http_add_on         = true
 
 #------------------------------------------------------------------------------
 # Monitoring: Logging

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
@@ -32,6 +32,8 @@ enable_hpa_scaling              = false
 enable_vpa_scaling              = false
 enable_cluster_autoscaling      = true
 enable_cluster_overprovisioning = false
+enable_keda                = true
+enable_keda_http_add_on    = true
 
 #------------------------------------------------------------------------------
 # Monitoring: Logging

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/terraform.tfvars
@@ -32,8 +32,8 @@ enable_hpa_scaling              = false
 enable_vpa_scaling              = false
 enable_cluster_autoscaling      = true
 enable_cluster_overprovisioning = false
-enable_keda                     = true
-enable_keda_http_add_on         = true
+enable_keda                     = false
+enable_keda_http_add_on         = false
 
 #------------------------------------------------------------------------------
 # Monitoring: Logging

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/variables.tf
@@ -192,3 +192,15 @@ variable "enable_prometheus_stack" {
   type    = bool
   default = false
 }
+
+#==================================#
+# enable_keda and keda http add on
+#==================================#
+variable "enable_keda" {
+  type    = bool
+  default = false
+}
+variable "enable_keda_http_add_on" {
+  type    = bool
+  default = false
+}

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/namespaces.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/namespaces.tf
@@ -109,3 +109,12 @@ resource "kubernetes_namespace" "velero" {
     name   = "velero"
   }
 }
+
+resource "kubernetes_namespace" "keda" {
+  count = var.enable_keda ? 1 : 0
+
+  metadata {
+    labels = local.labels
+    name   = "keda"
+  }
+}

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/scaling.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/scaling.tf
@@ -32,3 +32,35 @@ resource "helm_release" "cluster_autoscaling" {
     )
   ]
 }
+
+
+#------------------------------------------------------------------------------
+# KEDA: autoscaling k8s pods
+#------------------------------------------------------------------------------
+#
+# Kubernetes, a powerful container orchestration platform, revolutionized the way
+# applications are deployed and managed. However, scaling applications to meet
+# fluctuating workloads can be a complex task. KEDA, a Kubernetes-based
+# Event-Driven Autoscaler, provides a simple yet effective solution to
+# automatically scale Kubernetes Pods based on various metrics, including
+# resource utilization, custom metrics, and external events.
+#------------------------------------------------------------------------------
+resource "helm_release" "keda" {
+  count      = var.enable_keda ? 1 : 0
+  name       = "keda"
+  namespace  = kubernetes_namespace.keda[0].id
+  repository = "https://kedacore.github.io/charts"
+  chart      = "keda"
+  version    = "2.15.0"
+  values = []
+}
+
+resource "helm_release" "keda_http_add_on" {
+  count      = var.enable_keda && var.enable_keda_http_add_on ? 1 : 0
+  name       = "http-add-on"
+  namespace  = kubernetes_namespace.keda[0].id
+  repository = "https://kedacore.github.io/charts"
+  chart      = "keda-add-ons-http"
+  version    = "0.8.0"
+  values = []
+}

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
@@ -32,6 +32,8 @@ enable_external_secrets = true
 enable_hpa_scaling         = false
 enable_vpa_scaling         = false
 enable_cluster_autoscaling = true
+enable_keda                = true
+enable_keda_http_add_on    = true
 
 #------------------------------------------------------------------------------
 # Monitoring

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/terraform.tfvars
@@ -32,8 +32,8 @@ enable_external_secrets = true
 enable_hpa_scaling         = false
 enable_vpa_scaling         = false
 enable_cluster_autoscaling = true
-enable_keda                = true
-enable_keda_http_add_on    = true
+enable_keda                = false
+enable_keda_http_add_on    = false
 
 #------------------------------------------------------------------------------
 # Monitoring

--- a/apps-devstg/us-east-1/k8s-eks/k8s-components/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks/k8s-components/variables.tf
@@ -143,3 +143,15 @@ variable "schedules" {
   type    = any
   default = {}
 }
+
+#==================================#
+# enable_keda and keda http add on
+#==================================#
+variable "enable_keda" {
+  type    = bool
+  default = false
+}
+variable "enable_keda_http_add_on" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
## What?
* KEDA and KEDA-HTTP-Addon were added to `k8s-components` sub-layer for both `eks` layers
* KEDA is an improved way to manage pod auto-scalation
* KEDA-HTTP-Addon allows to intercept HTTP traffic, then scale down to zero and scale-up only in case of HTTP traffic to the given deployment (and service) 

## Why?
* Because a better way to autoscale pods is deserved here!
* Also because this way KEDA will be available if a client needs it.

## References
* [KEDA](https://keda.sh/)
* [KEDA-HTTP-Addon](https://github.com/kedacore/http-add-on)

