### PR TITLE
Fix | IAM policy for devops role with new actions and Inspector administration permissions

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -165,17 +165,35 @@ data "aws_iam_policy_document" "devops" {
   statement {
     sid = "OrganizationWide"
     actions = [
-      "organizations:ListDelegatedAdministrators",
-      "organizations:ListAccounts",
+      "organizations:DeregisterDelegatedAdministrator",
       "organizations:DescribeOrganization",
+      "organizations:DisableAWSServiceAccess",
+      "organizations:EnableAWSServiceAccess",
       "organizations:ListAWSServiceAccessForOrganization",
-      "organizations:ListRoots",
+      "organizations:ListAccounts",
       "organizations:ListAccountsForParent",
-      "organizations:ListOrganizationalUnitsForParent"
+      "organizations:ListDelegatedAdministrators",
+      "organizations:ListOrganizationalUnitsForParent",
+      "organizations:ListRoots",
+      "organizations:RegisterDelegatedAdministrator"
     ]
     effect    = "Allow"
     resources = ["*"]
+  }
 
+  statement {
+    sid = "InspectorAdministration"
+    actions = [
+      "inspector2:Enable",
+      "inspector2:Disable",
+      "inspector2:AssociateMember",
+      "inspector2:DisassociateMember",
+      "inspector2:UpdateOrganizationConfiguration",
+      "inspector2:EnableDelegatedAdminAccount",
+      "inspector2:DisableDelegatedAdminAccount"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
# What?
Add Inspector permissions to IAM policy por devops role

Code Apply ✅

# Why?
solve error
![image](https://github.com/user-attachments/assets/4b673dc2-6b0a-4370-ac51-3256a68ddefc)


# References
Related to the PR: https://github.com/binbashar/le-tf-infra-aws/pull/778
