### PR TITLE
Extra | Add Dockerfile for newer Terraform versions

### DIFF
--- a/NewerTerraformDockerfile
+++ b/NewerTerraformDockerfile
@@ -1,3 +1,14 @@
+## Run as:
+## TERRAFORM_VERSION=1.6.6 && \
+## USERNAME=leverage && \
+## USERID=$(id -u) && \
+## GROUPID=$(id -g) && \
+## docker build -t repo/image:${TERRAFORM_VERSION}-${USERID}-${GROUPID} \
+##        --build-arg TERRAFORM_VERSION=$TERRAFORM_VERSION \
+##        --build-arg USERNAME=$USERNAME \
+##        --build-arg USERID=$USERID \
+##        --build-arg GROUPID=$GROUPID .
+
 ARG IMAGE_TAG=1.9.1-tofu-0.3.0
 FROM binbash/leverage-toolbox:$IMAGE_TAG
 


### PR DESCRIPTION
## What?
* We are no longer supporting Terraform after v1.6.0 if a customer would like to use newer versions they would need to build their own docker image. This is a Dockerfile to do that


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a new Terraform Docker image variant with configurable Terraform version and platform via build arguments.
  - Defaults updated and the image runs as a dedicated non-root user for improved security and CI compatibility.
  - Simplifies use across diverse environments and pipelines.

- Chores
  - Added the new Docker image to the repository and aligned it with the standardized base image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->