### PR TITLE
Chore | Add Luis Gallardo to Administrators group

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -90,6 +90,7 @@ locals {
       email      = "luis.gallardo@binbash.com.ar"
       groups = [
         "devops",
+        "administrators",
       ]
     }
     "ezequiel.godoy" = {


### PR DESCRIPTION
## What?
* Add user to Administrators group


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted SSO configuration to add the Administrators group to user luis.gallardo, expanding access from DevOps-only to include administrative permissions. No other users or groups were changed. This update aligns access with current responsibilities and ensures proper privileges for management tasks. No service behavior or user experience changes for others occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->