### PR TITLE
feat(sso): add Hecber Cordova to SSO users

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -42,6 +42,14 @@ locals {
         "devops",
       ]
     }
+    "hecber.cordova" = {
+      first_name = "Hecber"
+      last_name  = "Cordova"
+      email      = "hecber.cordova@binbash.com.ar"
+      groups = [
+        "devops",
+      ]
+    }
     "francisco.rivera" = {
       first_name = "Francisco"
       last_name  = "Rivera"


### PR DESCRIPTION
## What?
Add Hecber Cordova as a new SSO user with devops group membership.

## Why?
* New team member onboarding

## Changes
- Added "hecber.cordova" user entry in `management/global/sso/locals.tf`
- Assigned to "devops" group
- Follows existing user pattern from PR #881

## Test plan
- [ ] Terraform format and validate
- [ ] Deploy to management account 
- [ ] Verify SSO user creation in AWS console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new user account (Hecber Cordova) to the single sign-on directory with DevOps group membership.
  * No changes to existing user accounts, permissions, or access policies.
  * Authentication flows and application behavior remain unchanged.
  * No downtime or service interruptions expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->