### PR TITLE
Adjust Terraform references to also mention OpenTofu and similar updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 </a>
 <br clear="left"/>
 
-# Leverage Reference Architecture: Terraform AWS Infrastructure
+# Leverage Reference Architecture: OpenTofu/Terraform AWS Infrastructure
 
 ## Overview
-This repository contains all Terraform configuration files used to create Binbash Leverage Reference AWS Cloud
+This repository contains all OpenTofu/Terraform configuration files used to create Binbash Leverage Reference AWS Cloud
 Solutions Architecture.
 
 ## Documentation
@@ -27,10 +27,10 @@ you should follow the steps below:
 
 1. [Install](https://leverage.binbash.co/user-guide/leverage-cli/installation/) and use the `leverage cli`
 2. Update your [configuration files](https://leverage.binbash.co/user-guide/ref-architecture-aws/configuration/#configuration-files)
-3. Review and assure you meet all the Terraform AWS pre-requisites
+3. Review and assure you meet all the OpenTofu/Terraform AWS pre-requisites
    1. AWS Credentials (Including your MFA setup)
       1. Run `leverage aws sso login` to setup the credentials.
-    2. [Initialize your accounts Terraform State Backend](https://leverage.binbash.co/user-guide/ref-architecture-aws/tf-state/)
+    2. [Initialize your accounts OpenTofu/Terraform State Backend](https://leverage.binbash.co/user-guide/ref-architecture-aws/tf-state/)
 
 4. Follow the [standard `leverage cli` workflow](https://leverage.binbash.co/user-guide/ref-architecture-aws/workflow/)
     1. Get into the folder that you need to work with (e.g. [`/security/global/base-identities`](https://github.com/binbashar/le-tf-infra-aws/tree/master/security/global/base-identities) )
@@ -42,7 +42,7 @@ you should follow the steps below:
 
 ### Consideration
 
-The `backend.tfvars` will inject the profile name with the necessary permissions that Terraform will
+The `backend.tfvars` will inject the profile name with the necessary permissions that OpenTofu/Terraform will
 use to make changes on AWS.
 * Such profile is usually one that relies on another profile to assume a role to get access to
   each corresponding account [( AWS IAM: users, groups, roles & policies )](https://leverage.binbash.co/user-guide/ref-architecture-aws/features/identities/identities/)
@@ -58,11 +58,11 @@ This repository includes pre-configured settings for AI-powered development tool
 
 - **[Cursor IDE](.cursor/)** - AI-first code editor with project-specific rules
   - [`.cursor/rules/`](.cursor/rules/) - Markdown rules for OpenTofu/Terraform best practices
-  - [`.cursor/mcp.json`](.cursor/mcp.json) - MCP server configurations for AWS and Terraform documentation
+  - [`.cursor/mcp.json`](.cursor/mcp.json) - MCP server configurations for AWS and OpenTofu/Terraform documentation
 
 - **[Kiro IDE](.kiro/)** - AI development environment with steering documents
   - [`.kiro/steering/`](.kiro/steering/) - Comprehensive documentation about the project structure, tech stack, and best practices
-  - [`.kiro/settings/mcp.json`](.kiro/settings/mcp.json) - MCP configurations for enhanced AWS/Terraform support
+  - [`.kiro/settings/mcp.json`](.kiro/settings/mcp.json) - MCP configurations for enhanced AWS/OpenTofu/Terraform support
 
 - **[Claude Code](CLAUDE.md)** - Anthropic's AI coding assistant
   - [`CLAUDE.md`](CLAUDE.md) - Project instructions and context for Claude
@@ -72,9 +72,9 @@ This repository includes pre-configured settings for AI-powered development tool
 
 These configurations are automatically loaded when you open the project in the respective IDE/tool. They provide:
 - Context-aware code suggestions aligned with Leverage best practices
-- AWS and Terraform/OpenTofu specific assistance
+- AWS and OpenTofu/Terraform specific assistance
 - Consistent code formatting and structure guidelines
-- Direct access to AWS documentation and Terraform registry
+- Direct access to AWS documentation and OpenTofu/Terraform registry
 
 ### Learn More
 
@@ -82,7 +82,7 @@ These configurations are automatically loaded when you open the project in the r
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
 - [MCP Protocol Specification](https://modelcontextprotocol.io/)
 
-## Project context commands
+## Project-wide Leverage CLI commands
 ```shell
 ╭─    ~/ref-architecture/le-tf-infra-aws  on   master · ✔  at 12:13:36 
 ╰─ leverage
@@ -100,25 +100,27 @@ Options:
   -h, --help           Show this message and exit.
 
 Commands:
-  credentials  Manage AWS cli credentials.
+  credentials  Manage AWS CLI credentials.
   project      Manage a Leverage project.
   run          Perform specified task(s) and all of its dependencies.
-  terraform    Run Terraform commands in a custom containerized...
-  tf           Run Terraform commands in a custom containerized...
+  terraform    Run Terraform commands through the Leverage CLI
+  tofu         Run OpenTofu commands through the Leverage CLI
+  tf           Short form of the "tofu" command
 ```
 
-## Layer context Terraform commands
+## Layer-wide Leverage CLI OpenTofu commands
 ```shell
 ╭─    ~/ref-architecture/le-tf-infra-aws  on   master · ✔  at 12:13:36 
-╰─ leverage tf
-Usage: leverage tf [OPTIONS] COMMAND [ARGS]...
+╰─ leverage tofu
+Usage: leverage tofu [OPTIONS] COMMAND [ARGS]...
 
-  Run Terraform commands in a custom containerized environment that provides
-  extra functionality when interacting with your cloud provider such as
-  handling multi factor authentication for you. All terraform subcommands that
-  receive extra args will pass the given strings as is to their corresponding
-  Terraform counterparts in the container. For example as in `leverage
-  terraform apply -auto-approve` or `leverage tf init -reconfigure`
+  Run OpenTofu commands through the Leverage CLI in order to obtain
+  additional functionality such as automatic AWS credentials injection or
+  config files autoloading.
+  All OpenTofu subcommands and their flags/arguments will be passed on to
+  the OpenTofu binary. For example the following:
+    - leverage tf init -reconfigure
+    - leverage tofu apply -auto-approve
 
 Options:
   -h, --help  Show this message and exit.
@@ -132,7 +134,7 @@ Commands:
   init      Initialize this layer.
   output    Show all output variables of this layer.
   plan      Generate an execution plan for this layer.
-  shell     Open a shell into the Terraform container in this layer.
+  shell     Open a shell into the Leverage toolbox container in this layer (deprecated).
   validate  Validate code of the current directory.
   version   Print version.
 ```


### PR DESCRIPTION
## What?
* Adjust Terraform references to also mention OpenTofu and similar updates

## References
* `closes #255`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect OpenTofu/Terraform support and integration throughout the project.
  * Expanded CLI command references to include OpenTofu commands alongside Terraform equivalents.
  * Standardized guides and examples to showcase OpenTofu/Terraform workflows and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->