### PR TITLE
Grant DevOps role permission over SupportPlans on all accounts

### DIFF
--- a/config/common.tfvars.example
+++ b/config/common.tfvars.example
@@ -40,6 +40,18 @@ accounts = {
     email = "binbash-data-science@binbash.com.ar",
     id    = 666666666666
   }
+  workshop-genai-1 = {
+    email = "aws+workshop-genai-1@binbash.com.ar",
+    id    = 777777777777
+  }
+  workshop-genai-2 = {
+    email = "aws+workshop-genai-2@binbash.com.ar",
+    id    = 888888888888
+  }
+  workshop-genai-3 = {
+    email = "aws+workshop-genai-3@binbash.com.ar",
+    id    = 999999999999
+  }
 }
 
 # External Accounts Integration

--- a/management/global/sso/.terraform.lock.hcl
+++ b/management/global/sso/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/hashicorp/aws" {
   constraints = ">= 4.30.0, >= 4.40.0, ~> 5.80"
   hashes = [
     "h1:Vl9vXjm/BJ0erNchBVK3XiJXxwRSBurarop4Vrm1m/E=",
+    "h1:s/WaduPnAJ6EZvKS1XRCMylfpEPNhDGXKbt/MlbVaxo=",
     "zh:13a07422f776dd97214dfa89d6a88340b99613cbb869013c756c1a68fd8cdd9d",
     "zh:1841d422278afa25d42a8d3ea9197ad08cf092769bd2aa89056d25d4c2629df8",
     "zh:269016c7ba09d76e42fbcf15de28f2de0595ff9a7304a0500011a4493d7a1551",
@@ -23,6 +24,7 @@ provider "registry.opentofu.org/hashicorp/null" {
   version = "3.2.4"
   hashes = [
     "h1:8ghdTVY6mALCeMuACnbrTmPaEzgamIYlgvunvqI2ZSY=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
     "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
     "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
     "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -20,7 +20,7 @@ module "account_assignments" {
       permission_set_name = "Administrator"
       principal_type      = local.principal_type_group
       principal_name      = local.groups["administrators"].name
-      account             = var.accounts.root.id
+      account             = var.accounts.management.id
     },
     #
     # NOTE The following are only left commented out as reference
@@ -115,7 +115,7 @@ module "account_assignments" {
       permission_set_name = "FinOps"
       principal_type      = local.principal_type_group
       principal_name      = local.groups["finops"].name
-      account             = var.accounts.root.id
+      account             = var.accounts.management.id
     },
 
     # -------------------------------------------------------------------------
@@ -183,7 +183,7 @@ module "account_assignments" {
       permission_set_name = "MarketplaceSeller"
       principal_type      = local.principal_type_group
       principal_name      = local.groups["marketplaceseller"].name
-      account             = var.accounts.root.id
+      account             = var.accounts.management.id
     },
     {
       permission_set_arn  = module.permission_sets.permission_sets["MarketplaceSeller"].arn

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -96,6 +96,7 @@ data "aws_iam_policy_document" "devops" {
       "states:*",
       "sts:*",
       "support:*",
+      "supportplans:*",
       "synthetics:*",
       "tag:*",
       "textract:*",


### PR DESCRIPTION
## What?
* Grant DevOps role permission over SupportPlans on all accounts
* Also fixed references to new data science accounts and to the renamed root account

## Why?
* Required for activating the AWS Support trial

## References
N/A

