### PR TITLE
Update Infracost workflow to ignore draft PRs

### DIFF
--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -1,7 +1,14 @@
 name: Costs | infracost
 # The GitHub Actions docs (https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on)
 # describe other options for 'on', 'pull_request' is a good default.
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
 env:
   # If you use private modules you'll need this env variable to use
   # the same ssh-agent socket value across all jobs & steps.


### PR DESCRIPTION
## What?
* Update Infracost workflow to ignore draft PRs.

## Why?
* It becomes very noisy and wastes Github Runners free minutes.

## References
N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run only on specific pull request events (opened, synchronize, reopened, ready for review). This reduces redundant runs, speeds up feedback, and provides clearer status checks during reviews. No changes to application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->