### PR TITLE
chore: grant data_scientist role access to agentcore tools and observability services

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -230,6 +230,7 @@ data "aws_iam_policy_document" "data_scientist" {
       "airflow:*",
       "athena:*",
       "apigateway:*",
+      "application-signals:*",
       "aoss:*",
       "autoscaling:*",
       "aws-marketplace:*",
@@ -239,8 +240,10 @@ data "aws_iam_policy_document" "data_scientist" {
       "ce:*",
       "cloudformation:*",
       "cloudshell:*",
+      "cloudtrail:*",
       "cloudwatch:*",
       "cognito-identity:*",
+      "codebuild:*",
       "cognito-idp:*",
       "config:*",
       "ds:*",
@@ -288,6 +291,7 @@ data "aws_iam_policy_document" "data_scientist" {
       "support:*",
       "tag:*",
       "transcribe:*",
+      "xray:*"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
## What?
* Grant data_scientist role access to AWS Application Signals, CloudTrail, CodeBuild, and X-Ray

## Why?
* Required for AWS Bedrock AgentCore deployment and observability
* Enables AgentCore launch command to build ARM64 containers
* Provides comprehensive monitoring and tracing for AI agent execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Data Scientist role capabilities by enabling access to Application Signals, AWS CloudTrail, AWS CodeBuild, and AWS X-Ray. This supports improved monitoring, tracing, and build workflows for data science projects. No changes to existing resource scopes or conditions; day-to-day access patterns remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->