### PR TITLE
#793 Increase sso session duration for datascientists

### DIFF
--- a/management/global/sso/.terraform.lock.hcl
+++ b/management/global/sso/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.30.0, >= 4.40.0, ~> 5.80"
   hashes = [
     "h1:jEKbxB3GtA9ak4XXkaIXTMbnu/SDiiqNKDeF/78XrHc=",
+    "h1:vInFMDq9oMs53/i+7IU8hZgmTLhFfng8L8kbuALZxSI=",
     "zh:0313253c78f195973752c4d1f62bfdd345a9c99c1bc7a612a8c1f1e27d51e49e",
     "zh:108523f3e9ebc93f7d900c51681f6edbd3f3a56b8a62b0afc31d8214892f91e0",
     "zh:175b9bf2a00bea6ac1c73796ad77b0e00dcbbde166235017c49377d7763861d8",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.3"
   hashes = [
+    "h1:+AnORRgFbRO6qqcfaQyeX80W0eX3VmjadjnUFUJTiXo=",
     "h1:obXguGZUWtNAO09f1f9Cb7hsPCOGXuGdN8bn/ohKRBQ=",
     "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
     "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",

--- a/management/global/sso/permission_sets.tf
+++ b/management/global/sso/permission_sets.tf
@@ -83,7 +83,7 @@ module "permission_sets" {
       name                                = "DataScientist"
       description                         = "Provides access to AWS services that have to do with Data Science and MLOps."
       relay_state                         = local.default_relay_state
-      session_duration                    = "PT2H"
+      session_duration                    = "PT8H"
       tags                                = local.tags
       inline_policy                       = data.aws_iam_policy_document.data_scientist.json
       policy_attachments                  = []


### PR DESCRIPTION
## What?
* Increased AWS SSO session duration for the DataScientist permission set.

## Why?
* Requested by the data science team to avoid frequent re-authentication during long-running tasks.
* Improves productivity and experiment continuity for model training and analysis.
* Aligns session duration with the nature of data science workloads.

## References
* https://github.com/binbashar/le-tf-infra-aws/issues/793

