### PR TITLE
Remove DevStg EKS VPC Peerings which are no longer necessary

### DIFF
--- a/apps-devstg/us-east-1/base-network/.terraform.lock.hcl
+++ b/apps-devstg/us-east-1/base-network/.terraform.lock.hcl
@@ -1,26 +1,20 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
+provider "registry.opentofu.org/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 3.28.0, >= 3.73.0, ~> 4.0, >= 4.9.0, ~> 4.10"
   hashes = [
-    "h1:DWVybabEz2gCyQkRM9zop1SKTG1tkH7+ruekC9KQM5w=",
-    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
-    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
-    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
-    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
-    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
-    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
-    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
-    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
-    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
-    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
-    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
-    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
-    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
-    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+    "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
+    "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
+    "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
+    "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",
+    "zh:91a11c67abe7e3329e86547babc9e56caee23e95beb0438165e8fc7e4f02ae44",
+    "zh:b1b59c5e5076877eb2d5b7cae8629ab3e030ec7972757d4e8a49a20b17131e06",
+    "zh:c3cf2f633400c43b0811c9facedbd56f700a637af7d72144a72422c0b635bb2e",
+    "zh:cfd13d1312127a9326c63126eb637a28dae3249dd67a5bbc52e336fb3e08b259",
+    "zh:dc49d6b634cdfbf6ae796b19b9c781599ab0bc941e2c229a452c76fbc9eee3cc",
+    "zh:e2d1bb7c0f66021039724640897bc7b12eb40eff37e0b94015abb6c41e612219",
+    "zh:ff1c838fb5a695191ff1682db31f7c68b2f7ebeb8d512bf1f0865949728a0b3d",
   ]
 }

--- a/apps-devstg/us-east-1/base-network/build.env
+++ b/apps-devstg/us-east-1/base-network/build.env
@@ -1,8 +1,0 @@
-# Project settings
-PROJECT=bb
-
-# General
-MFA_ENABLED=false
-
-# Terraform
-TERRAFORM_IMAGE_TAG=1.2.7-0.1.14

--- a/apps-devstg/us-east-1/base-network/config.tf
+++ b/apps-devstg/us-east-1/base-network/config.tf
@@ -10,7 +10,7 @@ provider "aws" {
 # Backend Config (partial)    #
 #=============================#
 terraform {
-  required_version = "~> 1.2.7"
+  required_version = "~> 1.2"
 
   required_providers {
     aws = "~> 4.10"

--- a/apps-devstg/us-east-1/base-network/locals.tf
+++ b/apps-devstg/us-east-1/base-network/locals.tf
@@ -181,12 +181,6 @@ locals {
       bucket  = "${var.project}-apps-devstg-terraform-backend"
       key     = "apps-devstg/k8s-eks-demoapps/network/terraform.tfstate"
     }
-    apps-devstg-k8s-eks = {
-      region  = var.region
-      profile = "${var.project}-apps-devstg-devops"
-      bucket  = "${var.project}-apps-devstg-terraform-backend"
-      key     = "apps-devstg/k8s-eks/network/terraform.tfstate"
-    }
   }
 
 }

--- a/apps-devstg/us-east-1/base-network/network.auto.tfvars
+++ b/apps-devstg/us-east-1/base-network/network.auto.tfvars
@@ -1,6 +1,6 @@
 # NAT GW
 vpc_enable_nat_gateway = false
-vpc_single_nat_gateway = false
+vpc_single_nat_gateway = true
 
 # Endpoints
 enable_ssm_endpoints = false

--- a/data-science/us-east-1/base-network/locals.tf
+++ b/data-science/us-east-1/base-network/locals.tf
@@ -86,12 +86,6 @@ locals {
       bucket  = "${var.project}-apps-devstg-terraform-backend"
       key     = "apps-devstg/network/terraform.tfstate"
     }
-    apps-devstg-k8s-eks = {
-      region  = var.region
-      profile = "${var.project}-apps-devstg-devops"
-      bucket  = "${var.project}-apps-devstg-terraform-backend"
-      key     = "apps-devstg/k8s-eks/network/terraform.tfstate"
-    }
   }
 
 }

--- a/shared/us-east-1/base-network/locals.tf
+++ b/shared/us-east-1/base-network/locals.tf
@@ -130,12 +130,6 @@ locals {
       bucket  = "${var.project}-apps-devstg-terraform-backend"
       key     = "apps-devstg/network/terraform.tfstate"
     }
-    apps-devstg-k8s-eks = {
-      region  = var.region
-      profile = "${var.project}-apps-devstg-devops"
-      bucket  = "${var.project}-apps-devstg-terraform-backend"
-      key     = "apps-devstg/k8s-eks/network/terraform.tfstate"
-    }
     apps-devstg-eks-demoapps = {
       region  = var.region
       profile = "${var.project}-apps-devstg-devops"


### PR DESCRIPTION
## What?
* Remove DevStg EKS VPC Peerings which are no longer necessary
* Also fixed the DevStg base-network layer

## Why?
* They did not allow us to remove the corresponding, unused EKS VPC (which no longer exists as code as it was removed a while ago)

## References
* Use `closes #363`, if this PR closes a GitHub issue `#123`

