### PR TITLE
fix: convert AWS account IDs to strings

### DIFF
--- a/config/common.tfvars.example
+++ b/config/common.tfvars.example
@@ -14,43 +14,43 @@ region_secondary      = "us-east-2"
 accounts = {
   management = {
     email = "aws+root@binbash.com.ar",
-    id    = 111111111111
+    id    = "111111111111"
   },
   security = {
     email = "binbash-security@binbash.com.ar",
-    id    = 222222222222
+    id    = "222222222222"
   },
   shared = {
     email = "binbash-shared@binbash.com.ar",
-    id    = 333333333333
+    id    = "333333333333"
   },
   network = {
     email = "binbash-network@binbash.com.ar",
-    id    = 444444444444
+    id    = "444444444444"
   },
   apps-devstg = {
     email = "binbash-apps-devstg@binbash.com.ar",
-    id    = 555555555555
+    id    = "555555555555"
   },
   apps-prd = {
     email = "binbash-apps-prd@binbash.com.ar",
-    id    = 666666666666
+    id    = "666666666666"
   }
   data-science = {
     email = "binbash-data-science@binbash.com.ar",
-    id    = 666666666666
+    id    = "666666666666"
   }
   workshop-genai-1 = {
     email = "aws+workshop-genai-1@binbash.com.ar",
-    id    = 777777777777
+    id    = "777777777777"
   }
   workshop-genai-2 = {
     email = "aws+workshop-genai-2@binbash.com.ar",
-    id    = 888888888888
+    id    = "888888888888"
   }
   workshop-genai-3 = {
     email = "aws+workshop-genai-3@binbash.com.ar",
-    id    = 999999999999
+    id    = "999999999999"
   }
 }
 


### PR DESCRIPTION
## Summary
• Convert AWS account IDs from numeric to string format in common.tfvars.example
• Ensures proper handling as strings and prevents potential issues with large numbers

## Test plan
- [x] Validate configuration format
- [ ] Test with existing layers that reference account IDs

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated example configuration to wrap all account IDs in quotes across environments (management, security, shared, network, apps-devstg, apps-prd, data-science, and workshop genai 1–3).
  - Improves readability, consistency, and copy-paste reliability during setup by avoiding numeric misinterpretation.
  - No changes to behavior or other fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->