### PR TITLE
Fix | Add FMS permissions to IAM policy por devops role

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -48,6 +48,7 @@ data "aws_iam_policy_document" "devops" {
       "es:*",
       "events:*",
       "execute-api:*",
+      "fms:*",
       "glue:*",
       "guardduty:*",
       "health:*",


### PR DESCRIPTION
## What?
Add FMS permissions to IAM policy por devops role

Code Apply ✅ 

## Why?
solve error
![image](https://github.com/user-attachments/assets/dfd6e275-0aec-4c27-906d-d81b8ff27d2d)


## References
* Related to the PR: https://github.com/binbashar/le-tf-infra-aws/pull/773/files

