### PR TITLE
fix #667 - Remove credits filter from aws budget

### DIFF
--- a/management/global/cost-mgmt/main.tf
+++ b/management/global/cost-mgmt/main.tf
@@ -32,7 +32,7 @@ module "aws_cost_mgmt_billing_alert_100" {
 #
 # Budget = U$S100 at 75%
 module "aws_cost_mgmt_budget_notif_75" {
-  source = "github.com/binbashar/terraform-aws-cost-budget.git?ref=v1.0.15"
+  source = "github.com/binbashar/terraform-aws-cost-budget.git?ref=v1.0.16"
 
   aws_env                = "${var.environment}-75-percent"
   currency               = var.currency
@@ -47,7 +47,7 @@ module "aws_cost_mgmt_budget_notif_75" {
 
 # Budget = U$S100 at 100%
 module "aws_cost_mgmt_budget_notif_100" {
-  source = "github.com/binbashar/terraform-aws-cost-budget.git?ref=v1.0.15"
+  source = "github.com/binbashar/terraform-aws-cost-budget.git?ref=v1.0.16"
 
   aws_env                = "${var.environment}-100-percent"
   currency               = var.currency


### PR DESCRIPTION
## What?
* Remove credits filter from aws budget

## Why?
* The AWS budget takes the applied credits into account; therefore, the forecasted value is not entirely accurate.

## References
* https://github.com/binbashar/le-tf-infra-aws/issues/667

* Terraform output

```
  # module.aws_cost_mgmt_budget_notif_75.aws_budgets_budget.budget_notifification will be updated in-place
  ~ resource "aws_budgets_budget" "budget_notifification" {
        id                = "754065527950:budget-MONTHLY-root-75-percent"
        name              = "budget-MONTHLY-root-75-percent"
        # (9 unchanged attributes hidden)

      ~ cost_types {
          ~ include_credit             = true -> false
            # (10 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }


  # module.aws_cost_mgmt_budget_notif_100.aws_budgets_budget.budget_notifification will be updated in-place
  ~ resource "aws_budgets_budget" "budget_notifification" {
        id                = "754065527950:budget-MONTHLY-root-100-percent"
        name              = "budget-MONTHLY-root-100-percent"
        # (9 unchanged attributes hidden)

      ~ cost_types {
          ~ include_credit             = true -> false
            # (10 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

```
