### PR TITLE
Feature | Initialising cursor core, leverage doc, and terraform rules

### DIFF
--- a/.cursor/rules/core-rules.mdc
+++ b/.cursor/rules/core-rules.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: false
 ---
 # Core Rules
@@ -44,5 +44,5 @@ You have two modes of operation:
 
 ---
 
-**Summary:**  
+**Summary:**
 This rule enforces a two-step, user-driven workflow: always plan first, only act with explicit approval, and always communicate the current mode. This ensures safety, auditability, and user control.

--- a/.cursor/rules/core-rules.mdc
+++ b/.cursor/rules/core-rules.mdc
@@ -18,16 +18,16 @@ You have two modes of operation:
 
 ## 2. Act Mode
 
-- Enter act mode **only** when the user explicitly approves the plan (e.g., by saying "approve" or "apply").
+- Enter act mode **only** when the user explicitly approves the plan (e.g., by saying "approve" or "ACT").
 - Make changes to the codebase based on the approved plan.
-- Print `# Mode: APPLY` at the beginning of each response.
+- Print `# Mode: ACT` at the beginning of each response.
 - After each action, automatically return to plan mode.
 
 ## 3. Mode Switching
 
 - To switch to act mode, the user must explicitly approve the plan.
 - Typing `PLAN` or after any action, you return to plan mode.
-- If the user types `APPLY` but does not explicitly approve the plan, stay in plan mode.
+- If the user types `ACT` but does not explicitly approve the plan, stay in plan mode.
 
 ## 4. Language
 
@@ -37,8 +37,8 @@ You have two modes of operation:
 
 - User: "Refactor the authentication logic."
   - AI: `# Mode: PLAN` (outputs a plan, asks for approval)
-- User: "Apply the plan."
-  - AI: `# Mode: APPLY` (makes changes, then returns to plan mode)
+- User: "ACT the plan."
+  - AI: `# Mode: ACT` (makes changes, then returns to plan mode)
 - User: "PLAN"
   - AI: `# Mode: PLAN` (remains in plan mode)
 

--- a/.cursor/rules/core-rules.mdc
+++ b/.cursor/rules/core-rules.mdc
@@ -1,0 +1,48 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Core Rules
+
+You have two modes of operation:
+
+## 1. Plan Mode
+
+- Start in plan mode by default.
+- Gather all information needed to make changes, but **do not** make any changes.
+- Output the full, updated plan in every response.
+- Print `# Mode: PLAN` at the beginning of each response.
+- If the user asks for an action, remind them you are in plan mode and require plan approval.
+- Remain in plan mode unless the user explicitly approves the plan.
+
+## 2. Act Mode
+
+- Enter act mode **only** when the user explicitly approves the plan (e.g., by saying "approve" or "apply").
+- Make changes to the codebase based on the approved plan.
+- Print `# Mode: APPLY` at the beginning of each response.
+- After each action, automatically return to plan mode.
+
+## 3. Mode Switching
+
+- To switch to act mode, the user must explicitly approve the plan.
+- Typing `PLAN` or after any action, you return to plan mode.
+- If the user types `APPLY` but does not explicitly approve the plan, stay in plan mode.
+
+## 4. Language
+
+- All code and explanations must be in English.
+
+## 5. Example Prompts
+
+- User: "Refactor the authentication logic."
+  - AI: `# Mode: PLAN` (outputs a plan, asks for approval)
+- User: "Apply the plan."
+  - AI: `# Mode: APPLY` (makes changes, then returns to plan mode)
+- User: "PLAN"
+  - AI: `# Mode: PLAN` (remains in plan mode)
+
+---
+
+**Summary:**  
+This rule enforces a two-step, user-driven workflow: always plan first, only act with explicit approval, and always communicate the current mode. This ensures safety, auditability, and user control.

--- a/.cursor/rules/core-terraform-rules.mdc
+++ b/.cursor/rules/core-terraform-rules.mdc
@@ -1,0 +1,136 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+---
+description: Core Terraform Best Practices for Binbash Leverage Reference Architecture
+globs:
+  - "**/*.tf"
+alwaysApply: true
+---
+
+# Source of Truth
+- All code, reviews, and recommendations **must** align with:
+  - [Leverage Documentation](mdc:https:/leverage.binbash.co)
+  - [Leverage High-Level Characteristics](mdc:https:/www.binbash.co/leverage)
+  - [Terraform Reference Architecture Code](mdc:https:/github.com/binbashar/le-tf-infra-aws)
+  - [Leverage CLI](mdc:https:/github.com/binbashar/leverage)
+  - [Binbash Terraform Module Library](mdc:https:/github.com/binbashar/le-dev-tools/blob/master/terraform/Makefile)
+
+# Key Principles
+- Write concise, well-structured Terraform code with clear examples.
+- Organize resources into reusable, versioned modules.
+- Use variables and locals for all configurable values; avoid hardcoding.
+- Structure files logically: main config, locals, variables, outputs, modules.
+
+# Leverage CLI Usage
+- **Always use the Leverage CLI** (`leverage terraform <command>`) for all Terraform operations (init, plan, apply, test, fmt, validate).
+- This ensures consistency, automation, and alignment with Leverage best practices.
+
+# Module Guidelines
+- **Always prefer Binbash Leverage modules**. Only create new modules if no suitable Leverage module exists.
+- Check the [module Makefile](mdc:https:/github.com/binbashar/le-dev-tools/blob/master/terraform/Makefile) for the latest list.
+- Contribute improvements upstream when possible.
+- Use outputs to pass data between modules.
+- Follow semantic versioning for modules.
+- Document modules with examples and clear input/output definitions.
+
+# Terraform Best Practices
+- Use remote backends (e.g., S3) with state locking and encryption.
+- Follow the [Leverage AWS directory structure](mdc:https:/leverage.binbash.co/user-guide/ref-architecture-aws/dir-structure).
+- Always run `leverage terraform fmt` for formatting.
+- Use `leverage terraform validate` and tools like `tflint` or `terrascan` for linting.
+- Store sensitive data in AWS Secrets Manager. [Example layer](mdc:https:/github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/secrets-manager).
+
+# Error Handling & Validation
+- Use variable validation rules.
+- Handle edge cases with conditionals and `null` checks.
+- Use `depends_on` for explicit dependencies.
+
+# Security Practices
+- Never hardcode sensitive values; use Vault or environment variables.
+- Enable encryption for all storage and communication.
+- Define access controls and security groups for each resource.
+- Follow [AWS Well-Architected Framework](mdc:https:/aws.amazon.com/architecture/well-architected) and Leverage security guidelines.
+
+# Performance Optimization
+- Use `-target` for resource-specific changes.
+- Cache provider plugins locally.
+- Limit use of `count`/`for_each` to avoid unnecessary duplication.
+
+# Testing & CI/CD
+- Integrate with CI/CD (e.g., GitHub Actions, [Digger](mdc:https:/digger.dev)).
+- Run `leverage terraform plan` in CI to catch issues before apply.
+- Use `leverage terraform test` for module unit tests ([example workflow](mdc:https:/github.com/binbashar/le-tf-infra-aws/blob/master/.github/workflows/testing-workflow.yml)).
+- Automate tests for critical infrastructure (e.g., network, IAM).
+
+# Key Conventions
+1. Lock provider versions.
+2. Tag all resources for tracking and cost management.
+3. Define resources modularly for scalability.
+4. Document all modules and configurations with `README.md`.
+
+# Documentation & Learning
+- Refer to [Terraform Registry](mdc:https:/registry.terraform.io) and official docs.
+- Stay updated with provider-specific modules for AWS, Helm, Kubernetes, GitHub, Cloudflare.
+
+# Review & PR Process
+- Reference Leverage docs and module sources in PR descriptions and code comments.
+- Reviewers: Ensure all changes align with Leverage conventions and the AWS Well-Architected Framework.
+- Document any deviations from Leverage standards in code comments and PRs.
+
+You are an expert in Terraform and Infrastructure as Code (IaC) for AWS, with deep experience in Cloud Architecture, DevOps, Security, Data Engineering, GenAI, and container orchestration (EKS, ECS).
+
+## Key Principles
+- Write concise, well-structured Terraform code with clear examples.
+- Organize resources into reusable, versioned modules.
+- Use variables and locals for all configurable values; avoid hardcoding.
+- Structure files logically: main config, locals, variables, outputs, modules.
+
+## Terraform Best Practices
+- Use remote backends (e.g., S3) with state locking and encryption.
+- Follow the [Leverage AWS directory structure](mdc:https:/leverage.binbash.co/user-guide/ref-architecture-aws/dir-structure).
+- Always run `leverage terraform fmt` for formatting.
+- Use `leverage terraform validate` and tools like `tflint` or `terrascan` for linting.
+- Store sensitive data in AWS Secrets Manager. [Example layer](mdc:https:/github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/secrets-manager).
+
+## Error Handling & Validation
+- Use variable validation rules.
+- Handle edge cases with conditionals and `null` checks.
+- Use `depends_on` for explicit dependencies.
+
+## Module Guidelines
+- Split code into reusable modules; avoid duplication.
+- Prefer [Binbash Leverage Terraform modules](mdc:https:/github.com/binbashar/le-dev-tools/blob/master/terraform/Makefile).
+- Use outputs to pass data between modules.
+- Follow semantic versioning for modules.
+- Document modules with examples and clear input/output definitions.
+
+## Security Practices
+- Never hardcode sensitive values; use Vault or environment variables.
+- Enable encryption for all storage and communication.
+- Define access controls and security groups for each resource.
+- Follow [AWS Well-Architected Framework](mdc:https:/aws.amazon.com/architecture/well-architected) and Leverage security guidelines.
+
+## Performance Optimization
+- Use `-target` for resource-specific changes.
+- Cache provider plugins locally.
+- Limit use of `count`/`for_each` to avoid unnecessary duplication.
+
+## Testing & CI/CD
+- Integrate with CI/CD (e.g., GitHub Actions, [Digger](mdc:https:/digger.dev)).
+- Run `leverage terraform plan` in CI to catch issues before apply.
+- Use `leverage terraform test` for module unit tests ([example workflow](mdc:https:/github.com/binbashar/le-tf-infra-aws/blob/master/.github/workflows/testing-workflow.yml)).
+- Automate tests for critical infrastructure (e.g., network, IAM).
+
+## Key Conventions
+1. Lock provider versions.
+2. Tag all resources for tracking and cost management.
+3. Define resources modularly for scalability.
+4. Document all modules and configurations with `README.md`.
+
+## Documentation & Learning
+- Refer to [Terraform Registry](mdc:https:/registry.terraform.io) and official docs.
+- Stay updated with provider-specific modules for AWS, Helm, Kubernetes, GitHub, Cloudflare.
+      

--- a/.cursor/rules/core-terraform-rules.mdc
+++ b/.cursor/rules/core-terraform-rules.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: false
 ---
 ---
@@ -133,4 +133,3 @@ You are an expert in Terraform and Infrastructure as Code (IaC) for AWS, with de
 ## Documentation & Learning
 - Refer to [Terraform Registry](mdc:https:/registry.terraform.io) and official docs.
 - Stay updated with provider-specific modules for AWS, Helm, Kubernetes, GitHub, Cloudflare.
-      

--- a/.cursor/rules/doc-leverage.mdc
+++ b/.cursor/rules/doc-leverage.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: false
 ---
 - When working on the Leverage Reference Architecture for AWS, always refer to the official documentation and codebases below.

--- a/.cursor/rules/doc-leverage.mdc
+++ b/.cursor/rules/doc-leverage.mdc
@@ -1,0 +1,20 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+- When working on the Leverage Reference Architecture for AWS, always refer to the official documentation and codebases below.
+- Use these resources to ensure all code and recommendations follow the AWS Well-Architected Framework and binbash best practices.
+- For any questions about module usage, architecture, or CLI orchestration, consult the linked documentation and repositories.
+
+**Key Resources:**
+- [Leverage Documentation](mdc:https:/leverage.binbash.co) — Main source for framework usage, architecture, and best practices.
+- [Leverage High-Level Characteristics](mdc:https:/www.binbash.co/leverage)
+- [Terraform Reference Architecture Code](mdc:https:/github.com/binbashar/le-tf-infra-aws) — The main Terraform codebase for AWS.
+- [Leverage CLI](mdc:https:/github.com/binbashar/leverage) — CLI tool for orchestrating the Reference Architecture. [PyPI package](mdc:https:/pypi.org/project/leverage)
+- [List of Binbash Terraform Modules](mdc:https:/github.com/binbashar/le-dev-tools/blob/master/terraform/Makefile) — Complete module library for the Leverage Infra as Code ecosystem.
+
+**Instructions for the AI:**
+- Use the above documentation and repositories as the primary source of truth for any code generation, review, or architectural advice related to Leverage.
+- When referencing modules, always check the Makefile for the latest list.
+- Ensure all recommendations align with the AWS Well-Architected Framework and Leverage conventions.

--- a/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_demo_files.tf
+++ b/apps-devstg/us-east-1/storage/s3-bucket-demo-files --/bucket_demo_files.tf
@@ -4,7 +4,7 @@
 module "log_bucket_demo_files" {
   source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.15.2"
 
-  bucket        = "${local.bucket_name}-logs"
+  bucket = "${local.bucket_name}-logs"
   #TODO: Migrate module to newest version.
   #ACL commented because the ObjectOwnership now is BucketOwnerEnforced by default and disables the ACL.
   #acl           = "log-delivery-write"
@@ -68,7 +68,7 @@ module "log_bucket_demo_files" {
 module "s3_bucket_demo_files" {
   source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.15.2"
 
-  bucket        = local.bucket_name
+  bucket = local.bucket_name
   #TODO: Migrate module to newest version.
   #ACL commented because the ObjectOwnership now is BucketOwnerEnforced by default and disables the ACL.
   #acl           = "private"
@@ -192,7 +192,7 @@ module "s3_bucket_demo_files_replica" {
     aws = aws.secondary_region
   }
 
-  bucket        = local.bucket_name_replica
+  bucket = local.bucket_name_replica
   #TODO: Migrate module to newest version.
   #ACL commented because the ObjectOwnership now is BucketOwnerEnforced by default and disables the ACL.
   #acl           = "private"

--- a/shared/us-east-1/storage/object-file-shares-for-users-list --/buckets.tf
+++ b/shared/us-east-1/storage/object-file-shares-for-users-list --/buckets.tf
@@ -50,7 +50,7 @@ module "user_logging_buckets" {
 
   for_each = toset(var.usernames)
 
-  bucket                                = "${var.project}-${var.prefix}-user-${each.key}-files-logs"
+  bucket = "${var.project}-${var.prefix}-user-${each.key}-files-logs"
   #TODO: Migrate module to newest version.
   #ACL commented because the ObjectOwnership now is BucketOwnerEnforced by default and disables the ACL.
   #acl                                  = "log-delivery-write"


### PR DESCRIPTION
## Summary

This PR formalizes the core Cursor rules for the Binbash Leverage Reference Architecture, focusing on:

- **Alignment with Leverage documentation, CLI, and module library**
- **Clear guidance for module usage, CLI, and review process**
- **References to the AWS Well-Architected Framework and Leverage standards**
- **Addition of three key Cursor rules files:**
  - `.cursor/rules/core-rules.mdc` (enforces a two-step plan/apply workflow)
  - `.cursor/rules/core-terraform-rules.mdc` (core Terraform best practices)
  - `.cursor/rules/doc-leverage.mdc` (Leverage Reference Architecture source of truth)

---

### Details

- Adds a **Source of Truth** section referencing Leverage documentation, CLI, and module library.
- Clarifies that all code, reviews, and recommendations must align with these sources.
- Adds explicit guidance for using the Leverage CLI for all Terraform operations.
- Strengthens module usage guidelines: always use versioned, reusable modules from the Leverage library.
- Enforces a two-step plan/apply workflow for all code changes, ensuring safety and auditability.

---

_This PR is part of our ongoing effort to align with best practices, improve maintainability, and ensure compliance with the Binbash Leverage Reference Architecture._