### PR TITLE
Feat(sso) | Offboarding: Remove user entry from aws accounts

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -121,14 +121,6 @@ locals {
         "devops",
       ]
     }
-    "alejandro.creta" = {
-      first_name = "Alejandro"
-      last_name  = "Creta"
-      email      = "alejandro.creta@binbash.com.ar"
-      groups = [
-        "devops",
-      ]
-    }
     "marcos.acosta" = {
       first_name = "Marcos"
       last_name  = "Acosta"


### PR DESCRIPTION
## What?
* Remove alejandro.creta user 

## Why?
* Offboarding

## References
* https://trello.com/c/XbOvOh7a/385-lehr-255-devops-alejandro-creta-off-boarding



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a deprovisioned user account from the Single Sign-On directory.
  * Updated group membership listings and derived group mappings to exclude the removed account.
  * No impact to other users: existing access, permissions, and sign-in experience remain unchanged.
  * Part of routine account hygiene to keep user directories accurate and up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->