### PR TITLE
FIX | Migration from vault to secrets manager

### DIFF
--- a/apps-devstg/us-east-1/databases-aurora/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/databases-aurora/.terraform.lock.hcl
@@ -57,26 +57,6 @@ provider "registry.terraform.io/hashicorp/random" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/vault" {
-  version     = "3.8.1"
-  constraints = "~> 3.8.0"
-  hashes = [
-    "h1:MD71uC9ZD29Y88lRPC2WrNl+qoJeZn3dgMzngSn134Q=",
-    "zh:020f7a4d53d0fe6739ca98db88f6ca119d7a8d2821a818e6f0e3253063fa70e1",
-    "zh:3315ced4e21d83dc9027f10c7776f7189138a20a68cadf4e2b2572a7c3e14a0d",
-    "zh:3adcb3f09ba5c7408ad84dcb178fc2e888e6df06ed00b093f7ac1324d705a232",
-    "zh:529b24a424f885758a334ec934023062cf9a9a94bc9a924bdba978df6212d98d",
-    "zh:5c594b1daa4761621c2b7d791a4c002b2c9389bc6796aed152e84203535343af",
-    "zh:5f5e7bae5801e1ad6096fc794f8c40652782ad10e29ddb5999bd90ea3fcc8c46",
-    "zh:76369b943889ae554f9421d8034014e52a251691ae5cdeecca761bb097c76378",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:c1461f4131994adaa2d2b4aee60ce9e78cf3876acdd740cfb35dad2befd637fc",
-    "zh:c53c031146f6fd0da773b17a7cdb415a77f9e0bfd85fa6f99e1cab9409a39c4d",
-    "zh:e65654763270cacf493cc14dd0f9bab97d58538426eeda5fe634b48b427f3612",
-    "zh:f468f1cbf6a084eb8c320b35318f4cca5a0482ddbb4a5d8c891af36eb2f6ad60",
-  ]
-}
-
 provider "registry.terraform.io/winebarrel/mysql" {
   version     = "1.10.6"
   constraints = "1.10.6"

--- a/apps-devstg/us-east-1/databases-aurora/cluster_demoapps.tf
+++ b/apps-devstg/us-east-1/databases-aurora/cluster_demoapps.tf
@@ -10,7 +10,7 @@ module "demoapps" {
   # Initial database and credentials
   database_name          = "demoapps"
   master_username        = "admin"
-  master_password        = data.vault_generic_secret.databases_aurora.data["administrator_password"]
+  master_password        = data.aws_secretsmanager_secret_version.databases_aurora.secret_string
   create_random_password = false
 
   # VPC and Subnets

--- a/apps-devstg/us-east-1/databases-aurora/cluster_demoapps.tf
+++ b/apps-devstg/us-east-1/databases-aurora/cluster_demoapps.tf
@@ -9,8 +9,8 @@ module "demoapps" {
 
   # Initial database and credentials
   database_name          = "demoapps"
-  master_username        = "admin"
-  master_password        = data.aws_secretsmanager_secret_version.databases_aurora.secret_string
+  master_username        = jsondecode(data.aws_secretsmanager_secret_version.databases_aurora.secret_string).username
+  master_password        = jsondecode(data.aws_secretsmanager_secret_version.databases_aurora.secret_string).password
   create_random_password = false
 
   # VPC and Subnets

--- a/apps-devstg/us-east-1/databases-aurora/config.tf
+++ b/apps-devstg/us-east-1/databases-aurora/config.tf
@@ -6,17 +6,10 @@ provider "aws" {
   profile = var.profile
 }
 
-#=============================#
-# Vault Provider Settings     #
-#=============================#
-provider "vault" {
-  address = var.vault_address
-
-  /*
-  Vault token that will be used by Terraform to authenticate.
- admin token from https://portal.cloud.hashicorp.com/.
- */
-  token = var.vault_token
+provider "aws" {
+  alias   = "shared"
+  region  = var.region
+  profile = "${var.project}-shared-devops"
 }
 
 provider "mysql" {
@@ -33,7 +26,6 @@ terraform {
 
   required_providers {
     aws   = "~> 4.12"
-    vault = "~> 3.8.0"
     mysql = {
       source  = "winebarrel/mysql"
       version = "1.10.6"
@@ -88,6 +80,7 @@ data "terraform_remote_state" "shared_vpc" {
 #       to store admin credentials under a separate path and create separate,
 #       more restrictied credentials for demoapps.
 #
-data "vault_generic_secret" "databases_aurora" {
-  path = "secrets/${var.project}/${var.environment}/databases-aurora"
+data "aws_secretsmanager_secret_version" "databases_aurora" {
+  provider  = aws.shared
+  secret_id = "/devops/database-aurora/administrator"
 }

--- a/apps-devstg/us-east-1/databases-aurora/config.tf
+++ b/apps-devstg/us-east-1/databases-aurora/config.tf
@@ -82,5 +82,5 @@ data "terraform_remote_state" "shared_vpc" {
 #
 data "aws_secretsmanager_secret_version" "databases_aurora" {
   provider  = aws.shared
-  secret_id = "/devops/database-aurora/administrator"
+  secret_id = "/bb/apps-devstg/database-aurora/administrator"
 }

--- a/apps-devstg/us-east-1/databases-aurora/config.tf
+++ b/apps-devstg/us-east-1/databases-aurora/config.tf
@@ -82,5 +82,5 @@ data "terraform_remote_state" "shared_vpc" {
 #
 data "aws_secretsmanager_secret_version" "databases_aurora" {
   provider  = aws.shared
-  secret_id = "/bb/apps-devstg/database-aurora/administrator"
+  secret_id = "/devops/apps-devstg/database-aurora/administrator"
 }

--- a/apps-devstg/us-east-1/databases-mysql --/build.env
+++ b/apps-devstg/us-east-1/databases-mysql --/build.env
@@ -1,0 +1,8 @@
+# Project settings
+PROJECT=bb
+
+# General
+MFA_ENABLED=false
+
+# Terraform
+TERRAFORM_IMAGE_TAG=1.2.7-0.1.14

--- a/apps-devstg/us-east-1/databases-mysql --/config.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/config.tf
@@ -6,17 +6,10 @@ provider "aws" {
   profile = var.profile
 }
 
-#=============================#
-# Vault Provider Settings     #
-#=============================#
-provider "vault" {
-  address = var.vault_address
-
-  /*
-  Vault token that will be used by Terraform to authenticate.
- admin token from https://portal.cloud.hashicorp.com/.
- */
-  token = var.vault_token
+provider "aws" {
+  alias   = "shared"
+  region  = var.region
+  profile = "${var.project}-shared-devops"
 }
 
 #=============================#
@@ -27,7 +20,6 @@ terraform {
 
   required_providers {
     aws   = "~> 4.0"
-    vault = "~> 3.6.0"
   }
 
   backend "s3" {
@@ -60,6 +52,7 @@ data "terraform_remote_state" "vpc-shared" {
   }
 }
 
-data "vault_generic_secret" "database_secrets" {
-  path = "secrets/${var.project}/${var.environment}/databases-mysql"
+data "aws_secretsmanager_secret_version" "database_secrets" {
+  provider  = aws.shared
+  secret_id = "/devops/database-mysql/administrator"
 }

--- a/apps-devstg/us-east-1/databases-mysql --/config.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/config.tf
@@ -54,5 +54,5 @@ data "terraform_remote_state" "vpc-shared" {
 
 data "aws_secretsmanager_secret_version" "database_secrets" {
   provider  = aws.shared
-  secret_id = "/devops/database-mysql/administrator"
+  secret_id = "/bb/apps-devstg/database-mysql/administrator"
 }

--- a/apps-devstg/us-east-1/databases-mysql --/config.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/config.tf
@@ -54,5 +54,5 @@ data "terraform_remote_state" "vpc-shared" {
 
 data "aws_secretsmanager_secret_version" "database_secrets" {
   provider  = aws.shared
-  secret_id = "/bb/apps-devstg/database-mysql/administrator"
+  secret_id = "/devops/apps-devstg/database-mysql/administrator"
 }

--- a/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
@@ -30,7 +30,7 @@ module "bb_mysql_db" {
   # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html
   identifier        = "${var.project}-${var.environment}-binbash-mysql"
   engine            = "mysql"
-  engine_version    = "8.0.28"
+  engine_version    = "8.0.41"
   instance_class    = "db.m6g.large"
   allocated_storage = 100
   storage_encrypted = true
@@ -41,7 +41,7 @@ module "bb_mysql_db" {
   username = "administrator"
 
   # Secret from Hashicorp Vault
-  password = data.vault_generic_secret.database_secrets.data["administrator_password"]
+  password = data.aws_secretsmanager_secret_version.database_secrets.secret_string
   port     = "3306"
 
   # Backup and maintenance

--- a/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
+++ b/apps-devstg/us-east-1/databases-mysql --/db_mysql.tf
@@ -38,10 +38,8 @@ module "bb_mysql_db" {
 
   # Database credentials
   db_name  = "${var.project}_${replace(var.environment, "apps-", "")}_binbash_mysql"
-  username = "administrator"
-
-  # Secret from Hashicorp Vault
-  password = data.aws_secretsmanager_secret_version.database_secrets.secret_string
+  username = jsondecode(data.aws_secretsmanager_secret_version.database_secrets.secret_string).username
+  password = jsondecode(data.aws_secretsmanager_secret_version.database_secrets.secret_string).password
   port     = "3306"
 
   # Backup and maintenance

--- a/management/us-east-1/notifications/config.tf
+++ b/management/us-east-1/notifications/config.tf
@@ -20,7 +20,6 @@ terraform {
 
   required_providers {
     aws   = "~> 4.10"
-    vault = "~> 3.6.0"
   }
 
   backend "s3" {
@@ -54,4 +53,9 @@ data "aws_secretsmanager_secret_version" "monitoring" {
 data "aws_secretsmanager_secret_version" "monitoring_security" {
   provider  = aws.shared
   secret_id = "/devops/notifications/slack/security"
+}
+
+data "aws_secretsmanager_secret_version" "costs_phone_numbers_notifications" {
+  provider  = aws.shared
+  secret_id = "/devops/notifications/phone/notifications"
 }

--- a/management/us-east-1/notifications/config.tf
+++ b/management/us-east-1/notifications/config.tf
@@ -6,24 +6,17 @@ provider "aws" {
   profile = var.profile
 }
 
-#=============================#
-# Vault Provider Settings     #
-#=============================#
-provider "vault" {
-  address = var.vault_address
-
-  /*
-  Vault token that will be used by Terraform to authenticate.
- admin token from https://portal.cloud.hashicorp.com/.
- */
-  token = var.vault_token
+provider "aws" {
+  alias   = "shared"
+  region  = var.region
+  profile = "${var.project}-shared-devops"
 }
 
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.2.7"
+  required_version = "~> 1.6"
 
   required_providers {
     aws   = "~> 4.10"
@@ -53,6 +46,12 @@ data "terraform_remote_state" "keys" {
   }
 }
 
-data "vault_generic_secret" "notifications" {
-  path = "secrets/${var.project}/${var.environment}/notifications"
+data "aws_secretsmanager_secret_version" "monitoring" {
+  provider  = aws.shared
+  secret_id = "/devops/notifications/slack/monitoring"
+}
+
+data "aws_secretsmanager_secret_version" "monitoring_security" {
+  provider  = aws.shared
+  secret_id = "/devops/notifications/slack/security"
 }

--- a/management/us-east-1/notifications/costs_tools_monitoring.tf
+++ b/management/us-east-1/notifications/costs_tools_monitoring.tf
@@ -10,7 +10,7 @@ module "notify_costs" {
     for v in ["phone1", "phone2", "phone3", "phone4", "phone5"] :
     v => {
       protocol               = "sms"
-      endpoint               = data.vault_generic_secret.notifications.data[v]
+      endpoint               = jsondecode(data.aws_secretsmanager_secret_version.costs_phone_numbers_notifications.secret_string)[v]
       endpoint_auto_confirms = true
       raw_message_delivery   = false
     }
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "sns-notify-costs" {
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring_costs" {
-  plaintext = data.vault_generic_secret.notifications.data["slack_webhook_monitoring_costs"]
+  plaintext = data.aws_secretsmanager_secret_version.monitoring.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/management/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/management/us-east-1/notifications/slack_tools_monitoring.tf
@@ -1,7 +1,7 @@
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring" {
-  plaintext = data.vault_generic_secret.notifications.data["slack_webhook_monitoring"]
+  plaintext = data.aws_secretsmanager_secret_version.monitoring.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/management/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/management/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -1,7 +1,7 @@
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring_sec" {
-  plaintext = data.vault_generic_secret.notifications.data["slack_webhook_monitoring_sec"]
+  plaintext = data.aws_secretsmanager_secret_version.monitoring_security.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/network/us-east-1/notifications/config.tf
+++ b/network/us-east-1/notifications/config.tf
@@ -6,28 +6,20 @@ provider "aws" {
   profile = var.profile
 }
 
-#=============================#
-# Vault Provider Settings     #
-#=============================#
-provider "vault" {
-  address = var.vault_address
-
-  /*
-  Vault token that will be used by Terraform to authenticate.
- admin token from https://portal.cloud.hashicorp.com/.
- */
-  token = var.vault_token
+provider "aws" {
+  alias   = "shared"
+  region  = var.region
+  profile = "${var.project}-shared-devops"
 }
 
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.2.7"
+  required_version = "~> 1.6.0"
 
   required_providers {
     aws   = "~> 4.10"
-    vault = "~> 3.6.0"
   }
 
   backend "s3" {
@@ -53,6 +45,7 @@ data "terraform_remote_state" "keys" {
   }
 }
 
-data "vault_generic_secret" "slack_hook_url_monitoring" {
-  path = "secrets/${var.project}/${var.environment}/notifications"
+data "aws_secretsmanager_secret_version" "security_channel_slack_webhook" {
+  provider  = aws.shared
+  secret_id = "/devops/notifications/slack/security"
 }

--- a/network/us-east-1/notifications/config.tf
+++ b/network/us-east-1/notifications/config.tf
@@ -16,7 +16,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.6.0"
+  required_version = "~> 1.6"
 
   required_providers {
     aws   = "~> 4.10"

--- a/network/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/network/us-east-1/notifications/slack_tools_monitoring.tf
@@ -1,7 +1,7 @@
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring" {
-  plaintext = data.vault_generic_secret.slack_hook_url_monitoring.data["slack_webhook_monitoring_sec"]
+  plaintext = data.aws_secretsmanager_secret_version.security_channel_slack_webhook.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/network/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/network/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -1,7 +1,7 @@
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring_sec" {
-  plaintext = data.vault_generic_secret.slack_hook_url_monitoring.data["slack_webhook_monitoring_sec"]
+  plaintext = data.aws_secretsmanager_secret_version.security_channel_slack_webhook.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/shared/us-east-1/notifications/config.tf
+++ b/shared/us-east-1/notifications/config.tf
@@ -16,7 +16,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.6.0"
+  required_version = "~> 1.6"
 
   required_providers {
     aws   = "~> 4.10"

--- a/shared/us-east-1/notifications/config.tf
+++ b/shared/us-east-1/notifications/config.tf
@@ -6,28 +6,20 @@ provider "aws" {
   profile = var.profile
 }
 
-#=============================#
-# Vault Provider Settings     #
-#=============================#
-provider "vault" {
-  address = var.vault_address
-
-  /*
-  Vault token that will be used by Terraform to authenticate.
- admin token from https://portal.cloud.hashicorp.com/.
- */
-  token = var.vault_token
+provider "aws" {
+  alias   = "shared"
+  region  = var.region
+  profile = "${var.project}-shared-devops"
 }
 
 #=============================#
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.2.7"
+  required_version = "~> 1.6.0"
 
   required_providers {
     aws   = "~> 4.10"
-    vault = "~> 3.6.0"
   }
 
   backend "s3" {
@@ -53,6 +45,7 @@ data "terraform_remote_state" "keys" {
   }
 }
 
-data "vault_generic_secret" "slack_hook_url_monitoring" {
-  path = "secrets/${var.project}/${var.environment}/notifications"
+data "aws_secretsmanager_secret_version" "slack_hook_url_monitoring" {
+  provider  = aws.shared
+  secret_id = "/devops/notifications/slack/security"
 }

--- a/shared/us-east-1/notifications/slack_tools_monitoring.tf
+++ b/shared/us-east-1/notifications/slack_tools_monitoring.tf
@@ -1,7 +1,7 @@
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring" {
-  plaintext = data.vault_generic_secret.slack_hook_url_monitoring.data["slack_webhook_monitoring"]
+  plaintext = data.aws_secretsmanager_secret_version.slack_hook_url_monitoring.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/shared/us-east-1/notifications/slack_tools_monitoring_sec.tf
+++ b/shared/us-east-1/notifications/slack_tools_monitoring_sec.tf
@@ -1,7 +1,7 @@
 # Encrypt the URL, storing encryption here will show it in logs and in tfstate
 # https://www.terraform.io/docs/state/sensitive-data.html
 resource "aws_kms_ciphertext" "slack_url_monitoring_sec" {
-  plaintext = data.vault_generic_secret.slack_hook_url_monitoring.data["slack_webhook_monitoring_sec"]
+  plaintext = data.aws_secretsmanager_secret_version.slack_hook_url_monitoring.secret_string
   key_id    = data.terraform_remote_state.keys.outputs.aws_kms_key_arn
 }
 

--- a/shared/us-east-1/secrets-manager/secrets.tf
+++ b/shared/us-east-1/secrets-manager/secrets.tf
@@ -54,13 +54,13 @@ module "secrets" {
       secret_string           = "INITIAL_VALUE"
       kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
     },
-    "/bb/apps-devstg/database-aurora/administrator" = {
+    "/devops/apps-devstg/database-aurora/administrator" = {
       description             = "Credentials for Aurora administrator user"
       recovery_window_in_days = 7
       secret_string           = "INITIAL_VALUE"
       kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
     },
-    "/bb/apps-devstg/database-mysql/administrator" = {
+    "/devops/apps-devstg/database-mysql/administrator" = {
       description             = "Credentials for MySQL administrator user"
       recovery_window_in_days = 7
       secret_string           = "INITIAL_VALUE"

--- a/shared/us-east-1/secrets-manager/secrets.tf
+++ b/shared/us-east-1/secrets-manager/secrets.tf
@@ -42,6 +42,18 @@ module "secrets" {
       secret_string           = "INITIAL_VALUE"
       kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
     },
+    "/devops/database-aurora/administrator" = {
+      description             = "Credentials for Aurora administrator user"
+      recovery_window_in_days = 7
+      secret_string           = "INITIAL_VALUE"
+      kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
+    },
+    "/devops/database-mysql/administrator" = {
+      description             = "Credentials for MySQL administrator user"
+      recovery_window_in_days = 7
+      secret_string           = "INITIAL_VALUE"
+      kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
+    },
   }
 
   tags = local.tags

--- a/shared/us-east-1/secrets-manager/secrets.tf
+++ b/shared/us-east-1/secrets-manager/secrets.tf
@@ -24,6 +24,12 @@ module "secrets" {
     # This secret was created based on the centralized secrets approach and the naming conventions
     # defined here: https://binbash.atlassian.net/wiki/spaces/BDPS/pages/2425978910/Secrets+Management+Conventions
     #
+    "/devops/notifications/slack/monitoring" = {
+      description             = "Slack Webhook for the tools monitoring notifications"
+      recovery_window_in_days = 7
+      secret_string           = "INITIAL_VALUE"
+      kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
+    },
     "/devops/notifications/slack/security" = {
       description             = "Slack Webhook for the security notifications"
       recovery_window_in_days = 7

--- a/shared/us-east-1/secrets-manager/secrets.tf
+++ b/shared/us-east-1/secrets-manager/secrets.tf
@@ -36,6 +36,12 @@ module "secrets" {
       secret_string           = "INITIAL_VALUE"
       kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
     },
+    "/devops/notifications/phone/notifications" = {
+      description             = "Phone number for the security notifications"
+      recovery_window_in_days = 7
+      secret_string           = "INITIAL_VALUE"
+      kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
+    },
     "/devops/monitoring/alertmanager" = {
       description             = "Slack webhook for Alertmanager notifications"
       recovery_window_in_days = 7
@@ -48,13 +54,13 @@ module "secrets" {
       secret_string           = "INITIAL_VALUE"
       kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
     },
-    "/devops/database-aurora/administrator" = {
+    "/bb/apps-devstg/database-aurora/administrator" = {
       description             = "Credentials for Aurora administrator user"
       recovery_window_in_days = 7
       secret_string           = "INITIAL_VALUE"
       kms_key_id              = data.terraform_remote_state.keys.outputs.aws_kms_key_id
     },
-    "/devops/database-mysql/administrator" = {
+    "/bb/apps-devstg/database-mysql/administrator" = {
       description             = "Credentials for MySQL administrator user"
       recovery_window_in_days = 7
       secret_string           = "INITIAL_VALUE"


### PR DESCRIPTION
## What?
* Migration from vault to secrets manager.

## Why?
* Hashicorp vault is not being used anymore.


