### PR TITLE
Add AWS Marketplace User Permissions to SSO Configuration

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -20,6 +20,7 @@ locals {
       groups = [
         "administrators",
         "devops",
+        "marketplaceseller",
       ]
     }
     "marcos.pagnucco" = {
@@ -283,6 +284,7 @@ locals {
       email      = "carlos.paez@binbash.com.ar"
       groups = [
         "devops",
+        "marketplaceseller",
       ]
     }
     "alex.delossantos" = {
@@ -363,7 +365,7 @@ locals {
     }
     marketplaceseller = {
       name        = "MarketplaceSeller"
-      description = "Provides access to the AWS MaketPlace Seller."
+      description = "Provides access to the AWS MarketPlace Seller."
     }
     datascientists = {
       name        = "DataScientists"

--- a/management/global/sso/permission_sets.tf
+++ b/management/global/sso/permission_sets.tf
@@ -74,6 +74,7 @@ module "permission_sets" {
       inline_policy    = data.aws_iam_policy_document.marketplaceseller.json
       policy_attachments = [
         "arn:aws:iam::aws:policy/AWSMarketplaceSellerFullAccess",
+        "arn:aws:iam::aws:policy/AWSMarketplaceFullAccess",
         "arn:aws:iam::aws:policy/WellArchitectedConsoleFullAccess",
         "arn:aws:iam::aws:policy/job-function/Billing",
       ]


### PR DESCRIPTION
## Description
This PR adds necessary permissions for AWS Marketplace access to the SSO permission sets, allowing designated users to access and manage Marketplace resources.

## Changes
- Updated SSO permissions to include Marketplace access
- Added users to the MarketplaceSeller group
- Enhanced user configuration in SSO to support Marketplace operations

## Testing
- Configuration validated against AWS IAM Identity Center requirements
- Permissions aligned with AWS best practices for Marketplace access

## Related Issues
Fixes access issues for Marketplace management