### PR TITLE
fix: replace tflocal with native commands for OpenTofu compatibility

### DIFF
--- a/.github/workflows/testing-workflow.yml
+++ b/.github/workflows/testing-workflow.yml
@@ -76,10 +76,6 @@ jobs:
         uses: opentofu/setup-opentofu@v1
         with:
           tofu_version: ${{ inputs.iac_version }}
-      - name: Install tflocal
-        if: steps.check-tests.outputs.hasTests == 'true'
-        run: |
-          pip install terraform-local
       - uses: LocalStack/setup-localstack@v0.2.4
         if: steps.check-tests.outputs.hasTests == 'true'
         with:
@@ -110,7 +106,7 @@ jobs:
       - name: Terraform Init
         if: steps.check-tests.outputs.hasTests == 'true'
         working-directory: ${{ inputs.working_directory }}
-        run: tflocal init -upgrade
+        run: $TF_CMD init -upgrade
       - name: Run Test
         if: steps.check-tests.outputs.hasTests == 'true'
         working-directory: ${{ inputs.working_directory }}
@@ -121,4 +117,4 @@ jobs:
           AWS_ENDPOINT_URL: http://localhost:4566
         run: |
           cp ../../../config/common.tfvars.example ../../../config/common.tfvars
-          tflocal test -var-file=../../../config/common.tfvars -var-file=../../config/account.tfvars -var-file=../../config/backend.tfvars
+          $TF_CMD test -var-file=../../../config/common.tfvars -var-file=../../config/account.tfvars -var-file=../../config/backend.tfvars


### PR DESCRIPTION
## Summary
- Resolves #846 - Fix KMS layer tests failing after OpenTofu migration
- Replace terraform-local (tflocal) with native terraform/tofu commands using $TF_CMD variable
- Enable OpenTofu compatibility in security-keys testing workflow

## Technical Details
**Problem**: The security-keys.yml workflow matrix includes both terraform and tofu platforms, but uses hardcoded `tflocal` commands that only work with terraform binary.

**Root Cause**: terraform-local doesn't recognize or support the `tofu` binary, causing OpenTofu matrix jobs to fail.

**Solution**: 
- Remove `pip install terraform-local` installation step
- Replace `tflocal init -upgrade` → `$TF_CMD init -upgrade`
- Replace `tflocal test -var-file=...` → `$TF_CMD test -var-file=...`
- Maintain existing LocalStack environment variables for AWS service emulation

## Changes Made
- **File**: `.github/workflows/testing-workflow.yml`
- **Impact**: Both terraform and tofu matrix jobs will now execute properly
- **Backward Compatibility**: Fully compatible with existing terraform workflows
- **Risk**: Very low - minimal changes, same environment variables, same test logic

## Testing Strategy
- ✅ **Local Validation**: Command substitution tested with both terraform and tofu binaries
- ✅ **Pre-commit Hooks**: All checks passed
- 🔄 **CI Validation**: Will test both terraform (1.6) and tofu (1.6) matrix jobs
- 🔄 **Layer Coverage**: All security-keys layers across accounts will be tested

## Test Scope
This fix enables testing across all security-keys layers:
- `apps-devstg/us-east-1/security-keys` 
- `apps-prd/us-east-1/security-keys`
- `security/us-east-1/security-keys`
- `shared/us-east-1/security-keys`
- `network/us-east-1/security-keys`
- `management/us-east-1/security-keys`
- `data-science/us-east-1/security-keys`
- Plus us-east-2 variants

## Expected Outcome
- ✅ OpenTofu compatibility restored in KMS layer testing
- ✅ No breaking changes to existing terraform workflows
- ✅ CI pipeline stabilized for future OpenTofu migration work
- ✅ Development velocity maintained with reliable testing

Closes #846