### PR TITLE
chore: grant data_scientist role access to cloudshell

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -237,6 +237,7 @@ data "aws_iam_policy_document" "data_scientist" {
       "bedrock-agentcore:*",
       "ce:*",
       "cloudformation:*",
+      "cloudshell:*",
       "cloudwatch:*",
       "cognito-identity:*",
       "cognito-idp:*",


### PR DESCRIPTION
## What?
* Gives data scientists access to [cloudshell](https://docs.aws.amazon.com/cloudshell/latest/userguide/welcome.html)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Data Scientist users can now access AWS CloudShell from the console to run CLI commands without local setup. This enables quicker troubleshooting, ad‑hoc scripting, and environment management in a secure, browser-based shell.
  - Existing resource scopes and conditions remain unchanged; only permissions were expanded to include CloudShell actions, minimizing risk while improving productivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->