### PR TITLE
chore(deps): update helm release uptime-kuma to v2.21.2 (clean)

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/monitoring-other.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/monitoring-other.tf
@@ -42,7 +42,7 @@ resource "helm_release" "uptime_kuma" {
   namespace  = kubernetes_namespace.monitoring_other[0].id
   repository = "https://helm.irsigler.cloud"
   chart      = "uptime-kuma"
-  version    = "2.14.2"
+  version    = "2.21.2"
   values = [
     <<-EOT
       ingress:


### PR DESCRIPTION
## 🔄 Clean Uptime Kuma Version Update

This is a **clean replacement** for the corrupted Renovate PR #736.

### 📋 Summary
- **Helm Chart**: `uptime-kuma` 
- **Version Update**: `2.14.2` → `2.21.2`
- **File Changed**: `apps-devstg/us-east-1/k8s-eks-demoapps/k8s-components/monitoring-other.tf`

### ✅ Validation
- **OpenTofu validate**: ✅ Passed
- **Syntax check**: ✅ Correct
- **Scope**: ✅ Single file change only

### 🔍 Breaking Changes Analysis
Reviewed uptime-kuma changelog from v2.14.2 to v2.21.2:
- Minor version updates only
- No breaking configuration changes identified
- Helm chart values remain compatible

### 🧪 Test Plan
- [x] Terraform validation passed
- [x] Clean branch created from master
- [ ] Deploy to apps-devstg environment 
- [ ] Verify uptime-kuma functionality

### 🤖 Agent Information
Created by **dependency-update agent** following Renovate dependency update procedures.

**Closes**: #736 (corrupted by manual changes)

---
*This PR contains only the intended uptime-kuma version change, without the 400+ unrelated file modifications that corrupted the original Renovate PR.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the uptime monitoring service Helm chart to v2.21.2.
  * Incorporates upstream fixes, stability improvements, and security updates included in the newer chart.
  * No configuration changes; behavior should remain consistent.
  * Improves compatibility with newer Kubernetes versions and enhances reliability of monitoring.
  * Deployment may trigger brief pod restarts during rollout; no downtime expected for monitored services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->