### PR TITLE
feat: add ServerSideApply=true to ArgoCD applications for External Secrets v0.19.2+ compatibility

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-workloads/demo_google_microservices.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-workloads/demo_google_microservices.tf
@@ -74,6 +74,7 @@ resource "kubernetes_manifest" "google_microservices_dev" {
         "syncOptions" = [
           "CreateNamespace=true",
           "Prune=true",
+          "ServerSideApply=true",
         ]
       }
     }

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-workloads/emojivoto.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/k8s-workloads/emojivoto.tf
@@ -49,6 +49,7 @@ resource "kubernetes_manifest" "demo-emojivoto" {
         "syncOptions" = [
           "CreateNamespace=true",
           "Prune=true",
+          "ServerSideApply=true",
         ]
       }
     }

--- a/apps-devstg/us-east-1/k8s-kind --/k8s-resources/chart-values/demoapps-emojivoto.yaml
+++ b/apps-devstg/us-east-1/k8s-kind --/k8s-resources/chart-values/demoapps-emojivoto.yaml
@@ -16,6 +16,7 @@ syncPolicy:
   syncOptions:
     - Validate=true
     - CreateNamespace=true
+    - ServerSideApply=true
 
 finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/apps-devstg/us-east-1/k8s-kind --/k8s-resources/chart-values/demoapps-gmd.yaml
+++ b/apps-devstg/us-east-1/k8s-kind --/k8s-resources/chart-values/demoapps-gmd.yaml
@@ -13,6 +13,7 @@ syncPolicy:
   syncOptions:
     - Validate=true
     - CreateNamespace=true
+    - ServerSideApply=true
 
 finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/apps-devstg/us-east-1/k8s-kind --/k8s-resources/chart-values/demoapps-sockshop.yaml
+++ b/apps-devstg/us-east-1/k8s-kind --/k8s-resources/chart-values/demoapps-sockshop.yaml
@@ -13,6 +13,7 @@ syncPolicy:
   syncOptions:
     - Validate=true
     - CreateNamespace=true
+    - ServerSideApply=true
 
 finalizers:
   - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
## Summary

This PR adds `ServerSideApply=true` to all ArgoCD applications to ensure compatibility with External Secrets v0.19.2+.

## Background

External Secrets v0.19.2 introduces a breaking change where CRDs are too large for client-side apply. According to the [release notes](https://github.com/external-secrets/external-secrets/releases/tag/v0.19.0):

> Please note that this a breaking change because our CRDs are now too big. Meaning a simple kubectl apply or Argo's default client side apply WILL NOT WORK! You have to add `--server-side` to kubectl apply and in argo add:
> 
> ```yaml
> spec:
>   syncPolicy:
>     syncOptions:
>     - ServerSideApply=true
> ```

## Changes

- **EKS ArgoCD Applications**: Added `ServerSideApply=true` to:
  - `emojivoto.tf` - demo-emojivoto application
  - `demo_google_microservices.tf` - google-microservices-dev application

- **Kind Demo Applications**: Added `ServerSideApply=true` to chart values for:
  - `demoapps-emojivoto.yaml`
  - `demoapps-gmd.yaml` 
  - `demoapps-sockshop.yaml`

## Testing

✅ Pre-commit hooks passed on all modified files
✅ No terraform formatting issues
✅ All syncOptions arrays properly formatted

## Related Issues

This PR addresses the compatibility requirements for PR #897 (External Secrets upgrade from v0.17.0 to v0.19.2).

## Deployment Notes

This change is required **before** merging the External Secrets upgrade in PR #897 to prevent ArgoCD sync failures due to large CRD sizes.