### PR TITLE
update renovate to run in terraform v1.6.6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,8 +63,8 @@
       ]
     },
     {
-      "allowedVersions": "~> 4.10",
-      "description": "Pin AWS provider version to ~> 4.10",
+      "allowedVersions": "~> 5.91",
+      "description": "Pin AWS provider version to ~> 5.91",
       "enabled": true,
       "matchPackageNames": [
         "hashicorp/aws"

--- a/renovate.json
+++ b/renovate.json
@@ -55,8 +55,8 @@
       ]
     },
     {
-      "allowedVersions": "~> 1.3.5",
-      "description": "Pin Terraform version to ~> 1.3.5",
+      "allowedVersions": "~> 1.6.6",
+      "description": "Pin Terraform version to ~> 1.6.6",
       "enabled": true,
       "matchPackageNames": [
         "terraform"


### PR DESCRIPTION
## What?
* Update the renovate configuration to run with terraform v1.6.6 to make easier the migration to open tofu.

## Why?
* Is the needed version to ensure compatibility with opentofu.