### PR TITLE
Fix | Route53 www.binbash.com.ar to www.binbash.co redirect

### DIFF
--- a/shared/global/base-dns/binbash.com.ar/zone_private.aws.binbash.com.ar.tf
+++ b/shared/global/base-dns/binbash.com.ar/zone_private.aws.binbash.com.ar.tf
@@ -29,14 +29,10 @@ resource "aws_route53_zone" "aws_private_hosted_zone_1" {
     vpc_id     = data.terraform_remote_state.vpc-apps-devstg.outputs.vpc_id
     vpc_region = var.region
   }
-  vpc {
-    vpc_id     = data.terraform_remote_state.vpc-apps-devstg-eks.outputs.vpc_id
-    vpc_region = var.region
-  }
-  vpc {
+/*   vpc {
     vpc_id     = data.terraform_remote_state.vpc-apps-devstg-eks-demoapps.outputs.vpc_id
     vpc_region = var.region
-  }
+  } */
   vpc {
     vpc_id     = data.terraform_remote_state.vpc-apps-devstg-eks-dr.outputs.vpc_id
     vpc_region = var.region

--- a/shared/global/base-dns/binbash.com.ar/zone_private.aws.binbash.com.ar.tf
+++ b/shared/global/base-dns/binbash.com.ar/zone_private.aws.binbash.com.ar.tf
@@ -29,10 +29,10 @@ resource "aws_route53_zone" "aws_private_hosted_zone_1" {
     vpc_id     = data.terraform_remote_state.vpc-apps-devstg.outputs.vpc_id
     vpc_region = var.region
   }
-/*   vpc {
+  vpc {
     vpc_id     = data.terraform_remote_state.vpc-apps-devstg-eks-demoapps.outputs.vpc_id
     vpc_region = var.region
-  } */
+  }
   vpc {
     vpc_id     = data.terraform_remote_state.vpc-apps-devstg-eks-dr.outputs.vpc_id
     vpc_region = var.region

--- a/shared/global/base-dns/binbash.com.ar/zone_public.binbash.com.ar.tf
+++ b/shared/global/base-dns/binbash.com.ar/zone_public.binbash.com.ar.tf
@@ -52,61 +52,13 @@ resource "aws_route53_record" "aws_public_hosted_zone_1_mx_records" {
 module "domain-redirect-binbash_com_ar-to-binbash_co" {
   source                  = "github.com/binbashar/terraform-aws-domain-redirect?ref=v1.0.1"
   source_hosted_zone_name = "binbash.com.ar"
+  source_hosted_zone_sub_domains = [
+    "www.binbash.com.ar", 
+    ]
   target_url              = "binbash.co"
   providers = {
     aws.us-east-1 = aws.main_region
   }
-}
-
-#
-# CNAME records
-#
-resource "aws_route53_record" "pub_CNAME_www_binbash_com_ar" {
-  zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
-  name    = "www.binbash.com.ar"
-  records = ["www33.wixdns.net"]
-  type    = "CNAME"
-  ttl     = 300
-}
-
-resource "aws_route53_record" "pub_CNAME_sendgrid_1" {
-  zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
-  name    = "url5402.binbash.com.ar"
-  records = ["sendgrid.net"]
-  type    = "CNAME"
-  ttl     = 300
-}
-
-resource "aws_route53_record" "pub_CNAME_sendgrid_2" {
-  zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
-  name    = "26974810.binbash.com.ar"
-  records = ["sendgrid.net"]
-  type    = "CNAME"
-  ttl     = 300
-}
-
-resource "aws_route53_record" "pub_CNAME_sendgrid_3" {
-  zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
-  name    = "em8184.binbash.com.ar"
-  records = ["u26974810.wl061.sendgrid.net"]
-  type    = "CNAME"
-  ttl     = 300
-}
-
-resource "aws_route53_record" "pub_CNAME_sendgrid_4" {
-  zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
-  name    = "s1._domainkey.binbash.com.ar"
-  records = ["s1.domainkey.u26974810.wl061.sendgrid.net"]
-  type    = "CNAME"
-  ttl     = 300
-}
-
-resource "aws_route53_record" "pub_CNAME_sendgrid_5" {
-  zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
-  name    = "s2._domainkey.binbash.com.ar"
-  records = ["s2.domainkey.u26974810.wl061.sendgrid.net"]
-  type    = "CNAME"
-  ttl     = 300
 }
 
 #


### PR DESCRIPTION
## What?
* Fixing Route53 www.binbash.com.ar to www.binbash.co redirect

## Why?
* The link in several binbash Medium posts still points to www.binbash.com.ar/contact  eg:https://medium.com/binbash-inc/ai-and-the-maybe-end-of-infrastructure-as-code-what-comes-after-terraform-opentofu-9186d3e675c0) and the redirect was failing "olimpicamente" to an old wix redirect that wasn't working 👇🏼  

<img width="1079" height="819" alt="image" src="https://github.com/user-attachments/assets/0515cd15-e750-4d5e-be41-657f5ec3f290" />

<img width="716" height="1600" alt="image" src="https://github.com/user-attachments/assets/4ae6b2f0-3a5f-4de8-9e88-790353ad7258" />

