### PR TITLE
Implement CloudWatch Synthetics Canaries for internal service uptime …

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -93,6 +93,7 @@ data "aws_iam_policy_document" "devops" {
       "servicequotas:*",
       "ses:*",
       "shield:*",
+      "synthetics:*",
       "sns:*",
       "sqlworkbench:*",
       "sqs:*",

--- a/shared/us-east-1/tools-uptime-monitoring/.terraform.lock.hcl
+++ b/shared/us-east-1/tools-uptime-monitoring/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:sQrOJIawX8VeHjXi9yOj8yTG6MWmDueNiOEwtug+plw=",
+    "zh:4f8fe5f92125fc7be91379dbde004aaf676fbb523082af167d0a57ac723836bc",
+    "zh:4fba9a08c254fd3c17464c1e13398e4927b1d3e22bfdc3bb66c4e5bd9573ada4",
+    "zh:65e9945c1e89333b01ef25c15518e125817268f9ecddc3f9d5337dc120d342ee",
+    "zh:6cc92ec02475310612a2fc663ab22366c17005203be55287e9af316ac0397ef4",
+    "zh:7e9efa56a27ea28c7a19465b4223f43653988639123160b09507cbc7a9ad5458",
+    "zh:9c77863b5ff47196cec4e82ce9b943c8a0de5840f7b1f82c7e96d92d8be7c7c1",
+    "zh:b6498ff9e2e717c94e5d2c494a2071acc123e8195bfdd9f7965a0676fa866b06",
+    "zh:c5941326ffe88ff77d15fb1212f746ea57eebf7556bc2707c3a054ad0e5a6ab0",
+    "zh:ec1c14feeeb3b78be2ab37533c6ef2e0d6417c6faa82ddd62c446db77f618926",
+    "zh:ed4643c4f8d9f7d060c01463317d68315b6af7197beaba331451ca3991a9c990",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = ">= 4.9.0, ~> 4.10"
+  hashes = [
+    "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
+    "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
+    "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
+    "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",
+    "zh:91a11c67abe7e3329e86547babc9e56caee23e95beb0438165e8fc7e4f02ae44",
+    "zh:b1b59c5e5076877eb2d5b7cae8629ab3e030ec7972757d4e8a49a20b17131e06",
+    "zh:c3cf2f633400c43b0811c9facedbd56f700a637af7d72144a72422c0b635bb2e",
+    "zh:cfd13d1312127a9326c63126eb637a28dae3249dd67a5bbc52e336fb3e08b259",
+    "zh:dc49d6b634cdfbf6ae796b19b9c781599ab0bc941e2c229a452c76fbc9eee3cc",
+    "zh:e2d1bb7c0f66021039724640897bc7b12eb40eff37e0b94015abb6c41e612219",
+    "zh:ff1c838fb5a695191ff1682db31f7c68b2f7ebeb8d512bf1f0865949728a0b3d",
+  ]
+}

--- a/shared/us-east-1/tools-uptime-monitoring/README.md
+++ b/shared/us-east-1/tools-uptime-monitoring/README.md
@@ -1,0 +1,115 @@
+# AWS Cloudwatch Synthetics
+
+## Overview
+
+This module creates `canaries` to check endpoints.
+
+`canaries` is how AWS Cloudwatch Synthetics calls the Lambdas that will check endpoints.
+
+More documentation [here](https://docs.aws.amazon.com/AmazonSynthetics/latest/APIReference/Welcome.html).
+
+## Dependencies
+
+This module uses a fork of [this module](https://github.com/clouddrove/terraform-aws-cloudwatch-synthetics) hosted in `binbashar` space to add a few modifications.
+
+## Notifications
+
+Same as with the original module, `alarm_email` can be set when calling the module to set the email that will suscribe to the SNS topic.
+
+As per the `binbash Leverage` needs, this email can be set to null, so later the [notifications](https://github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/notifications) module can be used to suscribe to this topic. For this an output is added with the topic name.
+
+### Setting `notifications` layer
+
+#### To use the topic created in the `synthetics` layer
+
+In the `notifications` layer add the remote state for the `synthetics` layer.
+
+``` hcl
+data "terraform_remote_state" "aws-cloudwatch-synthetics" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/aws-cloudwatch-synthetics/terraform.tfstate"
+  }
+}
+```
+
+Extract the topic name:
+
+``` hcl
+  arn_array = split(":", data.terraform_remote_state.aws-cloudwatch-synthetics.outputs.topic_target_canary)
+  topic_name = local.arn_array[length(local.arn_array) - 1]
+```
+
+Set the topic to not be created:
+
+``` hcl
+  create_sns_topic = false
+```
+
+And set the topic name from the `synthetics` layer:
+
+``` hcl
+  sns_topic_name       = local.topic_name
+```
+
+#### To use the topic created in the `notifications` layer
+
+In the `synthetics` layer add the remote state for the `notifications` layer.
+
+``` hcl
+data "terraform_remote_state" "notifications" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/notifications/terraform.tfstate"
+  }
+}
+```
+
+In `canaries.tf` file add (or set to `false`) this line:
+
+``` hcl
+  create_topic       = false
+```
+
+And set the topic name from the remote state:
+
+``` hcl
+  existent_topic_arn = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
+```
+
+
+
+## IAM permission
+
+Note if you are using the default `binbash Leverage` configuration, and you are using *DevOps* profile with SSO, maybe you'll have to add this permission to your *DevOps* policy:
+
+``` hcl
+synthetics:*
+```
+
+*(or something more specific if you want to narrow the permission set)*
+
+## Known issues
+
+If a canary in a private subnet is created, and then it is moved out from that subnet, e.g. you created the private canary, then comment out these lines:
+
+``` hcl
+  #subnet_ids                = data.terraform_remote_state.local-vpcs.outputs.private_subnets
+  #security_group_ids        = [aws_security_group.target-canary-sg.id]
+```
+
+...and re apply.
+
+In this case there is a chance the ENIs the canary took in first place in the private subnet remain attached even if they are not being used.
+
+E.g., if you want to destroy this infra the ENIs can not be detached even if the Lambda does not exist anymore.
+
+In this case, wait for 24hs, AWS should recognize the unused ENIs and will detach them automagically.

--- a/shared/us-east-1/tools-uptime-monitoring/canaries.tf
+++ b/shared/us-east-1/tools-uptime-monitoring/canaries.tf
@@ -1,0 +1,57 @@
+module "target-canary" {
+  source = "github.com/binbashar/terraform-aws-cloudwatch-synthetics.git?ref=1.6.0"
+
+  name_prefix = "${var.project}-${var.environment}"
+  environment = var.environment
+
+  # How often should the uptime check run?
+  schedule_expression = "rate(10 minutes)"
+  # The bucket where artifacts (e.g. screenshots) will be stored
+  s3_artifact_bucket = module.target_canary_s3_bucket.s3_bucket_id
+  alarm_email        = null
+  # A list of endpoints to monitor for uptime
+  endpoints = {
+    "pritunl-g"       = { url = "https://vpn.aws.binbash.com.ar/login" }
+  }
+  # The following are used for tagging
+  managedby       = "managedby@binbash.co"
+  repository      = "https://github.com/binbashar/terraform-aws-cloudwatch-synthetics"
+  runtime_version = "syn-nodejs-puppeteer-9.1"
+
+  # Whether to create a SNS topic or to reuse an existing one
+  create_topic       = false
+  existent_topic_arn = data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring
+
+  # If the uptime check requires private connectivity, then a list of subnets must be provided
+  subnet_ids = [data.terraform_remote_state.local-vpcs.outputs.private_subnets[0]]
+  # A security group for controlling the traffic of the Lambda function that runs the checks
+  security_group_ids = [aws_security_group.target-canary-sg.id]
+
+  tags = local.tags
+
+}
+
+#
+# Security group for granting access from the canary to the targets
+#
+resource "aws_security_group" "target-canary-sg" {
+  name        = "${var.project}-${var.environment}-target-canary-sg"
+  description = "Allow TLS outbound traffic"
+  vpc_id      = data.terraform_remote_state.local-vpcs.outputs.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["172.18.0.0/20"]
+  }
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow internet egress for S3 uploads."
+  }
+
+  tags = local.tags
+}

--- a/shared/us-east-1/tools-uptime-monitoring/common-variables.tf
+++ b/shared/us-east-1/tools-uptime-monitoring/common-variables.tf
@@ -1,0 +1,1 @@
+../../../config/common-variables.tf

--- a/shared/us-east-1/tools-uptime-monitoring/config.tf
+++ b/shared/us-east-1/tools-uptime-monitoring/config.tf
@@ -1,0 +1,48 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+#=============================#
+# Backend Config (partial)    #
+#=============================#
+terraform {
+  required_version = "~> 1.9"
+
+  required_providers {
+    aws = "~> 4.10"
+  }
+
+  backend "s3" {
+    key = "shared/uptime-monitoring/terraform.tfstate"
+  }
+}
+
+#=============================#
+# Data sources                #
+#=============================#
+data "terraform_remote_state" "local-vpcs" {
+
+  backend = "s3"
+
+  config = {
+    region  = lookup(local.local-vpc.local-base, "region")
+    profile = lookup(local.local-vpc.local-base, "profile")
+    bucket  = lookup(local.local-vpc.local-base, "bucket")
+    key     = lookup(local.local-vpc.local-base, "key")
+  }
+}
+
+data "terraform_remote_state" "notifications" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = var.profile
+    bucket  = var.bucket
+    key     = "${var.environment}/notifications/terraform.tfstate"
+  }
+}

--- a/shared/us-east-1/tools-uptime-monitoring/locals.tf
+++ b/shared/us-east-1/tools-uptime-monitoring/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  tags = {
+    Terraform   = "true"
+    Environment = var.environment
+  }
+  # network
+  local-vpc = {
+    local-base = {
+      region  = var.region
+      profile = "${var.project}-shared-devops"
+      bucket  = "${var.project}-shared-terraform-backend"
+      key     = "shared/network/terraform.tfstate"
+    }
+  }
+
+}

--- a/shared/us-east-1/tools-uptime-monitoring/outputs.tf
+++ b/shared/us-east-1/tools-uptime-monitoring/outputs.tf
@@ -1,0 +1,3 @@
+output "topic_target_canary" {
+  value = module.target-canary.topic_arn
+}

--- a/shared/us-east-1/tools-uptime-monitoring/s3.tf
+++ b/shared/us-east-1/tools-uptime-monitoring/s3.tf
@@ -1,0 +1,27 @@
+module "target_canary_s3_bucket" {
+  source = "github.com/binbashar/terraform-aws-s3-bucket.git?ref=v3.14.0"
+
+  bucket = "${var.project}-${var.environment}-target-canary"
+
+  force_destroy = true
+
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerEnforced"
+
+  versioning = {
+    enabled = true
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "screenshots"
+      enabled = true
+
+      expiration = {
+        days = 10
+      }
+    }
+  ]
+
+  tags = local.tags
+}


### PR DESCRIPTION
…monitoring

## What?
* Implement CloudWatch Synthetics Canaries for internal service uptime monitoring

## Why?
* This is useful for internal service uptime monitoring

## References
* `closes #561`

