### PR TITLE
Add santiago respane to the devops group

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -315,6 +315,7 @@ locals {
       email      = "santiago.respane@binbash.com.ar"
       groups = [
         "datascientists",
+        "devops"
       ]
     }
   }


### PR DESCRIPTION
## What?
* Add santiago respane to the devops group

## Why?
* He needs it to perform some cross-account tests

