### PR TITLE
Feat | SSO: add "administrators" group to Alex De Los Santos

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -218,6 +218,7 @@ locals {
       email      = "alex.delossantos@binbash.com.ar"
       groups = [
         "datascientists",
+        "administrators"
       ]
     }
     "favio.tolosa" = {


### PR DESCRIPTION
## What?
* Update role for Alex user



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated SSO group assignments: one user now also belongs to the Administrators group, enabling access to admin-only features.
  - No changes to other users’ permissions or sign-in experience.
  - No UI modifications or new functionality introduced.
  - No downtime or service impact expected.
  - Improves accuracy of access management and aligns user permissions with required administrative capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->