### PR TITLE
Feature | rename EKS metadata file

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
@@ -197,5 +197,5 @@ data:
   cluster_name: ${module.cluster.cluster_name}
   profile: ${var.profile}
 EOT
-  filename = "${path.module}/cluster.yaml"
+  filename = "${path.module}/metadata.yaml"
 }


### PR DESCRIPTION
The CLI expects a `metadata.yaml` file.