### PR TITLE
chore: grant data_scientist role access to codebuild

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -240,6 +240,7 @@ data "aws_iam_policy_document" "data_scientist" {
       "cloudformation:*",
       "cloudshell:*",
       "cloudwatch:*",
+      "codebuild:*",
       "cognito-identity:*",
       "cognito-idp:*",
       "config:*",


### PR DESCRIPTION
## What?
* Grant data_scientist role access to AWS CodeBuild

## Why?
* Required for AgentCore launch command to build ARM64 containers
* Enables deployment of AI agents using Bedrock AgentCore toolkit