### PR TITLE
feat(ISSUE-719): initialize baseline Terraform layer configuration for AWS backend

### DIFF
--- a/baseline/base-tf-backend/.terraform.lock.hcl
+++ b/baseline/base-tf-backend/.terraform.lock.hcl
@@ -1,0 +1,54 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:mC9+u1eaUILTjxey6Ivyf/3djm//RNNze9kBVX/trng=",
+    "zh:32e1d4b0595cea6cda4ca256195c162772ddff25594ab4008731a2ec7be230bf",
+    "zh:48c390af0c87df994ec9796f04ec2582bcac581fb81ed6bb58e0671da1c17991",
+    "zh:4be7289c969218a57b40902e2f359914f8d35a7f97b439140cb711aa21e494bd",
+    "zh:4cf958e631e99ed6c8b522c9b22e1f1b568c0bdadb01dd002ca7dffb1c927764",
+    "zh:7a0132c0faca4c4c96aa70808effd6817e28712bf5a39881666ac377b4250acf",
+    "zh:7d60de08fac427fb045e4590d1b921b6778498eee9eb16f78c64d4c577bde096",
+    "zh:91003bee5981e99ec3925ce2f452a5f743827f9d0e131a86613549c1464796f0",
+    "zh:9fe2fe75977c8149e2515fb30c6cc6cfd57b225d4ce592c570d81a3831d7ffa3",
+    "zh:e210e6be54933ce93e03d0994e520ba289aa01b2c1f70e77afb8f2ee796b0fe3",
+    "zh:e8793e5f9422f2b31a804e51806595f335b827c9a38db18766960464566f21d5",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version = "0.13.1"
+  hashes = [
+    "h1:ueilLAoXlZPufdJYuPFeqznwP39ZwLsRcQtqow+NUiI=",
+    "zh:10f32af8b544a039f19abd546e345d056a55cb7bdd69d5bbd7322cbc86883848",
+    "zh:35dd5beb34a9f73de8d0fed332814c69acae69397c9c065ce63ccd8315442bef",
+    "zh:56545d1dd5f2e7262e0c0c124264974229ec9cc234d0d7a0e36e14b869590f4a",
+    "zh:8d7259c3f819fd3470ff933c904b6a549502a8351feb1b5c040a4560decaf7e0",
+    "zh:a40f26878826b142e26fe193f7e3e14fc97f615cd6af140e88ce5bc25f3fcf50",
+    "zh:b2e82f25fecff172a9a9e24ea37d37e4fc630ee9245617cb40b10e66a6b979c8",
+    "zh:d4b699850a40ed07ef83c6b827605d24050b2732646ee017bda278e4ddf01c91",
+    "zh:e4e6a5e5614b6a54557400aabb748ebd57e947cdbd21ad1c7602c51368a80559",
+    "zh:eb78fb97bca22931e730487a20a90f5a6221ddfb3138aaf070737ea2b7c9c885",
+    "zh:faba366a1352ee679bba2a5b09c073c6854721db94b191d49b620b60946a065f",
+  ]
+}

--- a/baseline/base-tf-backend/README.md
+++ b/baseline/base-tf-backend/README.md
@@ -1,0 +1,11 @@
+# Terraform - S3 & DynamoDB for Remote State Storage & Locking
+
+## Overview
+Use this terraforms configuration files to create the S3 bucket & DynamoDB table needed to use Terraform Remote State Storage & Locking.
+
+## Set Up
+- Install terraform >= v0.12.28, use `terraform version` to check
+- Ensure you have `make` installed in your system
+- Refer to 'readme.md' in the root repository to understand how to set up the configuration file required for this
+- Run `make run`
+- You should see terraform output and a confirmation prompt to approve the changes

--- a/baseline/base-tf-backend/common-variables.tf
+++ b/baseline/base-tf-backend/common-variables.tf
@@ -1,0 +1,1 @@
+../../config/common-variables.tf

--- a/baseline/base-tf-backend/config.tf
+++ b/baseline/base-tf-backend/config.tf
@@ -12,7 +12,6 @@ provider "aws" {
   for_each = local.accounts_providers
   region   = each.value.region
   profile  = each.value.profile
-
 }
 
 terraform {

--- a/baseline/base-tf-backend/config.tf
+++ b/baseline/base-tf-backend/config.tf
@@ -1,0 +1,29 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+# Default provider configuration
+provider "aws" {
+  region  = var.region_primary
+  profile = "bb-shared-devops"
+}
+
+provider "aws" {
+  alias    = "accounts"
+  for_each = local.accounts_providers
+  region   = each.value.region
+  profile  = each.value.profile
+
+}
+
+terraform {
+  required_version = "~> 1.6"
+
+  required_providers {
+    aws = "~> 5.0"
+  }
+
+  backend "s3" {
+    key = local.backend_settings.bucket.key
+  }
+}
+

--- a/baseline/base-tf-backend/imports.tf
+++ b/baseline/base-tf-backend/imports.tf
@@ -1,0 +1,597 @@
+# Import blocks for existing Terraform backend resources
+# These imports are based on the plan.txt output showing resources to be created
+
+# ===========================================
+# APPS-DEVSTG ACCOUNT - US-EAST-1 REGION
+# ===========================================
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_dynamodb_table.without_server_side_encryption[0]
+  id = "bb-apps-devstg-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket.default
+  id = "bb-apps-devstg-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-apps-devstg-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.default
+  id = "bb-apps-devstg-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-apps-devstg-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.default
+  id = "bb-apps-devstg-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-apps-devstg-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-apps-devstg-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-apps-devstg-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_iam_role.bucket_replication[0]
+  id = "bb-apps-devstg-terraform-backend-bucket-replication"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::523857393444:policy/bb-apps-devstg-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["apps-devstg"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-apps-devstg-terraform-backend-bucket-replication"
+#}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.default[0]
+  id = "bb-apps-devstg-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-apps-devstg-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-devstg"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# APPS-PRD ACCOUNT - US-EAST-1 REGION
+# ===========================================
+import {
+  to = module.base_tf_backend["apps-prd"].aws_dynamodb_table.without_server_side_encryption[0]
+  id = "bb-apps-prd-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket.default
+  id = "bb-apps-prd-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-apps-prd-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.default
+  id = "bb-apps-prd-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-apps-prd-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.default
+  id = "bb-apps-prd-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-apps-prd-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-apps-prd-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-apps-prd-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_iam_role.bucket_replication[0]
+  id = "bb-apps-prd-terraform-backend-bucket-replication"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::802787198489:policy/bb-apps-prd-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["apps-prd"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-apps-prd-terraform-backend-bucket-replication"
+#}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.default[0]
+  id = "bb-apps-prd-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-apps-prd-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["apps-prd"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# DATA-SCIENCE ACCOUNT - US-EAST-1 REGION
+# ===========================================
+import {
+  to = module.base_tf_backend["data-science"].aws_dynamodb_table.without_server_side_encryption[0]
+  id = "bb-data-science-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket.default
+  id = "bb-data-science-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-data-science-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.default
+  id = "bb-data-science-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-data-science-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_versioning.default
+  id = "bb-data-science-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-data-science-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-data-science-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-data-science-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_iam_role.bucket_replication[0]
+  id = "bb-data-science-terraform-backend-bucket-replication"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::905418344519:policy/bb-data-science-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["data-science"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-data-science-terraform-backend-role-policy-attachment"
+#}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_policy.default[0]
+  id = "bb-data-science-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-data-science-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["data-science"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# MANAGEMENT ACCOUNT - US-EAST-1 REGION
+# ===========================================
+
+# The account was re-named to management and the module enforce the dynamodb table's name
+#import {
+#  to = module.base_tf_backend["management"].aws_dynamodb_table.without_server_side_encryption[0]
+#  id = "bb-root-terraform-backend"
+#}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket.default
+  id = "bb-root-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-root-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_public_access_block.default
+  id = "bb-root-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-root-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_versioning.default
+  id = "bb-root-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-root-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-root-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-root-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_iam_role.bucket_replication[0]
+  id = "bb-root-terraform-backend-bucket-replication"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["management"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-root-terraform-backend-role-policy-attachment"
+#}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_policy.default[0]
+  id = "bb-root-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["management"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-root-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["management"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# NETWORK ACCOUNT - US-EAST-1 REGION
+# ===========================================
+import {
+  to = module.base_tf_backend["network"].aws_dynamodb_table.without_server_side_encryption[0]
+  id = "bb-network-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket.default
+  id = "bb-network-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-network-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_public_access_block.default
+  id = "bb-network-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-network-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_versioning.default
+  id = "bb-network-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-network-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-network-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-network-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_iam_role.bucket_replication[0]
+  id = "bb-network-terraform-backend-bucket-replication"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::822280187662:policy/bb-network-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["network"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-network-terraform-backend-role-policy-attachment"
+#}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_policy.default[0]
+  id = "bb-network-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["network"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-network-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["network"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# SECURITY ACCOUNT - US-EAST-1 REGION
+# ===========================================
+import {
+  to = module.base_tf_backend["security"].aws_dynamodb_table.without_server_side_encryption[0]
+  id = "bb-security-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket.default
+  id = "bb-security-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-security-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_public_access_block.default
+  id = "bb-security-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-security-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_versioning.default
+  id = "bb-security-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-security-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-security-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-security-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_iam_role.bucket_replication[0]
+  id = "bb-security-terraform-backend-bucket-replication"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::900980591242:policy/bb-security-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["security"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-security-terraform-backend-role-policy-attachment"
+#}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_policy.default[0]
+  id = "bb-security-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["security"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-security-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["security"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# SHARED ACCOUNT - US-EAST-1 REGION
+# ===========================================
+import {
+  to = module.base_tf_backend["shared"].aws_dynamodb_table.without_server_side_encryption[0]
+  id = "bb-shared-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket.default
+  id = "bb-shared-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket.replication_bucket[0]
+  id = "bb-shared-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.default
+  id = "bb-shared-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.replication_bucket[0]
+  id = "bb-shared-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_versioning.default
+  id = "bb-shared-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_versioning.replication_bucket[0]
+  id = "bb-shared-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.default
+  id = "bb-shared-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]
+  id = "bb-shared-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_iam_role.bucket_replication[0]
+  id = "bb-shared-terraform-backend-bucket-replication-module"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_iam_policy.bucket_replication[0]
+  id = "arn:aws:iam::763606934258:policy/bb-shared-terraform-backend-bucket-replication"
+}
+
+#import {
+#  to = module.base_tf_backend["shared"].aws_iam_policy_attachment.bucket_replication[0]
+#  id = "bb-shared-terraform-backend-bucket-replication-module"
+#}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_policy.default[0]
+  id = "bb-shared-terraform-backend"
+}
+
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_policy.bucket_replication[0]
+  id = "bb-shared-terraform-backend-replica"
+}
+
+import {
+  to = module.base_tf_backend["shared"].time_sleep.wait_30_secs
+  id = "30s,"
+}
+
+# ===========================================
+# S3 BUCKET REPLICATION CONFIGURATION IMPORTS
+# ===========================================
+
+# Apps Dev/Staging Account
+#import {
+#  to = module.base_tf_backend["apps-devstg"].aws_s3_bucket_replication_configuration.this[0]
+#  id = "bb-apps-devstg-terraform-backend"
+#}
+#
+## Apps Production Account
+#import {
+#  to = module.base_tf_backend["apps-prd"].aws_s3_bucket_replication_configuration.this[0]
+#  id = "bb-apps-prd-terraform-backend"
+#}
+#
+## Data Science Account
+#import {
+#  to = module.base_tf_backend["data-science"].aws_s3_bucket_replication_configuration.this[0]
+#  id = "bb-data-science-terraform-backend"
+#}
+#
+## Management Account
+#import {
+#  to = module.base_tf_backend["management"].aws_s3_bucket_replication_configuration.this[0]
+#  id = "bb-root-terraform-backend"
+#}
+#
+## Network Account
+#import {
+#  to = module.base_tf_backend["network"].aws_s3_bucket_replication_configuration.this[0]
+#  id = "bb-network-terraform-backend"
+#}
+#
+## Security Account
+#import {
+#  for_each = local.accounts
+#  to = module.base_tf_backend[each.key].aws_s3_bucket_replication_configuration.this[0]
+#  id = "bb-${each.key}-terraform-backend"
+#}
+
+# Shared Account
+import {
+  to = module.base_tf_backend["shared"].aws_s3_bucket_replication_configuration.this[0]
+  id = "bb-shared-terraform-backend"
+}

--- a/baseline/base-tf-backend/main.tf
+++ b/baseline/base-tf-backend/main.tf
@@ -1,0 +1,40 @@
+#================================#
+# Terraform Backend Modules      #
+#================================#
+
+# Security Account Backend
+module "base_tf_backend" {
+  for_each = local.accounts_resources
+  providers = {
+    aws.primary   = aws.accounts["${each.key}-${each.value.region_primary}"]
+    aws.secondary = aws.accounts["${each.key}-${each.value.region_secondary}"]
+  }
+
+  source = "github.com/binbashar/terraform-aws-tfstate-backend.git?ref=v1.0.28"
+
+  delimiter = each.value.inputs.bucket.delimiter
+  namespace = each.value.inputs.bucket.namespace
+  stage     = each.key
+  name      = "terraform-backend"
+
+  acl                           = each.value.inputs.security.acl
+  block_public_acls             = each.value.inputs.security.block_public_acls
+  block_public_policy           = each.value.inputs.security.block_public_policy
+  restrict_public_buckets       = each.value.inputs.security.restrict_public_buckets
+  enable_server_side_encryption = each.value.inputs.security.enable_server_side_encryption
+  enforce_ssl_requests          = each.value.inputs.security.enforce_ssl_requests
+  ignore_public_acls            = each.value.inputs.security.ignore_public_acls
+  force_destroy                 = each.value.inputs.security.force_destroy
+
+  bucket_replication_enabled    = each.value.inputs.replication.bucket_replication_enabled
+  notifications_sns             = each.value.inputs.replication.notifications_sns
+  bucket_lifecycle_enabled      = each.value.inputs.replication.bucket_lifecycle_enabled
+  billing_mode                  = each.value.inputs.replication.billing_mode
+  enable_point_in_time_recovery = each.value.inputs.replication.enable_point_in_time_recovery
+  create_kms_key                = each.value.inputs.replication.create_kms_key
+
+  tags = merge(each.value.inputs.tags, {
+    Account   = each.key
+    AccountID = tostring(each.value.id)
+  })
+}

--- a/baseline/base-tf-backend/plan.txt
+++ b/baseline/base-tf-backend/plan.txt
@@ -1,0 +1,3815 @@
+[18:42:20.989] INFO     Checking for local docker image, tag: 1.9.1-tofu-0.3.0-1000-1000...                                            
+[18:42:21.021] INFO     ✔ OK                                                                                                           
+                                                                                                                                       
+[18:42:21.891] INFO     Attempting to get temporary credentials for management account.                                                
+[18:42:21.893] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.895] INFO     Attempting to get temporary credentials for shared account.                                                    
+[18:42:21.897] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.899] INFO     Attempting to get temporary credentials for apps-devstg account.                                               
+[18:42:21.902] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.904] INFO     Attempting to get temporary credentials for network account.                                                   
+[18:42:21.905] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.907] INFO     Attempting to get temporary credentials for security account.                                                  
+[18:42:21.908] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.910] INFO     Attempting to get temporary credentials for apps-prd account.                                                  
+[18:42:21.911] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.912] INFO     Attempting to get temporary credentials for shared account.                                                    
+[18:42:21.914] INFO     Using already configured temporary credentials.                                                                
+[18:42:21.916] INFO     Attempting to get temporary credentials for data-science account.                                              
+[18:42:21.918] INFO     Using already configured temporary credentials.                                                                
+module.base_tf_backend["network"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-network-terraform-backend-bucket-replication]
+module.base_tf_backend["apps-devstg"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-apps-devstg-terraform-backend-bucket-replication]
+module.base_tf_backend["network"].data.aws_region.current: Reading...
+module.base_tf_backend["apps-devstg"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend-bucket-replication]
+module.base_tf_backend["network"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-network-terraform-backend-bucket-replication]
+module.base_tf_backend["apps-devstg"].data.aws_region.current: Reading...
+module.base_tf_backend["network"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["network"].aws_dynamodb_table.without_server_side_encryption[0]: Preparing import... [id=bb-network-terraform-backend]
+module.base_tf_backend["apps-devstg"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["security"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-security-terraform-backend-bucket-replication]
+module.base_tf_backend["shared"].data.aws_region.current: Reading...
+module.base_tf_backend["security"].data.aws_region.current: Reading...
+module.base_tf_backend["network"].aws_dynamodb_table.without_server_side_encryption[0]: Refreshing state... [id=bb-network-terraform-backend]
+module.base_tf_backend["shared"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["security"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-security-terraform-backend-bucket-replication]
+module.base_tf_backend["security"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["security"].aws_dynamodb_table.without_server_side_encryption[0]: Preparing import... [id=bb-security-terraform-backend]
+module.base_tf_backend["shared"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-shared-terraform-backend-bucket-replication-module]
+module.base_tf_backend["security"].aws_dynamodb_table.without_server_side_encryption[0]: Refreshing state... [id=bb-security-terraform-backend]
+module.base_tf_backend["shared"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-shared-terraform-backend-bucket-replication-module]
+module.base_tf_backend["apps-prd"].data.aws_region.current: Reading...
+module.base_tf_backend["apps-prd"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["data-science"].data.aws_region.current: Reading...
+module.base_tf_backend["shared"].aws_dynamodb_table.without_server_side_encryption[0]: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["data-science"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["shared"].aws_dynamodb_table.without_server_side_encryption[0]: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_dynamodb_table.without_server_side_encryption[0]: Preparing import... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["management"].data.aws_region.current: Reading...
+module.base_tf_backend["apps-devstg"].aws_dynamodb_table.without_server_side_encryption[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["management"].data.aws_region.current: Read complete after 0s [id=us-east-1]
+module.base_tf_backend["apps-prd"].aws_dynamodb_table.without_server_side_encryption[0]: Preparing import... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_dynamodb_table.without_server_side_encryption[0]: Refreshing state... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["data-science"].aws_dynamodb_table.without_server_side_encryption[0]: Preparing import... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["data-science"].aws_dynamodb_table.without_server_side_encryption[0]: Refreshing state... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-apps-prd-terraform-backend-bucket-replication]
+module.base_tf_backend["apps-prd"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-apps-prd-terraform-backend-bucket-replication]
+module.base_tf_backend["data-science"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-data-science-terraform-backend-bucket-replication]
+module.base_tf_backend["data-science"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-data-science-terraform-backend-bucket-replication]
+module.base_tf_backend["management"].aws_iam_role.bucket_replication[0]: Preparing import... [id=bb-root-terraform-backend-bucket-replication]
+module.base_tf_backend["management"].aws_iam_role.bucket_replication[0]: Refreshing state... [id=bb-root-terraform-backend-bucket-replication]
+module.base_tf_backend["shared"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket.replication_bucket[0]: Preparing import... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket.replication_bucket[0]: Refreshing state... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket.default: Preparing import... [id=bb-security-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket.default: Preparing import... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket.default: Preparing import... [id=bb-root-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket.default: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket.default: Preparing import... [id=bb-network-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket.default: Preparing import... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket.default: Preparing import... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket.default: Refreshing state... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket.default: Refreshing state... [id=bb-root-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket.default: Refreshing state... [id=bb-security-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket.default: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket.default: Refreshing state... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket.default: Refreshing state... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket.default: Refreshing state... [id=bb-network-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_versioning.replication_bucket[0]: Preparing import... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_versioning.replication_bucket[0]: Refreshing state... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_public_access_block.replication_bucket[0]: Preparing import... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_public_access_block.replication_bucket[0]: Refreshing state... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["network"].data.aws_iam_policy_document.default-ssl: Reading...
+module.base_tf_backend["data-science"].data.aws_iam_policy_document.default-ssl: Reading...
+module.base_tf_backend["apps-devstg"].data.aws_iam_policy_document.default-ssl: Reading...
+module.base_tf_backend["data-science"].data.aws_iam_policy_document.default-ssl: Read complete after 0s [id=2003822905]
+module.base_tf_backend["network"].data.aws_iam_policy_document.default-ssl: Read complete after 0s [id=1256364257]
+module.base_tf_backend["apps-devstg"].data.aws_iam_policy_document.default-ssl: Read complete after 0s [id=1295115816]
+module.base_tf_backend["security"].data.aws_iam_policy_document.default-ssl: Reading...
+module.base_tf_backend["apps-prd"].data.aws_iam_policy_document.default-ssl: Reading...
+module.base_tf_backend["security"].data.aws_iam_policy_document.default-ssl: Read complete after 0s [id=2913786012]
+module.base_tf_backend["apps-prd"].data.aws_iam_policy_document.default-ssl: Read complete after 0s [id=4225281203]
+module.base_tf_backend["apps-devstg"].data.aws_iam_policy_document.default-ssl-vpc: Reading...
+module.base_tf_backend["data-science"].data.aws_iam_policy_document.default-ssl-vpc: Reading...
+module.base_tf_backend["data-science"].data.aws_iam_policy_document.default-ssl-vpc: Read complete after 0s [id=1058783944]
+module.base_tf_backend["apps-devstg"].data.aws_iam_policy_document.default-ssl-vpc: Read complete after 0s [id=572610631]
+module.base_tf_backend["network"].data.aws_iam_policy_document.default-ssl-vpc: Reading...
+module.base_tf_backend["security"].data.aws_iam_policy_document.default-ssl-vpc: Reading...
+module.base_tf_backend["apps-prd"].data.aws_iam_policy_document.default-ssl-vpc: Reading...
+module.base_tf_backend["network"].data.aws_iam_policy_document.default-ssl-vpc: Read complete after 0s [id=1382197413]
+module.base_tf_backend["management"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-root-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-root-terraform-backend]
+module.base_tf_backend["security"].data.aws_iam_policy_document.default-ssl-vpc: Read complete after 0s [id=3705658410]
+module.base_tf_backend["apps-prd"].data.aws_iam_policy_document.default-ssl-vpc: Read complete after 0s [id=2870517468]
+module.base_tf_backend["shared"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-security-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-security-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_versioning.default: Preparing import... [id=bb-network-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_versioning.default: Refreshing state... [id=bb-network-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-security-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-security-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-root-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-root-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-network-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-network-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.default: Preparing import... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.default: Refreshing state... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["apps-prd"].data.aws_iam_policy_document.bucket_replication[0]: Reading...
+module.base_tf_backend["apps-prd"].data.aws_iam_policy_document.bucket_replication[0]: Read complete after 0s [id=1910255310]
+module.base_tf_backend["network"].data.aws_iam_policy_document.bucket_replication[0]: Reading...
+module.base_tf_backend["security"].data.aws_iam_policy_document.bucket_replication[0]: Reading...
+module.base_tf_backend["security"].data.aws_iam_policy_document.bucket_replication[0]: Read complete after 0s [id=2920966486]
+module.base_tf_backend["network"].data.aws_iam_policy_document.bucket_replication[0]: Read complete after 0s [id=2960261984]
+module.base_tf_backend["apps-devstg"].data.aws_iam_policy_document.bucket_replication[0]: Reading...
+module.base_tf_backend["apps-devstg"].data.aws_iam_policy_document.bucket_replication[0]: Read complete after 0s [id=4173155100]
+module.base_tf_backend["data-science"].data.aws_iam_policy_document.bucket_replication[0]: Reading...
+module.base_tf_backend["data-science"].data.aws_iam_policy_document.bucket_replication[0]: Read complete after 0s [id=3887869635]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-root-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-root-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-network-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-network-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Preparing import... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0]: Refreshing state... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.default: Preparing import... [id=bb-security-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.default: Refreshing state... [id=bb-security-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_replication_configuration.this[0]: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_replication_configuration.this[0]: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["data-science"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["shared"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["data-science"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["shared"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["apps-devstg"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["apps-devstg"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["security"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["apps-prd"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["management"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["security"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["apps-prd"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["management"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["network"].time_sleep.wait_30_secs: Preparing import... [id=30s,]
+module.base_tf_backend["network"].time_sleep.wait_30_secs: Refreshing state... [id=2025-10-01T16:42:57Z]
+module.base_tf_backend["management"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-root-terraform-backend]
+module.base_tf_backend["network"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-network-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::523857393444:policy/bb-apps-devstg-terraform-backend-bucket-replication]
+module.base_tf_backend["network"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-network-terraform-backend]
+module.base_tf_backend["management"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-root-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend]
+module.base_tf_backend["apps-devstg"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::523857393444:policy/bb-apps-devstg-terraform-backend-bucket-replication]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-security-terraform-backend]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-apps-prd-terraform-backend]
+module.base_tf_backend["security"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-security-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["data-science"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-data-science-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_policy.default[0]: Preparing import... [id=bb-shared-terraform-backend]
+module.base_tf_backend["shared"].aws_s3_bucket_policy.default[0]: Refreshing state... [id=bb-shared-terraform-backend]
+module.base_tf_backend["network"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::822280187662:policy/bb-network-terraform-backend-bucket-replication]
+module.base_tf_backend["network"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::822280187662:policy/bb-network-terraform-backend-bucket-replication]
+module.base_tf_backend["management"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication]
+module.base_tf_backend["data-science"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::905418344519:policy/bb-data-science-terraform-backend-bucket-replication]
+module.base_tf_backend["management"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication]
+module.base_tf_backend["data-science"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::905418344519:policy/bb-data-science-terraform-backend-bucket-replication]
+module.base_tf_backend["apps-prd"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::802787198489:policy/bb-apps-prd-terraform-backend-bucket-replication]
+module.base_tf_backend["apps-prd"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::802787198489:policy/bb-apps-prd-terraform-backend-bucket-replication]
+module.base_tf_backend["security"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::900980591242:policy/bb-security-terraform-backend-bucket-replication]
+module.base_tf_backend["security"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::900980591242:policy/bb-security-terraform-backend-bucket-replication]
+module.base_tf_backend["shared"].aws_iam_policy.bucket_replication[0]: Preparing import... [id=arn:aws:iam::763606934258:policy/bb-shared-terraform-backend-bucket-replication]
+module.base_tf_backend["shared"].aws_iam_policy.bucket_replication[0]: Refreshing state... [id=arn:aws:iam::763606934258:policy/bb-shared-terraform-backend-bucket-replication]
+module.base_tf_backend["management"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["management"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-root-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["network"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-network-terraform-backend-replica]
+module.base_tf_backend["security"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-security-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["shared"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-shared-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-apps-devstg-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-apps-prd-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_policy.bucket_replication[0]: Preparing import... [id=bb-data-science-terraform-backend-replica]
+module.base_tf_backend["data-science"].aws_s3_bucket_policy.bucket_replication[0]: Refreshing state... [id=bb-data-science-terraform-backend-replica]
+
+OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+  ~ update in-place
+-/+ destroy and then create replacement
+ <= read (data resources)
+
+OpenTofu planned the following actions, but then encountered a problem:
+
+  # module.base_tf_backend["apps-devstg"].aws_dynamodb_table.without_server_side_encryption[0] will be imported
+    resource "aws_dynamodb_table" "without_server_side_encryption" {
+        arn                         = "arn:aws:dynamodb:us-east-1:523857393444:table/bb-apps-devstg-terraform-backend"
+        billing_mode                = "PROVISIONED"
+        deletion_protection_enabled = false
+        hash_key                    = "LockID"
+        id                          = "bb-apps-devstg-terraform-backend"
+        name                        = "bb-apps-devstg-terraform-backend"
+        read_capacity               = 5
+        stream_enabled              = false
+        table_class                 = "STANDARD"
+        tags                        = {
+            "Environment" = "apps-devstg"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "apps-devstg"
+            "Terraform"   = "true"
+        }
+        write_capacity              = 5
+
+        attribute {
+            name = "LockID"
+            type = "S"
+        }
+
+        point_in_time_recovery {
+            enabled                 = false
+            recovery_period_in_days = 0
+        }
+
+        ttl {
+            enabled = false
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_iam_policy.bucket_replication[0] will be imported
+    resource "aws_iam_policy" "bucket_replication" {
+        arn              = "arn:aws:iam::523857393444:policy/bb-apps-devstg-terraform-backend-bucket-replication"
+        attachment_count = 1
+        id               = "arn:aws:iam::523857393444:policy/bb-apps-devstg-terraform-backend-bucket-replication"
+        name             = "bb-apps-devstg-terraform-backend-bucket-replication"
+        path             = "/"
+        policy           = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action   = [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-apps-devstg-terraform-backend"
+                        Sid      = "1"
+                    },
+                    {
+                        Action   = [
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersion",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-apps-devstg-terraform-backend/*"
+                        Sid      = "2"
+                    },
+                    {
+                        Action   = [
+                            "s3:ReplicateTags",
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-apps-devstg-terraform-backend-replica/*"
+                        Sid      = "6"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        policy_id        = "ANPAXT6CVO4SFOLFB2O5S"
+        tags             = {}
+        tags_all         = {}
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_iam_role.bucket_replication[0] will be imported
+    resource "aws_iam_role" "bucket_replication" {
+        arn                   = "arn:aws:iam::523857393444:role/bb-apps-devstg-terraform-backend-bucket-replication"
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        create_date           = "2024-04-16T22:28:44Z"
+        force_detach_policies = false
+        id                    = "bb-apps-devstg-terraform-backend-bucket-replication"
+        managed_policy_arns   = [
+            "arn:aws:iam::523857393444:policy/bb-apps-devstg-terraform-backend-bucket-replication",
+        ]
+        max_session_duration  = 3600
+        name                  = "bb-apps-devstg-terraform-backend-bucket-replication"
+        path                  = "/"
+        tags                  = {}
+        tags_all              = {}
+        unique_id             = "AROAXT6CVO4SFILB2ZIT2"
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket.default will be imported
+    resource "aws_s3_bucket" "default" {
+        arn                         = "arn:aws:s3:::bb-apps-devstg-terraform-backend"
+        bucket                      = "bb-apps-devstg-terraform-backend"
+        bucket_domain_name          = "bb-apps-devstg-terraform-backend.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-apps-devstg-terraform-backend.s3.us-east-1.amazonaws.com"
+        hosted_zone_id              = "Z3AQBSTGFYJSTF"
+        id                          = "bb-apps-devstg-terraform-backend"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-apps-devstg-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-1"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "apps-devstg"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "apps-devstg"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "3a99800a2e08b1bb876a6ad0ec19d8b17ea74e1078b140933364b23d1545538a"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        replication_configuration {
+            role = "arn:aws:iam::523857393444:role/bb-apps-devstg-terraform-backend-bucket-replication"
+
+            rules {
+                id       = "standard_bucket_replication"
+                priority = 0
+                status   = "Enabled"
+
+                destination {
+                    bucket        = "arn:aws:s3:::bb-apps-devstg-terraform-backend-replica"
+                    storage_class = "STANDARD"
+                }
+            }
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket.replication_bucket[0] will be imported
+    resource "aws_s3_bucket" "replication_bucket" {
+        arn                         = "arn:aws:s3:::bb-apps-devstg-terraform-backend-replica"
+        bucket                      = "bb-apps-devstg-terraform-backend-replica"
+        bucket_domain_name          = "bb-apps-devstg-terraform-backend-replica.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-apps-devstg-terraform-backend-replica.s3.us-east-2.amazonaws.com"
+        hosted_zone_id              = "Z2O1EMRO9K5GLX"
+        id                          = "bb-apps-devstg-terraform-backend-replica"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-apps-devstg-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-2"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "apps-devstg"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "apps-devstg"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "3a99800a2e08b1bb876a6ad0ec19d8b17ea74e1078b140933364b23d1545538a"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.bucket_replication[0] will be imported
+    resource "aws_s3_bucket_policy" "bucket_replication" {
+        bucket = "bb-apps-devstg-terraform-backend-replica"
+        id     = "bb-apps-devstg-terraform-backend-replica"
+        policy = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-apps-devstg-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_policy.default[0] will be imported
+    resource "aws_s3_bucket_policy" "default" {
+        bucket = "bb-apps-devstg-terraform-backend"
+        id     = "bb-apps-devstg-terraform-backend"
+        policy = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-apps-devstg-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.default will be imported
+    resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-apps-devstg-terraform-backend"
+        id                      = "bb-apps-devstg-terraform-backend"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_public_access_block.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-apps-devstg-terraform-backend-replica"
+        id                      = "bb-apps-devstg-terraform-backend-replica"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_replication_configuration.this[0] will be created
+  + resource "aws_s3_bucket_replication_configuration" "this" {
+      + bucket = "bb-apps-devstg-terraform-backend"
+      + id     = (known after apply)
+      + role   = "arn:aws:iam::523857393444:role/bb-apps-devstg-terraform-backend-bucket-replication"
+
+      + rule {
+          + id     = "standard_bucket_replication"
+          + status = "Enabled"
+
+          + destination {
+              + bucket        = "arn:aws:s3:::bb-apps-devstg-terraform-backend-replica"
+              + storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.default will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+        bucket = "bb-apps-devstg-terraform-backend"
+        id     = "bb-apps-devstg-terraform-backend"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+        bucket = "bb-apps-devstg-terraform-backend-replica"
+        id     = "bb-apps-devstg-terraform-backend-replica"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.default will be imported
+    resource "aws_s3_bucket_versioning" "default" {
+        bucket = "bb-apps-devstg-terraform-backend"
+        id     = "bb-apps-devstg-terraform-backend"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].aws_s3_bucket_versioning.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_versioning" "replication_bucket" {
+        bucket = "bb-apps-devstg-terraform-backend-replica"
+        id     = "bb-apps-devstg-terraform-backend-replica"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["apps-devstg"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_dynamodb_table.without_server_side_encryption[0] will be imported
+    resource "aws_dynamodb_table" "without_server_side_encryption" {
+        arn                         = "arn:aws:dynamodb:us-east-1:802787198489:table/bb-apps-prd-terraform-backend"
+        billing_mode                = "PROVISIONED"
+        deletion_protection_enabled = false
+        hash_key                    = "LockID"
+        id                          = "bb-apps-prd-terraform-backend"
+        name                        = "bb-apps-prd-terraform-backend"
+        read_capacity               = 5
+        stream_enabled              = false
+        table_class                 = "STANDARD"
+        tags                        = {
+            "Environment" = "apps-prd"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "apps-prd"
+            "Terraform"   = "true"
+        }
+        write_capacity              = 5
+
+        attribute {
+            name = "LockID"
+            type = "S"
+        }
+
+        point_in_time_recovery {
+            enabled                 = false
+            recovery_period_in_days = 0
+        }
+
+        ttl {
+            enabled = false
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_iam_policy.bucket_replication[0] will be imported
+    resource "aws_iam_policy" "bucket_replication" {
+        arn              = "arn:aws:iam::802787198489:policy/bb-apps-prd-terraform-backend-bucket-replication"
+        attachment_count = 1
+        id               = "arn:aws:iam::802787198489:policy/bb-apps-prd-terraform-backend-bucket-replication"
+        name             = "bb-apps-prd-terraform-backend-bucket-replication"
+        path             = "/"
+        policy           = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action   = [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-apps-prd-terraform-backend"
+                        Sid      = "1"
+                    },
+                    {
+                        Action   = [
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersion",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-apps-prd-terraform-backend/*"
+                        Sid      = "2"
+                    },
+                    {
+                        Action   = [
+                            "s3:ReplicateTags",
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-apps-prd-terraform-backend-replica/*"
+                        Sid      = "6"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        policy_id        = "ANPA3V2OYQYM2QEVN3C5Q"
+        tags             = {}
+        tags_all         = {}
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_iam_role.bucket_replication[0] will be imported
+    resource "aws_iam_role" "bucket_replication" {
+        arn                   = "arn:aws:iam::802787198489:role/bb-apps-prd-terraform-backend-bucket-replication"
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        create_date           = "2025-05-28T18:42:36Z"
+        force_detach_policies = false
+        id                    = "bb-apps-prd-terraform-backend-bucket-replication"
+        managed_policy_arns   = [
+            "arn:aws:iam::802787198489:policy/bb-apps-prd-terraform-backend-bucket-replication",
+        ]
+        max_session_duration  = 3600
+        name                  = "bb-apps-prd-terraform-backend-bucket-replication"
+        path                  = "/"
+        tags                  = {}
+        tags_all              = {}
+        unique_id             = "AROA3V2OYQYMSN5LNDJW3"
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket.default will be imported
+    resource "aws_s3_bucket" "default" {
+        arn                         = "arn:aws:s3:::bb-apps-prd-terraform-backend"
+        bucket                      = "bb-apps-prd-terraform-backend"
+        bucket_domain_name          = "bb-apps-prd-terraform-backend.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-apps-prd-terraform-backend.s3.us-east-1.amazonaws.com"
+        hosted_zone_id              = "Z3AQBSTGFYJSTF"
+        id                          = "bb-apps-prd-terraform-backend"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-apps-prd-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-1"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "apps-prd"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "apps-prd"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "7103b9199553c430c90df5b3be171ec9cf8692eab196a82d4b2750b312cf42ab"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        replication_configuration {
+            role = "arn:aws:iam::802787198489:role/bb-apps-prd-terraform-backend-bucket-replication"
+
+            rules {
+                id       = "standard_bucket_replication"
+                priority = 0
+                status   = "Enabled"
+
+                destination {
+                    bucket        = "arn:aws:s3:::bb-apps-prd-terraform-backend-replica"
+                    storage_class = "STANDARD"
+                }
+            }
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket.replication_bucket[0] will be imported
+    resource "aws_s3_bucket" "replication_bucket" {
+        arn                         = "arn:aws:s3:::bb-apps-prd-terraform-backend-replica"
+        bucket                      = "bb-apps-prd-terraform-backend-replica"
+        bucket_domain_name          = "bb-apps-prd-terraform-backend-replica.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-apps-prd-terraform-backend-replica.s3.us-east-2.amazonaws.com"
+        hosted_zone_id              = "Z2O1EMRO9K5GLX"
+        id                          = "bb-apps-prd-terraform-backend-replica"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-apps-prd-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-2"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "apps-prd"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "apps-prd"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "7103b9199553c430c90df5b3be171ec9cf8692eab196a82d4b2750b312cf42ab"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.bucket_replication[0] will be imported
+    resource "aws_s3_bucket_policy" "bucket_replication" {
+        bucket = "bb-apps-prd-terraform-backend-replica"
+        id     = "bb-apps-prd-terraform-backend-replica"
+        policy = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-apps-prd-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_policy.default[0] will be imported
+    resource "aws_s3_bucket_policy" "default" {
+        bucket = "bb-apps-prd-terraform-backend"
+        id     = "bb-apps-prd-terraform-backend"
+        policy = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-apps-prd-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.default will be imported
+    resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-apps-prd-terraform-backend"
+        id                      = "bb-apps-prd-terraform-backend"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_public_access_block.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-apps-prd-terraform-backend-replica"
+        id                      = "bb-apps-prd-terraform-backend-replica"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_replication_configuration.this[0] will be created
+  + resource "aws_s3_bucket_replication_configuration" "this" {
+      + bucket = "bb-apps-prd-terraform-backend"
+      + id     = (known after apply)
+      + role   = "arn:aws:iam::802787198489:role/bb-apps-prd-terraform-backend-bucket-replication"
+
+      + rule {
+          + id     = "standard_bucket_replication"
+          + status = "Enabled"
+
+          + destination {
+              + bucket        = "arn:aws:s3:::bb-apps-prd-terraform-backend-replica"
+              + storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.default will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+        bucket = "bb-apps-prd-terraform-backend"
+        id     = "bb-apps-prd-terraform-backend"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+        bucket = "bb-apps-prd-terraform-backend-replica"
+        id     = "bb-apps-prd-terraform-backend-replica"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.default will be imported
+    resource "aws_s3_bucket_versioning" "default" {
+        bucket = "bb-apps-prd-terraform-backend"
+        id     = "bb-apps-prd-terraform-backend"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].aws_s3_bucket_versioning.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_versioning" "replication_bucket" {
+        bucket = "bb-apps-prd-terraform-backend-replica"
+        id     = "bb-apps-prd-terraform-backend-replica"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["apps-prd"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+  # module.base_tf_backend["data-science"].aws_dynamodb_table.without_server_side_encryption[0] will be imported
+    resource "aws_dynamodb_table" "without_server_side_encryption" {
+        arn                         = "arn:aws:dynamodb:us-east-1:905418344519:table/bb-data-science-terraform-backend"
+        billing_mode                = "PROVISIONED"
+        deletion_protection_enabled = false
+        hash_key                    = "LockID"
+        id                          = "bb-data-science-terraform-backend"
+        name                        = "bb-data-science-terraform-backend"
+        read_capacity               = 5
+        stream_enabled              = false
+        table_class                 = "STANDARD"
+        tags                        = {
+            "Environment" = "data-science"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "data-science"
+            "Terraform"   = "true"
+        }
+        write_capacity              = 5
+
+        attribute {
+            name = "LockID"
+            type = "S"
+        }
+
+        point_in_time_recovery {
+            enabled                 = false
+            recovery_period_in_days = 0
+        }
+
+        ttl {
+            enabled = false
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_iam_policy.bucket_replication[0] will be imported
+    resource "aws_iam_policy" "bucket_replication" {
+        arn              = "arn:aws:iam::905418344519:policy/bb-data-science-terraform-backend-bucket-replication"
+        attachment_count = 1
+        id               = "arn:aws:iam::905418344519:policy/bb-data-science-terraform-backend-bucket-replication"
+        name             = "bb-data-science-terraform-backend-bucket-replication"
+        path             = "/"
+        policy           = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action   = [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-data-science-terraform-backend"
+                        Sid      = "1"
+                    },
+                    {
+                        Action   = [
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersion",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-data-science-terraform-backend/*"
+                        Sid      = "2"
+                    },
+                    {
+                        Action   = [
+                            "s3:ReplicateTags",
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-data-science-terraform-backend-replica/*"
+                        Sid      = "6"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        policy_id        = "ANPA5FTZDRBDXBFOWKUYQ"
+        tags             = {}
+        tags_all         = {}
+    }
+
+  # module.base_tf_backend["data-science"].aws_iam_role.bucket_replication[0] will be imported
+    resource "aws_iam_role" "bucket_replication" {
+        arn                   = "arn:aws:iam::905418344519:role/bb-data-science-terraform-backend-bucket-replication"
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        create_date           = "2024-04-29T20:29:22Z"
+        force_detach_policies = false
+        id                    = "bb-data-science-terraform-backend-bucket-replication"
+        managed_policy_arns   = [
+            "arn:aws:iam::905418344519:policy/bb-data-science-terraform-backend-bucket-replication",
+        ]
+        max_session_duration  = 3600
+        name                  = "bb-data-science-terraform-backend-bucket-replication"
+        path                  = "/"
+        tags                  = {}
+        tags_all              = {}
+        unique_id             = "AROA5FTZDRBDRWGS32PIA"
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket.default will be imported
+    resource "aws_s3_bucket" "default" {
+        arn                         = "arn:aws:s3:::bb-data-science-terraform-backend"
+        bucket                      = "bb-data-science-terraform-backend"
+        bucket_domain_name          = "bb-data-science-terraform-backend.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-data-science-terraform-backend.s3.us-east-1.amazonaws.com"
+        hosted_zone_id              = "Z3AQBSTGFYJSTF"
+        id                          = "bb-data-science-terraform-backend"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-data-science-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-1"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "data-science"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "data-science"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "f6ecfa7a9960b5b3290527d86afe6a38e66a7c92f1635b4bf7fc9f8b12d7a73b"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        replication_configuration {
+            role = "arn:aws:iam::905418344519:role/bb-data-science-terraform-backend-bucket-replication"
+
+            rules {
+                id       = "standard_bucket_replication"
+                priority = 0
+                status   = "Enabled"
+
+                destination {
+                    bucket        = "arn:aws:s3:::bb-data-science-terraform-backend-replica"
+                    storage_class = "STANDARD"
+                }
+            }
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket.replication_bucket[0] will be imported
+    resource "aws_s3_bucket" "replication_bucket" {
+        arn                         = "arn:aws:s3:::bb-data-science-terraform-backend-replica"
+        bucket                      = "bb-data-science-terraform-backend-replica"
+        bucket_domain_name          = "bb-data-science-terraform-backend-replica.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-data-science-terraform-backend-replica.s3.us-east-2.amazonaws.com"
+        hosted_zone_id              = "Z2O1EMRO9K5GLX"
+        id                          = "bb-data-science-terraform-backend-replica"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-data-science-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-2"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "data-science"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "data-science"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "f6ecfa7a9960b5b3290527d86afe6a38e66a7c92f1635b4bf7fc9f8b12d7a73b"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_policy.bucket_replication[0] will be imported
+    resource "aws_s3_bucket_policy" "bucket_replication" {
+        bucket = "bb-data-science-terraform-backend-replica"
+        id     = "bb-data-science-terraform-backend-replica"
+        policy = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-data-science-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_policy.default[0] will be imported
+    resource "aws_s3_bucket_policy" "default" {
+        bucket = "bb-data-science-terraform-backend"
+        id     = "bb-data-science-terraform-backend"
+        policy = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-data-science-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.default will be imported
+    resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-data-science-terraform-backend"
+        id                      = "bb-data-science-terraform-backend"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_public_access_block.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-data-science-terraform-backend-replica"
+        id                      = "bb-data-science-terraform-backend-replica"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_replication_configuration.this[0] will be created
+  + resource "aws_s3_bucket_replication_configuration" "this" {
+      + bucket = "bb-data-science-terraform-backend"
+      + id     = (known after apply)
+      + role   = "arn:aws:iam::905418344519:role/bb-data-science-terraform-backend-bucket-replication"
+
+      + rule {
+          + id     = "standard_bucket_replication"
+          + status = "Enabled"
+
+          + destination {
+              + bucket        = "arn:aws:s3:::bb-data-science-terraform-backend-replica"
+              + storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.default will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+        bucket = "bb-data-science-terraform-backend"
+        id     = "bb-data-science-terraform-backend"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+        bucket = "bb-data-science-terraform-backend-replica"
+        id     = "bb-data-science-terraform-backend-replica"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_versioning.default will be imported
+    resource "aws_s3_bucket_versioning" "default" {
+        bucket = "bb-data-science-terraform-backend"
+        id     = "bb-data-science-terraform-backend"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["data-science"].aws_s3_bucket_versioning.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_versioning" "replication_bucket" {
+        bucket = "bb-data-science-terraform-backend-replica"
+        id     = "bb-data-science-terraform-backend-replica"
+
+        versioning_configuration {
+            status = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["data-science"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+  # module.base_tf_backend["management"].data.aws_iam_policy_document.bucket_replication[0] will be read during apply
+  # (config refers to values not yet known)
+ <= data "aws_iam_policy_document" "bucket_replication" {
+      + id            = (known after apply)
+      + json          = (known after apply)
+      + minified_json = (known after apply)
+
+      + statement {
+          + actions   = [
+              + "s3:GetReplicationConfiguration",
+              + "s3:ListBucket",
+            ]
+          + effect    = "Allow"
+          + resources = [
+              + (known after apply),
+            ]
+          + sid       = "1"
+        }
+      + statement {
+          + actions   = [
+              + "s3:GetObjectVersion",
+              + "s3:GetObjectVersionAcl",
+              + "s3:GetObjectVersionForReplication",
+            ]
+          + effect    = "Allow"
+          + resources = [
+              + (known after apply),
+            ]
+          + sid       = "2"
+        }
+      + statement {
+          + actions   = [
+              + "s3:ReplicateDelete",
+              + "s3:ReplicateObject",
+              + "s3:ReplicateTags",
+            ]
+          + effect    = "Allow"
+          + resources = [
+              + (known after apply),
+            ]
+          + sid       = "6"
+        }
+    }
+
+  # module.base_tf_backend["management"].data.aws_iam_policy_document.default-ssl will be read during apply
+  # (config refers to values not yet known)
+ <= data "aws_iam_policy_document" "default-ssl" {
+      + id            = (known after apply)
+      + json          = (known after apply)
+      + minified_json = (known after apply)
+
+      + statement {
+          + actions   = [
+              + "s3:*",
+            ]
+          + effect    = "Deny"
+          + resources = [
+              + (known after apply),
+            ]
+          + sid       = "EnforceSSlRequestsOnly"
+
+          + condition {
+              + test     = "Bool"
+              + values   = [
+                  + "false",
+                ]
+              + variable = "aws:SecureTransport"
+            }
+
+          + principals {
+              + identifiers = [
+                  + "*",
+                ]
+              + type        = "AWS"
+            }
+        }
+    }
+
+  # module.base_tf_backend["management"].data.aws_iam_policy_document.default-ssl-vpc will be read during apply
+  # (config refers to values not yet known)
+ <= data "aws_iam_policy_document" "default-ssl-vpc" {
+      + id            = (known after apply)
+      + json          = (known after apply)
+      + minified_json = (known after apply)
+
+      + statement {
+          + actions   = [
+              + "s3:*",
+            ]
+          + effect    = "Deny"
+          + resources = [
+              + (known after apply),
+            ]
+          + sid       = "EnforceSSlRequestsOnly"
+
+          + condition {
+              + test     = "Bool"
+              + values   = [
+                  + "false",
+                ]
+              + variable = "aws:SecureTransport"
+            }
+
+          + principals {
+              + identifiers = [
+                  + "*",
+                ]
+              + type        = "AWS"
+            }
+        }
+      + statement {
+          + actions   = [
+              + "s3:*",
+            ]
+          + effect    = "Deny"
+          + resources = [
+              + (known after apply),
+              + (known after apply),
+            ]
+          + sid       = "EnforceVPCRequestsOnly"
+
+          + condition {
+              + test     = "StringNotEquals"
+              + values   = []
+              + variable = "aws:sourceVpc"
+            }
+
+          + principals {
+              + identifiers = [
+                  + "*",
+                ]
+              + type        = "AWS"
+            }
+        }
+    }
+
+  # module.base_tf_backend["management"].aws_dynamodb_table.without_server_side_encryption[0] will be created
+  + resource "aws_dynamodb_table" "without_server_side_encryption" {
+      + arn              = (known after apply)
+      + billing_mode     = "PROVISIONED"
+      + hash_key         = "LockID"
+      + id               = (known after apply)
+      + name             = "bb-management-terraform-backend"
+      + read_capacity    = 5
+      + stream_arn       = (known after apply)
+      + stream_label     = (known after apply)
+      + stream_view_type = (known after apply)
+      + tags             = {
+          + "Environment" = "management"
+          + "Terraform"   = "true"
+        }
+      + tags_all         = {
+          + "Environment" = "management"
+          + "Terraform"   = "true"
+        }
+      + write_capacity   = 5
+
+      + attribute {
+          + name = "LockID"
+          + type = "S"
+        }
+
+      + point_in_time_recovery {
+          + enabled                 = false
+          + recovery_period_in_days = (known after apply)
+        }
+
+      + server_side_encryption (known after apply)
+
+      + ttl (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_iam_policy.bucket_replication[0] must be replaced
+  # (imported from "arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_iam_policy" "bucket_replication" {
+      ~ arn              = "arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication" -> (known after apply)
+      ~ attachment_count = 1 -> (known after apply)
+      ~ id               = "arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication" -> (known after apply)
+      ~ name             = "bb-root-terraform-backend-bucket-replication" -> "bb-management-terraform-backend-bucket-replication" # forces replacement
+      + name_prefix      = (known after apply)
+        path             = "/"
+      ~ policy           = jsonencode(
+            {
+              - Statement = [
+                  - {
+                      - Action   = [
+                          - "s3:ListBucket",
+                          - "s3:GetReplicationConfiguration",
+                        ]
+                      - Effect   = "Allow"
+                      - Resource = "arn:aws:s3:::bb-root-terraform-backend"
+                      - Sid      = "1"
+                    },
+                  - {
+                      - Action   = [
+                          - "s3:GetObjectVersionForReplication",
+                          - "s3:GetObjectVersionAcl",
+                          - "s3:GetObjectVersion",
+                        ]
+                      - Effect   = "Allow"
+                      - Resource = "arn:aws:s3:::bb-root-terraform-backend/*"
+                      - Sid      = "2"
+                    },
+                  - {
+                      - Action   = [
+                          - "s3:ReplicateTags",
+                          - "s3:ReplicateObject",
+                          - "s3:ReplicateDelete",
+                        ]
+                      - Effect   = "Allow"
+                      - Resource = "arn:aws:s3:::bb-root-terraform-backend-replica/*"
+                      - Sid      = "6"
+                    },
+                ]
+              - Version   = "2012-10-17"
+            }
+        ) -> (known after apply)
+      ~ policy_id        = "ANPA27EOO2SHM7PIZIAOX" -> (known after apply)
+      - tags             = {} -> null
+      ~ tags_all         = {} -> (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_iam_role.bucket_replication[0] must be replaced
+  # (imported from "bb-root-terraform-backend-bucket-replication")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_iam_role" "bucket_replication" {
+      ~ arn                   = "arn:aws:iam::754065527950:role/bb-root-terraform-backend-bucket-replication" -> (known after apply)
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+      ~ create_date           = "2025-06-25T23:39:00Z" -> (known after apply)
+        force_detach_policies = false
+      ~ id                    = "bb-root-terraform-backend-bucket-replication" -> (known after apply)
+      ~ managed_policy_arns   = [
+          - "arn:aws:iam::754065527950:policy/bb-root-terraform-backend-bucket-replication",
+        ] -> (known after apply)
+        max_session_duration  = 3600
+      ~ name                  = "bb-root-terraform-backend-bucket-replication" -> "bb-management-terraform-backend-bucket-replication" # forces replacement
+      + name_prefix           = (known after apply)
+        path                  = "/"
+      - tags                  = {} -> null
+      ~ tags_all              = {} -> (known after apply)
+      ~ unique_id             = "AROA27EOO2SHB2K3AP57X" -> (known after apply)
+
+      ~ inline_policy {
+          + arn                   = (known after apply)
+          + assume_role_policy    = (known after apply)
+          + create_date           = (known after apply)
+          + description           = (known after apply)
+          + force_detach_policies = (known after apply)
+          + id                    = (known after apply)
+          + managed_policy_arns   = (known after apply)
+          + max_session_duration  = (known after apply)
+          + name                  = (known after apply)
+          + name_prefix           = (known after apply)
+          + path                  = (known after apply)
+          + permissions_boundary  = (known after apply)
+          + tags                  = (known after apply)
+          + tags_all              = (known after apply)
+          + unique_id             = (known after apply)
+        } -> (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket.default must be replaced
+  # (imported from "bb-root-terraform-backend")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket" "default" {
+      + acceleration_status         = (known after apply)
+      + acl                         = (known after apply)
+      ~ arn                         = "arn:aws:s3:::bb-root-terraform-backend" -> (known after apply)
+      ~ bucket                      = "bb-root-terraform-backend" -> "bb-management-terraform-backend" # forces replacement
+      ~ bucket_domain_name          = "bb-root-terraform-backend.s3.amazonaws.com" -> (known after apply)
+      + bucket_prefix               = (known after apply)
+      ~ bucket_regional_domain_name = "bb-root-terraform-backend.s3.us-east-1.amazonaws.com" -> (known after apply)
+      + force_destroy               = false
+      ~ hosted_zone_id              = "Z3AQBSTGFYJSTF" -> (known after apply)
+      ~ id                          = "bb-root-terraform-backend" -> (known after apply)
+      ~ object_lock_enabled         = false -> (known after apply)
+      ~ policy                      = jsonencode(
+            {
+              - Statement = [
+                  - {
+                      - Action    = "s3:*"
+                      - Condition = {
+                          - Bool = {
+                              - "aws:SecureTransport" = "false"
+                            }
+                        }
+                      - Effect    = "Deny"
+                      - Principal = {
+                          - AWS = "*"
+                        }
+                      - Resource  = "arn:aws:s3:::bb-root-terraform-backend/*"
+                      - Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+              - Version   = "2012-10-17"
+            }
+        ) -> (known after apply)
+      ~ region                      = "us-east-1" -> (known after apply)
+      ~ request_payer               = "BucketOwner" -> (known after apply)
+      ~ tags                        = {
+          ~ "Environment" = "root" -> "management"
+            "Terraform"   = "true"
+        }
+      ~ tags_all                    = {
+          ~ "Environment" = "root" -> "management"
+            "Terraform"   = "true"
+        }
+      + website_domain              = (known after apply)
+      + website_endpoint            = (known after apply)
+
+      ~ cors_rule {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ grant {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ lifecycle_rule {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ logging {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ object_lock_configuration {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ replication_configuration {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ server_side_encryption_configuration {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ versioning {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ website {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket.replication_bucket[0] must be replaced
+  # (imported from "bb-root-terraform-backend-replica")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket" "replication_bucket" {
+      + acceleration_status         = (known after apply)
+      + acl                         = (known after apply)
+      ~ arn                         = "arn:aws:s3:::bb-root-terraform-backend-replica" -> (known after apply)
+      ~ bucket                      = "bb-root-terraform-backend-replica" -> "bb-management-terraform-backend-replica" # forces replacement
+      ~ bucket_domain_name          = "bb-root-terraform-backend-replica.s3.amazonaws.com" -> (known after apply)
+      + bucket_prefix               = (known after apply)
+      ~ bucket_regional_domain_name = "bb-root-terraform-backend-replica.s3.us-east-2.amazonaws.com" -> (known after apply)
+      + force_destroy               = false
+      ~ hosted_zone_id              = "Z2O1EMRO9K5GLX" -> (known after apply)
+      ~ id                          = "bb-root-terraform-backend-replica" -> (known after apply)
+      ~ object_lock_enabled         = false -> (known after apply)
+      ~ policy                      = jsonencode(
+            {
+              - Id        = "TerraformStateBucketPolicies"
+              - Statement = [
+                  - {
+                      - Action    = "s3:*"
+                      - Condition = {
+                          - Bool = {
+                              - "aws:SecureTransport" = "false"
+                            }
+                        }
+                      - Effect    = "Deny"
+                      - Principal = "*"
+                      - Resource  = "arn:aws:s3:::bb-root-terraform-backend-replica/*"
+                      - Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+              - Version   = "2012-10-17"
+            }
+        ) -> (known after apply)
+      ~ region                      = "us-east-2" -> (known after apply)
+      ~ request_payer               = "BucketOwner" -> (known after apply)
+      ~ tags                        = {
+          ~ "Environment" = "root" -> "management"
+            "Terraform"   = "true"
+        }
+      ~ tags_all                    = {
+          ~ "Environment" = "root" -> "management"
+            "Terraform"   = "true"
+        }
+      + website_domain              = (known after apply)
+      + website_endpoint            = (known after apply)
+
+      ~ cors_rule {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ grant {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ lifecycle_rule {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ logging {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ object_lock_configuration {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ replication_configuration {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ server_side_encryption_configuration {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ versioning {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+
+      ~ website {
+          + acceleration_status         = (known after apply)
+          + acl                         = (known after apply)
+          + arn                         = (known after apply)
+          + bucket                      = (known after apply)
+          + bucket_domain_name          = (known after apply)
+          + bucket_prefix               = (known after apply)
+          + bucket_regional_domain_name = (known after apply)
+          + force_destroy               = (known after apply)
+          + hosted_zone_id              = (known after apply)
+          + id                          = (known after apply)
+          + object_lock_enabled         = (known after apply)
+          + policy                      = (known after apply)
+          + region                      = (known after apply)
+          + request_payer               = (known after apply)
+          + tags                        = (known after apply)
+          + tags_all                    = (known after apply)
+          + website_domain              = (known after apply)
+          + website_endpoint            = (known after apply)
+        } -> (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_policy.bucket_replication[0] must be replaced
+  # (imported from "bb-root-terraform-backend-replica")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_policy" "bucket_replication" {
+      ~ bucket = "bb-root-terraform-backend-replica" # forces replacement -> (known after apply) # forces replacement
+      ~ id     = "bb-root-terraform-backend-replica" -> (known after apply)
+      ~ policy = jsonencode(
+            {
+              - Id        = "TerraformStateBucketPolicies"
+              - Statement = [
+                  - {
+                      - Action    = "s3:*"
+                      - Condition = {
+                          - Bool = {
+                              - "aws:SecureTransport" = "false"
+                            }
+                        }
+                      - Effect    = "Deny"
+                      - Principal = "*"
+                      - Resource  = "arn:aws:s3:::bb-root-terraform-backend-replica/*"
+                      - Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+              - Version   = "2012-10-17"
+            }
+        ) -> (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_policy.default[0] must be replaced
+  # (imported from "bb-root-terraform-backend")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_policy" "default" {
+      ~ bucket = "bb-root-terraform-backend" # forces replacement -> (known after apply) # forces replacement
+      ~ id     = "bb-root-terraform-backend" -> (known after apply)
+      ~ policy = jsonencode(
+            {
+              - Statement = [
+                  - {
+                      - Action    = "s3:*"
+                      - Condition = {
+                          - Bool = {
+                              - "aws:SecureTransport" = "false"
+                            }
+                        }
+                      - Effect    = "Deny"
+                      - Principal = {
+                          - AWS = "*"
+                        }
+                      - Resource  = "arn:aws:s3:::bb-root-terraform-backend/*"
+                      - Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+              - Version   = "2012-10-17"
+            }
+        ) -> (known after apply)
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_public_access_block.default must be replaced
+  # (imported from "bb-root-terraform-backend")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+      ~ bucket                  = "bb-root-terraform-backend" # forces replacement -> (known after apply) # forces replacement
+      ~ id                      = "bb-root-terraform-backend" -> (known after apply)
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_public_access_block.replication_bucket[0] must be replaced
+  # (imported from "bb-root-terraform-backend-replica")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+      ~ bucket                  = "bb-root-terraform-backend-replica" # forces replacement -> (known after apply) # forces replacement
+      ~ id                      = "bb-root-terraform-backend-replica" -> (known after apply)
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_replication_configuration.this[0] will be created
+  + resource "aws_s3_bucket_replication_configuration" "this" {
+      + bucket = (known after apply)
+      + id     = (known after apply)
+      + role   = (known after apply)
+
+      + rule {
+          + id     = "standard_bucket_replication"
+          + status = "Enabled"
+
+          + destination {
+              + bucket        = (known after apply)
+              + storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.default must be replaced
+  # (imported from "bb-root-terraform-backend")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+      ~ bucket = "bb-root-terraform-backend" -> "bb-management-terraform-backend" # forces replacement
+      ~ id     = "bb-root-terraform-backend" -> (known after apply)
+
+      - rule {
+          - bucket_key_enabled = false -> null
+
+          - apply_server_side_encryption_by_default {
+              - sse_algorithm = "AES256" -> null
+            }
+        }
+      + rule {
+          + apply_server_side_encryption_by_default {
+              + sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] must be replaced
+  # (imported from "bb-root-terraform-backend-replica")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+      ~ bucket = "bb-root-terraform-backend-replica" # forces replacement -> (known after apply) # forces replacement
+      ~ id     = "bb-root-terraform-backend-replica" -> (known after apply)
+
+      - rule {
+          - bucket_key_enabled = false -> null
+
+          - apply_server_side_encryption_by_default {
+              - sse_algorithm = "AES256" -> null
+            }
+        }
+      + rule {
+          + apply_server_side_encryption_by_default {
+              + sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_versioning.default must be replaced
+  # (imported from "bb-root-terraform-backend")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_versioning" "default" {
+      ~ bucket = "bb-root-terraform-backend" # forces replacement -> (known after apply) # forces replacement
+      ~ id     = "bb-root-terraform-backend" -> (known after apply)
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["management"].aws_s3_bucket_versioning.replication_bucket[0] must be replaced
+  # (imported from "bb-root-terraform-backend-replica")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_s3_bucket_versioning" "replication_bucket" {
+      ~ bucket = "bb-root-terraform-backend-replica" # forces replacement -> (known after apply) # forces replacement
+      ~ id     = "bb-root-terraform-backend-replica" -> (known after apply)
+
+      ~ versioning_configuration {
+          ~ mfa_delete = "Disabled" -> (known after apply)
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["management"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+  # module.base_tf_backend["network"].aws_dynamodb_table.without_server_side_encryption[0] will be imported
+    resource "aws_dynamodb_table" "without_server_side_encryption" {
+        arn                         = "arn:aws:dynamodb:us-east-1:822280187662:table/bb-network-terraform-backend"
+        billing_mode                = "PROVISIONED"
+        deletion_protection_enabled = false
+        hash_key                    = "LockID"
+        id                          = "bb-network-terraform-backend"
+        name                        = "bb-network-terraform-backend"
+        read_capacity               = 5
+        stream_enabled              = false
+        table_class                 = "STANDARD"
+        tags                        = {
+            "Environment" = "network"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "network"
+            "Terraform"   = "true"
+        }
+        write_capacity              = 5
+
+        attribute {
+            name = "LockID"
+            type = "S"
+        }
+
+        point_in_time_recovery {
+            enabled                 = false
+            recovery_period_in_days = 0
+        }
+
+        ttl {
+            enabled = false
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_iam_policy.bucket_replication[0] will be imported
+    resource "aws_iam_policy" "bucket_replication" {
+        arn              = "arn:aws:iam::822280187662:policy/bb-network-terraform-backend-bucket-replication"
+        attachment_count = 1
+        id               = "arn:aws:iam::822280187662:policy/bb-network-terraform-backend-bucket-replication"
+        name             = "bb-network-terraform-backend-bucket-replication"
+        path             = "/"
+        policy           = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action   = [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-network-terraform-backend"
+                        Sid      = "1"
+                    },
+                    {
+                        Action   = [
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersion",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-network-terraform-backend/*"
+                        Sid      = "2"
+                    },
+                    {
+                        Action   = [
+                            "s3:ReplicateTags",
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-network-terraform-backend-replica/*"
+                        Sid      = "6"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        policy_id        = "ANPA3645X54HKGJW2MB4W"
+        tags             = {}
+        tags_all         = {}
+    }
+
+  # module.base_tf_backend["network"].aws_iam_role.bucket_replication[0] will be imported
+    resource "aws_iam_role" "bucket_replication" {
+        arn                   = "arn:aws:iam::822280187662:role/bb-network-terraform-backend-bucket-replication"
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        create_date           = "2025-06-21T14:15:13Z"
+        force_detach_policies = false
+        id                    = "bb-network-terraform-backend-bucket-replication"
+        managed_policy_arns   = [
+            "arn:aws:iam::822280187662:policy/bb-network-terraform-backend-bucket-replication",
+        ]
+        max_session_duration  = 3600
+        name                  = "bb-network-terraform-backend-bucket-replication"
+        path                  = "/"
+        tags                  = {}
+        tags_all              = {}
+        unique_id             = "AROA3645X54HOORYQDRCW"
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket.default will be imported
+    resource "aws_s3_bucket" "default" {
+        arn                         = "arn:aws:s3:::bb-network-terraform-backend"
+        bucket                      = "bb-network-terraform-backend"
+        bucket_domain_name          = "bb-network-terraform-backend.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-network-terraform-backend.s3.us-east-1.amazonaws.com"
+        hosted_zone_id              = "Z3AQBSTGFYJSTF"
+        id                          = "bb-network-terraform-backend"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-network-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-1"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "network"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "network"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "02b3a527febda61098dd997caa7d1c8c35f5e0b842cc1db4b681897d3c1248f8"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        replication_configuration {
+            role = "arn:aws:iam::822280187662:role/bb-network-terraform-backend-bucket-replication"
+
+            rules {
+                id       = "standard_bucket_replication"
+                priority = 0
+                status   = "Enabled"
+
+                destination {
+                    bucket        = "arn:aws:s3:::bb-network-terraform-backend-replica"
+                    storage_class = "STANDARD"
+                }
+            }
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket.replication_bucket[0] will be imported
+    resource "aws_s3_bucket" "replication_bucket" {
+        arn                         = "arn:aws:s3:::bb-network-terraform-backend-replica"
+        bucket                      = "bb-network-terraform-backend-replica"
+        bucket_domain_name          = "bb-network-terraform-backend-replica.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-network-terraform-backend-replica.s3.us-east-2.amazonaws.com"
+        hosted_zone_id              = "Z2O1EMRO9K5GLX"
+        id                          = "bb-network-terraform-backend-replica"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-network-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-2"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "network"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "network"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "02b3a527febda61098dd997caa7d1c8c35f5e0b842cc1db4b681897d3c1248f8"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_policy.bucket_replication[0] will be imported
+    resource "aws_s3_bucket_policy" "bucket_replication" {
+        bucket = "bb-network-terraform-backend-replica"
+        id     = "bb-network-terraform-backend-replica"
+        policy = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-network-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_policy.default[0] will be imported
+    resource "aws_s3_bucket_policy" "default" {
+        bucket = "bb-network-terraform-backend"
+        id     = "bb-network-terraform-backend"
+        policy = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-network-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_public_access_block.default will be imported
+    resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-network-terraform-backend"
+        id                      = "bb-network-terraform-backend"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_public_access_block.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-network-terraform-backend-replica"
+        id                      = "bb-network-terraform-backend-replica"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_replication_configuration.this[0] will be created
+  + resource "aws_s3_bucket_replication_configuration" "this" {
+      + bucket = "bb-network-terraform-backend"
+      + id     = (known after apply)
+      + role   = "arn:aws:iam::822280187662:role/bb-network-terraform-backend-bucket-replication"
+
+      + rule {
+          + id     = "standard_bucket_replication"
+          + status = "Enabled"
+
+          + destination {
+              + bucket        = "arn:aws:s3:::bb-network-terraform-backend-replica"
+              + storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.default will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+        bucket = "bb-network-terraform-backend"
+        id     = "bb-network-terraform-backend"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+        bucket = "bb-network-terraform-backend-replica"
+        id     = "bb-network-terraform-backend-replica"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_versioning.default will be imported
+    resource "aws_s3_bucket_versioning" "default" {
+        bucket = "bb-network-terraform-backend"
+        id     = "bb-network-terraform-backend"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["network"].aws_s3_bucket_versioning.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_versioning" "replication_bucket" {
+        bucket = "bb-network-terraform-backend-replica"
+        id     = "bb-network-terraform-backend-replica"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["network"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+  # module.base_tf_backend["security"].aws_dynamodb_table.without_server_side_encryption[0] will be imported
+    resource "aws_dynamodb_table" "without_server_side_encryption" {
+        arn                         = "arn:aws:dynamodb:us-east-1:900980591242:table/bb-security-terraform-backend"
+        billing_mode                = "PROVISIONED"
+        deletion_protection_enabled = false
+        hash_key                    = "LockID"
+        id                          = "bb-security-terraform-backend"
+        name                        = "bb-security-terraform-backend"
+        read_capacity               = 5
+        stream_enabled              = false
+        table_class                 = "STANDARD"
+        tags                        = {
+            "Environment" = "security"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "security"
+            "Terraform"   = "true"
+        }
+        write_capacity              = 5
+
+        attribute {
+            name = "LockID"
+            type = "S"
+        }
+
+        point_in_time_recovery {
+            enabled                 = false
+            recovery_period_in_days = 0
+        }
+
+        ttl {
+            enabled = false
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_iam_policy.bucket_replication[0] will be imported
+    resource "aws_iam_policy" "bucket_replication" {
+        arn              = "arn:aws:iam::900980591242:policy/bb-security-terraform-backend-bucket-replication"
+        attachment_count = 1
+        id               = "arn:aws:iam::900980591242:policy/bb-security-terraform-backend-bucket-replication"
+        name             = "bb-security-terraform-backend-bucket-replication"
+        path             = "/"
+        policy           = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action   = [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-security-terraform-backend"
+                        Sid      = "1"
+                    },
+                    {
+                        Action   = [
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersion",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-security-terraform-backend/*"
+                        Sid      = "2"
+                    },
+                    {
+                        Action   = [
+                            "s3:ReplicateTags",
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                        ]
+                        Effect   = "Allow"
+                        Resource = "arn:aws:s3:::bb-security-terraform-backend-replica/*"
+                        Sid      = "6"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        policy_id        = "ANPA5DRVAZKFOQQ5EFZI4"
+        tags             = {}
+        tags_all         = {}
+    }
+
+  # module.base_tf_backend["security"].aws_iam_role.bucket_replication[0] will be imported
+    resource "aws_iam_role" "bucket_replication" {
+        arn                   = "arn:aws:iam::900980591242:role/bb-security-terraform-backend-bucket-replication"
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        create_date           = "2025-06-13T23:52:22Z"
+        force_detach_policies = false
+        id                    = "bb-security-terraform-backend-bucket-replication"
+        managed_policy_arns   = [
+            "arn:aws:iam::900980591242:policy/bb-security-terraform-backend-bucket-replication",
+        ]
+        max_session_duration  = 3600
+        name                  = "bb-security-terraform-backend-bucket-replication"
+        path                  = "/"
+        tags                  = {}
+        tags_all              = {}
+        unique_id             = "AROA5DRVAZKFCFCLWBO4X"
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket.default will be imported
+    resource "aws_s3_bucket" "default" {
+        arn                         = "arn:aws:s3:::bb-security-terraform-backend"
+        bucket                      = "bb-security-terraform-backend"
+        bucket_domain_name          = "bb-security-terraform-backend.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-security-terraform-backend.s3.us-east-1.amazonaws.com"
+        hosted_zone_id              = "Z3AQBSTGFYJSTF"
+        id                          = "bb-security-terraform-backend"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-security-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-1"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "security"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "security"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "dec403a9fd9b9964897cc9b0b57c868533fcd0df80c5e8dc9d53db63842d9d36"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        replication_configuration {
+            role = "arn:aws:iam::900980591242:role/bb-security-terraform-backend-bucket-replication"
+
+            rules {
+                id       = "standard_bucket_replication"
+                priority = 0
+                status   = "Enabled"
+
+                destination {
+                    bucket        = "arn:aws:s3:::bb-security-terraform-backend-replica"
+                    storage_class = "STANDARD"
+                }
+            }
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket.replication_bucket[0] will be imported
+    resource "aws_s3_bucket" "replication_bucket" {
+        arn                         = "arn:aws:s3:::bb-security-terraform-backend-replica"
+        bucket                      = "bb-security-terraform-backend-replica"
+        bucket_domain_name          = "bb-security-terraform-backend-replica.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-security-terraform-backend-replica.s3.us-east-2.amazonaws.com"
+        hosted_zone_id              = "Z2O1EMRO9K5GLX"
+        id                          = "bb-security-terraform-backend-replica"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-security-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-2"
+        request_payer               = "BucketOwner"
+        tags                        = {
+            "Environment" = "security"
+            "Terraform"   = "true"
+        }
+        tags_all                    = {
+            "Environment" = "security"
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "dec403a9fd9b9964897cc9b0b57c868533fcd0df80c5e8dc9d53db63842d9d36"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_policy.bucket_replication[0] will be imported
+    resource "aws_s3_bucket_policy" "bucket_replication" {
+        bucket = "bb-security-terraform-backend-replica"
+        id     = "bb-security-terraform-backend-replica"
+        policy = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-security-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_policy.default[0] will be imported
+    resource "aws_s3_bucket_policy" "default" {
+        bucket = "bb-security-terraform-backend"
+        id     = "bb-security-terraform-backend"
+        policy = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-security-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_public_access_block.default will be imported
+    resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-security-terraform-backend"
+        id                      = "bb-security-terraform-backend"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_public_access_block.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-security-terraform-backend-replica"
+        id                      = "bb-security-terraform-backend-replica"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_replication_configuration.this[0] will be created
+  + resource "aws_s3_bucket_replication_configuration" "this" {
+      + bucket = "bb-security-terraform-backend"
+      + id     = (known after apply)
+      + role   = "arn:aws:iam::900980591242:role/bb-security-terraform-backend-bucket-replication"
+
+      + rule {
+          + id     = "standard_bucket_replication"
+          + status = "Enabled"
+
+          + destination {
+              + bucket        = "arn:aws:s3:::bb-security-terraform-backend-replica"
+              + storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.default will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+        bucket = "bb-security-terraform-backend"
+        id     = "bb-security-terraform-backend"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+        bucket = "bb-security-terraform-backend-replica"
+        id     = "bb-security-terraform-backend-replica"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_versioning.default will be imported
+    resource "aws_s3_bucket_versioning" "default" {
+        bucket = "bb-security-terraform-backend"
+        id     = "bb-security-terraform-backend"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["security"].aws_s3_bucket_versioning.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_versioning" "replication_bucket" {
+        bucket = "bb-security-terraform-backend-replica"
+        id     = "bb-security-terraform-backend-replica"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["security"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+  # module.base_tf_backend["shared"].data.aws_iam_policy_document.bucket_replication[0] will be read during apply
+  # (depends on a resource or a module with changes pending)
+ <= data "aws_iam_policy_document" "bucket_replication" {
+      + id            = (known after apply)
+      + json          = (known after apply)
+      + minified_json = (known after apply)
+
+      + statement {
+          + actions   = [
+              + "s3:GetReplicationConfiguration",
+              + "s3:ListBucket",
+            ]
+          + effect    = "Allow"
+          + resources = [
+              + "arn:aws:s3:::bb-shared-terraform-backend",
+            ]
+          + sid       = "1"
+        }
+      + statement {
+          + actions   = [
+              + "s3:GetObjectVersion",
+              + "s3:GetObjectVersionAcl",
+              + "s3:GetObjectVersionForReplication",
+            ]
+          + effect    = "Allow"
+          + resources = [
+              + "arn:aws:s3:::bb-shared-terraform-backend/*",
+            ]
+          + sid       = "2"
+        }
+      + statement {
+          + actions   = [
+              + "s3:ReplicateDelete",
+              + "s3:ReplicateObject",
+              + "s3:ReplicateTags",
+            ]
+          + effect    = "Allow"
+          + resources = [
+              + "arn:aws:s3:::bb-shared-terraform-backend-replica/*",
+            ]
+          + sid       = "6"
+        }
+    }
+
+  # module.base_tf_backend["shared"].data.aws_iam_policy_document.default-ssl will be read during apply
+  # (depends on a resource or a module with changes pending)
+ <= data "aws_iam_policy_document" "default-ssl" {
+      + id            = (known after apply)
+      + json          = (known after apply)
+      + minified_json = (known after apply)
+
+      + statement {
+          + actions   = [
+              + "s3:*",
+            ]
+          + effect    = "Deny"
+          + resources = [
+              + "arn:aws:s3:::bb-shared-terraform-backend/*",
+            ]
+          + sid       = "EnforceSSlRequestsOnly"
+
+          + condition {
+              + test     = "Bool"
+              + values   = [
+                  + "false",
+                ]
+              + variable = "aws:SecureTransport"
+            }
+
+          + principals {
+              + identifiers = [
+                  + "*",
+                ]
+              + type        = "AWS"
+            }
+        }
+    }
+
+  # module.base_tf_backend["shared"].data.aws_iam_policy_document.default-ssl-vpc will be read during apply
+  # (depends on a resource or a module with changes pending)
+ <= data "aws_iam_policy_document" "default-ssl-vpc" {
+      + id            = (known after apply)
+      + json          = (known after apply)
+      + minified_json = (known after apply)
+
+      + statement {
+          + actions   = [
+              + "s3:*",
+            ]
+          + effect    = "Deny"
+          + resources = [
+              + "arn:aws:s3:::bb-shared-terraform-backend/*",
+            ]
+          + sid       = "EnforceSSlRequestsOnly"
+
+          + condition {
+              + test     = "Bool"
+              + values   = [
+                  + "false",
+                ]
+              + variable = "aws:SecureTransport"
+            }
+
+          + principals {
+              + identifiers = [
+                  + "*",
+                ]
+              + type        = "AWS"
+            }
+        }
+      + statement {
+          + actions   = [
+              + "s3:*",
+            ]
+          + effect    = "Deny"
+          + resources = [
+              + "arn:aws:s3:::bb-shared-terraform-backend",
+              + "arn:aws:s3:::bb-shared-terraform-backend/*",
+            ]
+          + sid       = "EnforceVPCRequestsOnly"
+
+          + condition {
+              + test     = "StringNotEquals"
+              + values   = []
+              + variable = "aws:sourceVpc"
+            }
+
+          + principals {
+              + identifiers = [
+                  + "*",
+                ]
+              + type        = "AWS"
+            }
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_dynamodb_table.without_server_side_encryption[0] will be updated in-place
+  # (imported from "bb-shared-terraform-backend")
+  ~ resource "aws_dynamodb_table" "without_server_side_encryption" {
+        arn                         = "arn:aws:dynamodb:us-east-1:763606934258:table/bb-shared-terraform-backend"
+        billing_mode                = "PROVISIONED"
+        deletion_protection_enabled = false
+        hash_key                    = "LockID"
+        id                          = "bb-shared-terraform-backend"
+        name                        = "bb-shared-terraform-backend"
+        read_capacity               = 5
+        stream_enabled              = false
+        table_class                 = "STANDARD"
+      ~ tags                        = {
+            "Environment" = "shared"
+          - "Layer"       = "base-tf-backend" -> null
+            "Terraform"   = "true"
+        }
+      ~ tags_all                    = {
+            "Environment" = "shared"
+          - "Layer"       = "base-tf-backend" -> null
+            "Terraform"   = "true"
+        }
+        write_capacity              = 5
+
+        attribute {
+            name = "LockID"
+            type = "S"
+        }
+
+        point_in_time_recovery {
+            enabled                 = false
+            recovery_period_in_days = 0
+        }
+
+        ttl {
+            enabled = false
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_iam_role.bucket_replication[0] must be replaced
+  # (imported from "bb-shared-terraform-backend-bucket-replication-module")
+  # Warning: this will destroy the imported resource
+-/+ resource "aws_iam_role" "bucket_replication" {
+      ~ arn                   = "arn:aws:iam::763606934258:role/bb-shared-terraform-backend-bucket-replication-module" -> (known after apply)
+        assume_role_policy    = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "sts:AssumeRole"
+                        Effect    = "Allow"
+                        Principal = {
+                            Service = "s3.amazonaws.com"
+                        }
+                        Sid       = ""
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+      ~ create_date           = "2020-07-17T18:31:02Z" -> (known after apply)
+        force_detach_policies = false
+      ~ id                    = "bb-shared-terraform-backend-bucket-replication-module" -> (known after apply)
+      ~ managed_policy_arns   = [
+          - "arn:aws:iam::763606934258:policy/bb-shared-terraform-backend-bucket-replication-module",
+        ] -> (known after apply)
+        max_session_duration  = 3600
+      ~ name                  = "bb-shared-terraform-backend-bucket-replication-module" -> "bb-shared-terraform-backend-bucket-replication" # forces replacement
+      + name_prefix           = (known after apply)
+        path                  = "/"
+      - tags                  = {} -> null
+      ~ tags_all              = {} -> (known after apply)
+      ~ unique_id             = "AROA3DSUFELZMBMZLSMFR" -> (known after apply)
+
+      ~ inline_policy {
+          + arn                   = (known after apply)
+          + assume_role_policy    = (known after apply)
+          + create_date           = (known after apply)
+          + description           = (known after apply)
+          + force_detach_policies = (known after apply)
+          + id                    = (known after apply)
+          + managed_policy_arns   = (known after apply)
+          + max_session_duration  = (known after apply)
+          + name                  = (known after apply)
+          + name_prefix           = (known after apply)
+          + path                  = (known after apply)
+          + permissions_boundary  = (known after apply)
+          + tags                  = (known after apply)
+          + tags_all              = (known after apply)
+          + unique_id             = (known after apply)
+        } -> (known after apply)
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket.default will be updated in-place
+  # (imported from "bb-shared-terraform-backend")
+  ~ resource "aws_s3_bucket" "default" {
+        arn                         = "arn:aws:s3:::bb-shared-terraform-backend"
+        bucket                      = "bb-shared-terraform-backend"
+        bucket_domain_name          = "bb-shared-terraform-backend.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-shared-terraform-backend.s3.us-east-1.amazonaws.com"
+      + force_destroy               = false
+        hosted_zone_id              = "Z3AQBSTGFYJSTF"
+        id                          = "bb-shared-terraform-backend"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = {
+                            AWS = "*"
+                        }
+                        Resource  = "arn:aws:s3:::bb-shared-terraform-backend/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-1"
+        request_payer               = "BucketOwner"
+      ~ tags                        = {
+            "Environment" = "shared"
+          - "Layer"       = "base-tf-backend" -> null
+            "Terraform"   = "true"
+        }
+      ~ tags_all                    = {
+            "Environment" = "shared"
+          - "Layer"       = "base-tf-backend" -> null
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "cbe5acb79da28f88a038a35aeb5abc79194b2cfee1ada0f9025eab91147c99fc"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        replication_configuration {
+            role = "arn:aws:iam::763606934258:role/bb-shared-terraform-backend-bucket-replication-module"
+
+            rules {
+                id       = "standard_bucket_replication"
+                priority = 0
+                status   = "Enabled"
+
+                destination {
+                    bucket        = "arn:aws:s3:::bb-shared-terraform-backend-replica"
+                    storage_class = "STANDARD"
+                }
+            }
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket.replication_bucket[0] will be updated in-place
+  # (imported from "bb-shared-terraform-backend-replica")
+  ~ resource "aws_s3_bucket" "replication_bucket" {
+        arn                         = "arn:aws:s3:::bb-shared-terraform-backend-replica"
+        bucket                      = "bb-shared-terraform-backend-replica"
+        bucket_domain_name          = "bb-shared-terraform-backend-replica.s3.amazonaws.com"
+        bucket_regional_domain_name = "bb-shared-terraform-backend-replica.s3.us-east-2.amazonaws.com"
+      + force_destroy               = false
+        hosted_zone_id              = "Z2O1EMRO9K5GLX"
+        id                          = "bb-shared-terraform-backend-replica"
+        object_lock_enabled         = false
+        policy                      = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-shared-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+        region                      = "us-east-2"
+        request_payer               = "BucketOwner"
+      ~ tags                        = {
+            "Environment" = "shared"
+          - "Layer"       = "base-tf-backend" -> null
+            "Terraform"   = "true"
+        }
+      ~ tags_all                    = {
+            "Environment" = "shared"
+          - "Layer"       = "base-tf-backend" -> null
+            "Terraform"   = "true"
+        }
+
+        grant {
+            id          = "cbe5acb79da28f88a038a35aeb5abc79194b2cfee1ada0f9025eab91147c99fc"
+            permissions = [
+                "FULL_CONTROL",
+            ]
+            type        = "CanonicalUser"
+        }
+
+        server_side_encryption_configuration {
+            rule {
+                bucket_key_enabled = false
+
+                apply_server_side_encryption_by_default {
+                    sse_algorithm = "AES256"
+                }
+            }
+        }
+
+        versioning {
+            enabled    = true
+            mfa_delete = false
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_policy.bucket_replication[0] will be imported
+    resource "aws_s3_bucket_policy" "bucket_replication" {
+        bucket = "bb-shared-terraform-backend-replica"
+        id     = "bb-shared-terraform-backend-replica"
+        policy = jsonencode(
+            {
+                Id        = "TerraformStateBucketPolicies"
+                Statement = [
+                    {
+                        Action    = "s3:*"
+                        Condition = {
+                            Bool = {
+                                "aws:SecureTransport" = "false"
+                            }
+                        }
+                        Effect    = "Deny"
+                        Principal = "*"
+                        Resource  = "arn:aws:s3:::bb-shared-terraform-backend-replica/*"
+                        Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+                Version   = "2012-10-17"
+            }
+        )
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_policy.default[0] will be updated in-place
+  # (imported from "bb-shared-terraform-backend")
+  ~ resource "aws_s3_bucket_policy" "default" {
+        bucket = "bb-shared-terraform-backend"
+        id     = "bb-shared-terraform-backend"
+      ~ policy = jsonencode(
+            {
+              - Statement = [
+                  - {
+                      - Action    = "s3:*"
+                      - Condition = {
+                          - Bool = {
+                              - "aws:SecureTransport" = "false"
+                            }
+                        }
+                      - Effect    = "Deny"
+                      - Principal = {
+                          - AWS = "*"
+                        }
+                      - Resource  = "arn:aws:s3:::bb-shared-terraform-backend/*"
+                      - Sid       = "EnforceSSlRequestsOnly"
+                    },
+                ]
+              - Version   = "2012-10-17"
+            }
+        ) -> (known after apply)
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.default will be imported
+    resource "aws_s3_bucket_public_access_block" "default" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-shared-terraform-backend"
+        id                      = "bb-shared-terraform-backend"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_public_access_block.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_public_access_block" "replication_bucket" {
+        block_public_acls       = true
+        block_public_policy     = true
+        bucket                  = "bb-shared-terraform-backend-replica"
+        id                      = "bb-shared-terraform-backend-replica"
+        ignore_public_acls      = true
+        restrict_public_buckets = true
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_replication_configuration.this[0] will be updated in-place
+  # (imported from "bb-shared-terraform-backend")
+  ~ resource "aws_s3_bucket_replication_configuration" "this" {
+        bucket = "bb-shared-terraform-backend"
+        id     = "bb-shared-terraform-backend"
+      ~ role   = "arn:aws:iam::763606934258:role/bb-shared-terraform-backend-bucket-replication-module" -> (known after apply)
+
+        rule {
+            id       = "standard_bucket_replication"
+            priority = 0
+            status   = "Enabled"
+
+            destination {
+                bucket        = "arn:aws:s3:::bb-shared-terraform-backend-replica"
+                storage_class = "STANDARD"
+            }
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.default will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+        bucket = "bb-shared-terraform-backend"
+        id     = "bb-shared-terraform-backend"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_server_side_encryption_configuration.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_server_side_encryption_configuration" "replication_bucket" {
+        bucket = "bb-shared-terraform-backend-replica"
+        id     = "bb-shared-terraform-backend-replica"
+
+        rule {
+            bucket_key_enabled = false
+
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_versioning.default will be imported
+    resource "aws_s3_bucket_versioning" "default" {
+        bucket = "bb-shared-terraform-backend"
+        id     = "bb-shared-terraform-backend"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["shared"].aws_s3_bucket_versioning.replication_bucket[0] will be imported
+    resource "aws_s3_bucket_versioning" "replication_bucket" {
+        bucket = "bb-shared-terraform-backend-replica"
+        id     = "bb-shared-terraform-backend-replica"
+
+        versioning_configuration {
+            mfa_delete = "Disabled"
+            status     = "Enabled"
+        }
+    }
+
+  # module.base_tf_backend["shared"].time_sleep.wait_30_secs must be replaced
+  # (imported from "30s,")
+  # Warning: this will destroy the imported resource
+-/+ resource "time_sleep" "wait_30_secs" {
+        create_duration = "30s"
+      ~ id              = "2025-10-01T16:42:57Z" -> (known after apply)
+      - triggers        = {} -> null # forces replacement
+    }
+
+Plan: 97 to import, 27 to add, 5 to change, 20 to destroy.
+
+Warning: Value for undeclared variable
+
+The root module does not declare a variable named "profile" but a value was found in file "/binbash/baseline/config/backend.tfvars". If you meant to use this value, add a "variable" block to the configuration.
+
+To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
+
+Warning: Value for undeclared variable
+
+The root module does not declare a variable named "encrypt" but a value was found in file "/binbash/baseline/config/backend.tfvars". If you meant to use this value, add a "variable" block to the configuration.
+
+To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
+
+Warning: Values for undeclared variables
+
+In addition to the other similar warnings shown, 3 other variable(s) defined without being declared.
+
+Warning: Argument is deprecated
+
+  with module.base_tf_backend["apps-prd"].aws_s3_bucket_replication_configuration.this[0],
+  on .terraform/modules/base_tf_backend/bucket_replication.tf line 39, in resource "aws_s3_bucket_replication_configuration" "this":
+  39:     prefix = ""
+
+prefix is deprecated. Use filter instead.
+
+(and 5 more similar warnings elsewhere)
+
+Warning: Invalid Attribute Combination
+
+  with module.base_tf_backend.aws_s3_bucket_lifecycle_configuration.replication_bucket,
+  on .terraform/modules/base_tf_backend/bucket_replication.tf line 89, in resource "aws_s3_bucket_lifecycle_configuration" "replication_bucket":
+  89: resource "aws_s3_bucket_lifecycle_configuration" "replication_bucket" {
+
+No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
+
+This will be an error in a future version of the provider
+
+(and 3 more similar warnings elsewhere)
+
+Error: Cannot import non-existent remote object
+
+While attempting to import an existing object to "module.base_tf_backend[\"shared\"].aws_iam_policy.bucket_replication[0]", the provider detected that no object exists with the given id. Only pre-existing objects can be imported; check that the id is correct and that it is associated with the provider's configured region or endpoint, or use "tofu apply" to create a new remote object for this resource.

--- a/baseline/base-tf-backend/runtime.tf
+++ b/baseline/base-tf-backend/runtime.tf
@@ -1,0 +1,202 @@
+locals {
+  # ===========================================
+  # STANDARD TAGS FOR ALL RESOURCES IN THIS LAYER
+  # -------------------------------------------
+  # Purpose: Provide a consistent tagging baseline across resources
+  # created by this module. These are merged with per-resource tags
+  # when applicable.
+  # ===========================================
+  tags = {
+    Terraform   = "true"
+    Environment = var.environment
+    Layer       = local.layer_name
+  }
+
+  # ===========================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNT OVERRIDES
+  # -------------------------------------------
+  # Purpose: Define per-account runtime settings (profiles/regions)
+  # to build provider aliases and resource matrices.
+  # Notes:
+  # - Profiles map to SSO/credential profiles in the runner.
+  # - Regions rely on primary/secondary variables for consistency.
+  # Runtime backend settings - only specific parameters to override
+  # ===========================================
+  runtime_accounts = {
+    management = {
+      profile = "bb-management-administrator"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    shared = {
+      profile = "bb-shared-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    security = {
+      profile = "bb-security-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    network = {
+      profile = "bb-network-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    apps-devstg = {
+      profile = "bb-apps-devstg-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    apps-prd = {
+      profile = "bb-apps-prd-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    data-science = {
+      profile = "bb-data-science-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+  }
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: BACKEND SETTINGS OVERRIDES
+  # -----------------------------------------------------------
+  # Purpose: Minimal, targeted overrides for backend settings that
+  # should differ at runtime without redefining the full structure.
+  # ================================================================
+  runtime_backend_settings = {
+    bucket = {
+    }
+    security = {
+    }
+    replication = {
+    }
+    tags = {
+      Layer = "base-tf-backend"
+    }
+  }
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNTS MERGE (BASE + OVERRIDES)
+  # -----------------------------------------------------------
+  # Purpose: Combine base account definitions with the runtime
+  # overrides above. Unspecified fields remain from base config.
+  # Result: local.accounts is the canonical structure downstream.
+  # ================================================================
+  accounts = merge(
+    var.accounts,
+    {
+      management = merge(
+        var.accounts.management,
+        local.runtime_accounts.management
+      )
+      shared = merge(
+        var.accounts.shared,
+        local.runtime_accounts.shared
+      )
+      security = merge(
+        var.accounts.security,
+        local.runtime_accounts.security
+      )
+      network = merge(
+        var.accounts.network,
+        local.runtime_accounts.network
+      )
+      apps-devstg = merge(
+        var.accounts.apps-devstg,
+        local.runtime_accounts.apps-devstg
+      )
+      apps-prd = merge(
+        var.accounts.apps-prd,
+        local.runtime_accounts.apps-prd
+      )
+      data-science = merge(
+        var.accounts.data-science,
+        local.runtime_accounts.data-science
+      )
+    }
+  )
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNTS → PROVIDERS MATRIX
+  # -----------------------------------------------------------
+  # Purpose: Expand accounts into a map keyed by "account-region"
+  # used to instantiate provider aliases per account/region.
+  # Includes id/email/profile to support auditing and provider auth.
+  # Transform accounts variable into accounts_providers structure
+  # ================================================================
+  accounts_providers = merge([
+    for account, config in local.accounts : {
+      for region in lookup(config, "regions", []) :
+      "${account}-${region}" => {
+        region  = region
+        id      = lookup(config, "id", null)
+        email   = lookup(config, "email", null)
+        profile = lookup(config, "profile", null)
+      }
+    }
+  ]...)
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNTS → RESOURCES INPUT MAP
+  # -----------------------------------------------------------
+  # Purpose: Create a simplified per-account map consumed by the
+  # tfstate-backend module. It carries account metadata, primary/
+  # secondary regions, and the merged backend settings.
+  # Transform accounts variable into accounts_resources structure
+  # ================================================================
+  accounts_resources = merge([
+    for account, config in local.accounts : {
+      "${account}" : {
+        id               = lookup(config, "id", null)
+        email            = lookup(config, "email", null)
+        region_primary   = config.regions[0]
+        region_secondary = config.regions[1]
+        inputs           = local.backend_settings
+      }
+    }
+  ]...)
+
+  # ===========================================
+  # RUNTIME DEPENDENCY INJECTION: BACKEND SETTINGS MERGE (BASE + OVERRIDES)
+  # -------------------------------------------
+  # Purpose: Layer runtime overrides over base backend settings,
+  # preserving unspecified values. This feeds downstream modules.
+  backend_settings = merge(
+    var.backend_settings,
+    {
+      bucket = merge(
+        var.backend_settings.bucket,
+        local.runtime_backend_settings.bucket
+      )
+      security = merge(
+        var.backend_settings.security,
+        local.runtime_backend_settings.security
+      )
+      replication = merge(
+        var.backend_settings.replication,
+        local.runtime_backend_settings.replication
+      )
+      tags = merge(
+        var.backend_settings.tags,
+        local.runtime_backend_settings.tags
+      )
+    }
+  )
+}

--- a/baseline/base-tf-backend/runtime.tf
+++ b/baseline/base-tf-backend/runtime.tf
@@ -178,6 +178,7 @@ locals {
   # -------------------------------------------
   # Purpose: Layer runtime overrides over base backend settings,
   # preserving unspecified values. This feeds downstream modules.
+  # ===========================================
   backend_settings = merge(
     var.backend_settings,
     {

--- a/baseline/base-tf-backend/settings.auto.tfvars
+++ b/baseline/base-tf-backend/settings.auto.tfvars
@@ -1,0 +1,32 @@
+region_secondary = "us-west-2"
+region_primary   = "us-east-1"
+
+backend_settings = {
+  bucket = {
+    key       = "baseline/base-tf-backend/terraform.tfstate"
+    name      = "terraform-backend"
+    delimiter = "-"
+    namespace = "bb"
+  }
+  security = {
+    acl                           = "private"
+    block_public_acls             = true
+    block_public_policy           = true
+    restrict_public_buckets       = true
+    enable_server_side_encryption = true
+    enforce_ssl_requests          = true
+    ignore_public_acls            = true
+    force_destroy                 = false
+  }
+  replication = {
+    bucket_replication_enabled    = true
+    notifications_sns             = false
+    bucket_lifecycle_enabled      = false
+    billing_mode                  = "PROVISIONED"
+    enable_point_in_time_recovery = false
+    create_kms_key                = false
+  }
+  tags = {
+    Layer = "baseline/base-tf-backend"
+  }
+}

--- a/baseline/base-tf-backend/variables.tf
+++ b/baseline/base-tf-backend/variables.tf
@@ -1,0 +1,36 @@
+#================================#
+# Local variables                #
+#================================#
+variable "backend_settings" {
+  type = object({
+    # Bucket Name
+    bucket = object({
+      key       = string
+      name      = optional(string, "terraform-backend")
+      delimiter = optional(string, "-")
+      namespace = string
+    })
+    # Security
+    security = object({
+      acl                           = optional(string, "private")
+      block_public_acls             = optional(bool, true)
+      block_public_policy           = optional(bool, true)
+      restrict_public_buckets       = optional(bool, true)
+      enable_server_side_encryption = optional(bool, true)
+      enforce_ssl_requests          = optional(bool, true)
+      ignore_public_acls            = optional(bool, true)
+      force_destroy                 = optional(bool, false)
+    })
+    # Replication
+    replication = object({
+      bucket_replication_enabled    = optional(bool, true)
+      notifications_sns             = optional(bool, false)
+      bucket_lifecycle_enabled      = optional(bool, false)
+      billing_mode                  = optional(string, "PROVISIONED")
+      enable_point_in_time_recovery = optional(bool, false)
+      create_kms_key                = optional(bool, false)
+    })
+    # Tags
+    tags = map(string)
+  })
+}

--- a/baseline/config/account.tfvars
+++ b/baseline/config/account.tfvars
@@ -1,0 +1,9 @@
+#
+# Account Configuration
+#
+
+# Environment Name
+environment = "shared"
+
+# SSO
+sso_role = "DevOps"

--- a/baseline/config/backend.tfvars
+++ b/baseline/config/backend.tfvars
@@ -1,0 +1,18 @@
+#
+# Backend Configuration
+#
+
+# AWS Profile (required by the backend but also used for other resources)
+profile = "bb-shared-devops"
+
+# S3 bucket
+bucket = "bb-shared-terraform-backend"
+
+# AWS Region (required by the backend but also used for other resources)
+region = "us-east-1"
+
+# Enable DynamoDB server-side encryption?
+encrypt = true
+
+# DynamoDB Table Name
+dynamodb_table = "bb-shared-terraform-backend"

--- a/baseline/security-base/.terraform.lock.hcl
+++ b/baseline/security-base/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.10"
+  hashes = [
+    "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
+    "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
+    "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
+    "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",
+    "zh:91a11c67abe7e3329e86547babc9e56caee23e95beb0438165e8fc7e4f02ae44",
+    "zh:b1b59c5e5076877eb2d5b7cae8629ab3e030ec7972757d4e8a49a20b17131e06",
+    "zh:c3cf2f633400c43b0811c9facedbd56f700a637af7d72144a72422c0b635bb2e",
+    "zh:cfd13d1312127a9326c63126eb637a28dae3249dd67a5bbc52e336fb3e08b259",
+    "zh:dc49d6b634cdfbf6ae796b19b9c781599ab0bc941e2c229a452c76fbc9eee3cc",
+    "zh:e2d1bb7c0f66021039724640897bc7b12eb40eff37e0b94015abb6c41e612219",
+    "zh:ff1c838fb5a695191ff1682db31f7c68b2f7ebeb8d512bf1f0865949728a0b3d",
+  ]
+}

--- a/baseline/security-base/MIGRATION.md
+++ b/baseline/security-base/MIGRATION.md
@@ -1,0 +1,77 @@
+### Migration guide: adopting the new security-base framework version
+
+This guide explains how to migrate existing, already-provisioned resources into Terraform state using import blocks, and how to safely apply the new module without recreating resources.
+
+---
+
+## Scope
+- **Target**: `baseline/security-base` stack
+- **Goal**: Import pre-existing account-level security resources (e.g., EBS encryption by default, S3 account public access block) into Terraform using `imports.tf` and then apply the new configuration without drift.
+
+## Prerequisites
+- Terraform >= 1.5 (supports `import {}` blocks in configuration)
+- Valid AWS credentials for each target account (via profiles or SSO)
+- The existing `plan.txt` produced from an initial dry-run of the new framework (shows what Terraform would create)
+
+## High-level steps
+1) Generate an initial plan to discover resources Terraform intends to create.
+2) From that plan, compose `imports.tf` with `import { to, id }` blocks mapping to the real, existing resources.
+3) Run `terraform plan` again; verify that resources are now recognized as "to import" rather than "to create".
+4) Execute the import-aware apply to write resources into state without changes.
+5) Remove or keep `imports.tf` based on your team policy (see "Post-import cleanup").
+
+## Compose `imports.tf`
+`imports.tf` should contain one `import {}` per resource instance, where:
+- `to` is the full resource address in the current configuration (including keys for for_each maps)
+- `id` is the remote resource identifier required by the provider
+
+You can use `imports.tf.example` in this folder as a starting template. Copy it to `imports.tf` and replace placeholders with the correct resource addresses and IDs for each account/region.
+
+Example template:
+
+```hcl
+import {
+  to = aws_ebs_encryption_by_default.main["apps-devstg-us-east-1"]
+  id = "123456789012" # AWS Account ID for the target account
+}
+```
+
+Your repository already includes a curated `imports.tf` aligned with `plan.txt`. For reference, it follows this pattern:
+
+```8:18:baseline/security-base/imports.tf
+import {
+  to = aws_ebs_encryption_by_default.main["apps-devstg-us-east-1"]
+  id = "523857393444"
+}
+```
+
+Repeat for each account/region and for each resource type (e.g., `aws_s3_account_public_access_block`). Ensure the `id` value matches the provider's expected import ID (for these account-level resources, it is the AWS Account ID).
+
+## Commands
+Run the following from `baseline/security-base`.
+
+```bash
+# 1) Initialize/upgrade providers
+leverage tf init --skip-validation
+
+# 2) Validate configuration
+leverage tf validate
+
+# 3) Preview the import actions (should show "to import")
+leverage tf plan 
+
+# 4) Apply the imports (records resources in state, no changes to infra)
+leverage tf apply 
+```
+
+Notes:
+- If you prefer, you can skip the `-out=tfplan` and run `leverage tf apply` directly after reviewing the plan.
+- If any resource still shows as "to create", either its `import {}` block is missing or the `id` is incorrect.
+
+## Verifying state
+- After apply, run `leverage tf state list` and confirm addresses for imported resources are present.
+- Optionally run `leverage tf plan` again; it should be a no-op (or only show expected outputs/locals changes).
+
+## Post-import cleanup
+- Teams commonly keep `imports.tf` under version control for auditability and future re-imports.
+- Alternatively, once state is correct and plans are clean, you may remove specific `import {}` blocks to reduce noise. If you do so, commit that change only after confirming the plan remains a no-op.

--- a/baseline/security-base/MIGRATION.md
+++ b/baseline/security-base/MIGRATION.md
@@ -16,7 +16,7 @@ This guide explains how to migrate existing, already-provisioned resources into 
 ## High-level steps
 1) Generate an initial plan to discover resources Terraform intends to create.
 2) From that plan, compose `imports.tf` with `import { to, id }` blocks mapping to the real, existing resources.
-3) Run `terraform plan` again; verify that resources are now recognized as "to import" rather than "to create".
+3) Run `leverage tf plan` again; verify that resources are now recognized as "to import" rather than "to create".
 4) Execute the import-aware apply to write resources into state without changes.
 5) Remove or keep `imports.tf` based on your team policy (see "Post-import cleanup").
 

--- a/baseline/security-base/MIGRATION.md
+++ b/baseline/security-base/MIGRATION.md
@@ -6,7 +6,7 @@ This guide explains how to migrate existing, already-provisioned resources into 
 
 ## Scope
 - **Target**: `baseline/security-base` stack
-- **Goal**: Import pre-existing account-level security resources (e.g., EBS encryption by default, S3 account public access block) into Terraform using `imports.tf` and then apply the new configuration without drift.
+- **Goal**: Import pre-existing account-level security resources (e.g., EBS encryption by default, S3 account public access block) into OpenTofu/Terraform using `imports.tf` and then apply the new configuration without drift.
 
 ## Prerequisites
 - Terraform >= 1.5 (supports `import {}` blocks in configuration)

--- a/baseline/security-base/account.tf
+++ b/baseline/security-base/account.tf
@@ -1,0 +1,29 @@
+#
+# Enable encrypted EBS by default (HIPAA)
+#
+resource "aws_ebs_encryption_by_default" "main" {
+  for_each = local.account_settings
+  provider = aws.accounts[each.key]
+  enabled = each.value.inputs.ebs_encryption
+}
+
+#
+# Disable public access through ACLs or bucket policies to all buckets by default
+#
+resource "aws_s3_account_public_access_block" "main" {
+  for_each = local.account_settings
+  provider = aws.accounts[each.key]
+  block_public_acls   = each.value.inputs.block_public_acls
+  block_public_policy = each.value.inputs.block_public_policy
+}
+
+//module "root-login-notifications" {
+//  for_each = local.accounts_settings
+//  source = "github.com/binbashar/terraform-aws-root-login-notifications.git?ref=v2.3.0"
+//  providers = {
+//    aws = aws.by_region[each.key]
+//  }
+//  alarm_suffix   = "${each.value.environment}-account"
+//  send_sns       = each.value.parameters.send_sns
+//  sns_topic_name = each.value.parameters.sns_topic_name_monitoring_security
+//}

--- a/baseline/security-base/build.env
+++ b/baseline/security-base/build.env
@@ -1,0 +1,8 @@
+# Project settings
+PROJECT=bb
+
+# General
+MFA_ENABLED=false
+
+# Terraform
+TERRAFORM_IMAGE_TAG=1.9.1-tofu-0.3.0

--- a/baseline/security-base/common-variables.tf
+++ b/baseline/security-base/common-variables.tf
@@ -1,0 +1,1 @@
+../../config/common-variables.tf

--- a/baseline/security-base/config.tf
+++ b/baseline/security-base/config.tf
@@ -6,13 +6,12 @@ provider "aws" {
   region = var.region_primary
   profile = "bb-shared-devops"
 }
+
 provider "aws" {
   alias   = "accounts"
   for_each = local.account_settings
   region  = each.value.region
-
   profile = each.value.profile
-
 }
 
 #=============================#

--- a/baseline/security-base/config.tf
+++ b/baseline/security-base/config.tf
@@ -1,0 +1,33 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+
+provider "aws" {
+  region = var.region_primary
+  profile = "bb-shared-devops"
+}
+provider "aws" {
+  alias   = "accounts"
+  for_each = local.account_settings
+  region  = each.value.region
+
+  profile = each.value.profile
+
+}
+
+#=============================#
+# Backend Config (partial)    #
+#=============================#
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = "~> 4.10"
+  }
+
+  # Backend commented out to avoid initialization prompts
+  # Uncomment and configure when ready to use S3 backend
+  backend "s3" {
+    key = "baseline/security-base/terraform.tfstate"
+  }
+}

--- a/baseline/security-base/imports.tf
+++ b/baseline/security-base/imports.tf
@@ -1,0 +1,178 @@
+# Import blocks for existing security-base resources
+# These imports are based on the plan.txt output showing resources to be created
+
+# ===========================================
+# EBS ENCRYPTION BY DEFAULT RESOURCES
+# ===========================================
+
+# Apps Dev/Staging Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["apps-devstg-us-east-1"]
+  id = "523857393444"
+}
+
+# Apps Dev/Staging Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["apps-devstg-us-east-2"]
+  id = "523857393444"
+}
+
+# Apps Production Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["apps-prd-us-east-1"]
+  id = "802787198489"
+}
+
+# Apps Production Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["apps-prd-us-east-2"]
+  id = "802787198489"
+}
+
+# Data Science Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["data-science-us-east-1"]
+  id = "905418344519"
+}
+
+# Data Science Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["data-science-us-east-2"]
+  id = "905418344519"
+}
+
+# Management Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["management-us-east-1"]
+  id = "754065527950"
+}
+
+# Management Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["management-us-east-2"]
+  id = "754065527950"
+}
+
+# Network Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["network-us-east-1"]
+  id = "822280187662"
+}
+
+# Network Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["network-us-east-2"]
+  id = "822280187662"
+}
+
+# Security Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["security-us-east-1"]
+  id = "900980591242"
+}
+
+# Security Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["security-us-east-2"]
+  id = "900980591242"
+}
+
+# Shared Account - US-East-1
+import {
+  to = aws_ebs_encryption_by_default.main["shared-us-east-1"]
+  id = "763606934258"
+}
+
+# Shared Account - US-East-2
+import {
+  to = aws_ebs_encryption_by_default.main["shared-us-east-2"]
+  id = "763606934258"
+}
+
+# ===========================================
+# S3 ACCOUNT PUBLIC ACCESS BLOCK RESOURCES
+# ===========================================
+
+# Apps Dev/Staging Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["apps-devstg-us-east-1"]
+  id = "523857393444"
+}
+
+# Apps Dev/Staging Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["apps-devstg-us-east-2"]
+  id = "523857393444"
+}
+
+# Apps Production Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["apps-prd-us-east-1"]
+  id = "802787198489"
+}
+
+# Apps Production Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["apps-prd-us-east-2"]
+  id = "802787198489"
+}
+
+# Data Science Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["data-science-us-east-1"]
+  id = "905418344519"
+}
+
+# Data Science Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["data-science-us-east-2"]
+  id = "905418344519"
+}
+
+# Management Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["management-us-east-1"]
+  id = "754065527950"
+}
+
+# Management Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["management-us-east-2"]
+  id = "754065527950"
+}
+
+# Network Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["network-us-east-1"]
+  id = "822280187662"
+}
+
+# Network Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["network-us-east-2"]
+  id = "822280187662"
+}
+
+# Security Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["security-us-east-1"]
+  id = "900980591242"
+}
+
+# Security Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["security-us-east-2"]
+  id = "900980591242"
+}
+
+# Shared Account - US-East-1
+import {
+  to = aws_s3_account_public_access_block.main["shared-us-east-1"]
+  id = "763606934258"
+}
+
+# Shared Account - US-East-2
+import {
+  to = aws_s3_account_public_access_block.main["shared-us-east-2"]
+  id = "763606934258"
+}

--- a/baseline/security-base/outputs.tf
+++ b/baseline/security-base/outputs.tf
@@ -1,0 +1,8 @@
+#=============================#
+# Debug Outputs               #
+#=============================#
+
+//output "accounts_settings" {
+//  description = "Accounts settings with merged settings from settings.tfvars and dev_settings.tfvars"
+//  value       = local.accounts_settings
+//} 

--- a/baseline/security-base/plan.txt
+++ b/baseline/security-base/plan.txt
@@ -1,0 +1,347 @@
+[18:52:23.609] INFO     Checking for local docker image, tag: 1.9.1-tofu-0.3.0-1000-1000...                    
+[18:52:23.643] INFO     ✔ OK                                                                                   
+                                                                                                               
+[18:52:24.524] INFO     Attempting to get temporary credentials for apps-devstg account.                       
+[18:52:24.526] INFO     Using already configured temporary credentials.                                        
+[18:52:24.528] INFO     Attempting to get temporary credentials for network account.                           
+[18:52:24.529] INFO     Using already configured temporary credentials.                                        
+[18:52:24.530] INFO     Attempting to get temporary credentials for apps-prd account.                          
+[18:52:24.532] INFO     Using already configured temporary credentials.                                        
+[18:52:24.533] INFO     Attempting to get temporary credentials for data-science account.                      
+[18:52:24.535] INFO     Using already configured temporary credentials.                                        
+[18:52:24.536] INFO     Attempting to get temporary credentials for shared account.                            
+[18:52:24.538] INFO     Using already configured temporary credentials.                                        
+[18:52:24.539] INFO     Attempting to get temporary credentials for security account.                          
+[18:52:24.540] INFO     Using already configured temporary credentials.                                        
+[18:52:24.541] INFO     Attempting to get temporary credentials for management account.                        
+[18:52:24.543] INFO     Using already configured temporary credentials.                                        
+[18:52:24.544] INFO     Attempting to get temporary credentials for shared account.                            
+[18:52:24.546] INFO     Using already configured temporary credentials.                                        
+aws_s3_account_public_access_block.main["shared-us-east-1"]: Preparing import... [id=763606934258]
+aws_s3_account_public_access_block.main["data-science-us-east-1"]: Preparing import... [id=905418344519]
+aws_s3_account_public_access_block.main["management-us-east-1"]: Preparing import... [id=754065527950]
+aws_s3_account_public_access_block.main["apps-prd-us-east-1"]: Preparing import... [id=802787198489]
+aws_s3_account_public_access_block.main["data-science-us-east-2"]: Preparing import... [id=905418344519]
+aws_s3_account_public_access_block.main["apps-devstg-us-east-1"]: Preparing import... [id=523857393444]
+aws_s3_account_public_access_block.main["security-us-east-1"]: Preparing import... [id=900980591242]
+aws_s3_account_public_access_block.main["apps-devstg-us-east-2"]: Preparing import... [id=523857393444]
+aws_s3_account_public_access_block.main["security-us-east-2"]: Preparing import... [id=900980591242]
+aws_s3_account_public_access_block.main["network-us-east-2"]: Preparing import... [id=822280187662]
+aws_s3_account_public_access_block.main["security-us-east-2"]: Refreshing state... [id=900980591242]
+aws_s3_account_public_access_block.main["management-us-east-1"]: Refreshing state... [id=754065527950]
+aws_s3_account_public_access_block.main["data-science-us-east-2"]: Refreshing state... [id=905418344519]
+aws_s3_account_public_access_block.main["apps-devstg-us-east-1"]: Refreshing state... [id=523857393444]
+aws_s3_account_public_access_block.main["security-us-east-1"]: Refreshing state... [id=900980591242]
+aws_s3_account_public_access_block.main["apps-prd-us-east-1"]: Refreshing state... [id=802787198489]
+aws_s3_account_public_access_block.main["data-science-us-east-1"]: Refreshing state... [id=905418344519]
+aws_s3_account_public_access_block.main["network-us-east-2"]: Refreshing state... [id=822280187662]
+aws_s3_account_public_access_block.main["shared-us-east-1"]: Refreshing state... [id=763606934258]
+aws_s3_account_public_access_block.main["apps-devstg-us-east-2"]: Refreshing state... [id=523857393444]
+aws_s3_account_public_access_block.main["management-us-east-2"]: Preparing import... [id=754065527950]
+aws_s3_account_public_access_block.main["apps-prd-us-east-2"]: Preparing import... [id=802787198489]
+aws_s3_account_public_access_block.main["network-us-east-1"]: Preparing import... [id=822280187662]
+aws_s3_account_public_access_block.main["shared-us-east-2"]: Preparing import... [id=763606934258]
+aws_s3_account_public_access_block.main["apps-prd-us-east-2"]: Refreshing state... [id=802787198489]
+aws_s3_account_public_access_block.main["shared-us-east-2"]: Refreshing state... [id=763606934258]
+aws_s3_account_public_access_block.main["management-us-east-2"]: Refreshing state... [id=754065527950]
+aws_s3_account_public_access_block.main["network-us-east-1"]: Refreshing state... [id=822280187662]
+aws_ebs_encryption_by_default.main["shared-us-east-1"]: Preparing import... [id=763606934258]
+aws_ebs_encryption_by_default.main["security-us-east-2"]: Preparing import... [id=900980591242]
+aws_ebs_encryption_by_default.main["network-us-east-1"]: Preparing import... [id=822280187662]
+aws_ebs_encryption_by_default.main["apps-prd-us-east-1"]: Preparing import... [id=802787198489]
+aws_ebs_encryption_by_default.main["security-us-east-2"]: Refreshing state... [id=900980591242]
+aws_ebs_encryption_by_default.main["apps-prd-us-east-2"]: Preparing import... [id=802787198489]
+aws_ebs_encryption_by_default.main["network-us-east-1"]: Refreshing state... [id=822280187662]
+aws_ebs_encryption_by_default.main["apps-prd-us-east-1"]: Refreshing state... [id=802787198489]
+aws_ebs_encryption_by_default.main["apps-prd-us-east-2"]: Refreshing state... [id=802787198489]
+aws_ebs_encryption_by_default.main["data-science-us-east-2"]: Preparing import... [id=905418344519]
+aws_ebs_encryption_by_default.main["shared-us-east-1"]: Refreshing state... [id=763606934258]
+aws_ebs_encryption_by_default.main["data-science-us-east-2"]: Refreshing state... [id=905418344519]
+aws_ebs_encryption_by_default.main["apps-devstg-us-east-1"]: Preparing import... [id=523857393444]
+aws_ebs_encryption_by_default.main["apps-devstg-us-east-1"]: Refreshing state... [id=523857393444]
+aws_ebs_encryption_by_default.main["network-us-east-2"]: Preparing import... [id=822280187662]
+aws_ebs_encryption_by_default.main["network-us-east-2"]: Refreshing state... [id=822280187662]
+aws_ebs_encryption_by_default.main["management-us-east-2"]: Preparing import... [id=754065527950]
+aws_ebs_encryption_by_default.main["shared-us-east-2"]: Preparing import... [id=763606934258]
+aws_ebs_encryption_by_default.main["shared-us-east-2"]: Refreshing state... [id=763606934258]
+aws_ebs_encryption_by_default.main["management-us-east-2"]: Refreshing state... [id=754065527950]
+aws_ebs_encryption_by_default.main["management-us-east-1"]: Preparing import... [id=754065527950]
+aws_ebs_encryption_by_default.main["management-us-east-1"]: Refreshing state... [id=754065527950]
+aws_ebs_encryption_by_default.main["apps-devstg-us-east-2"]: Preparing import... [id=523857393444]
+aws_ebs_encryption_by_default.main["apps-devstg-us-east-2"]: Refreshing state... [id=523857393444]
+aws_ebs_encryption_by_default.main["security-us-east-1"]: Preparing import... [id=900980591242]
+aws_ebs_encryption_by_default.main["security-us-east-1"]: Refreshing state... [id=900980591242]
+aws_ebs_encryption_by_default.main["data-science-us-east-1"]: Preparing import... [id=905418344519]
+aws_ebs_encryption_by_default.main["data-science-us-east-1"]: Refreshing state... [id=905418344519]
+
+OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+OpenTofu will perform the following actions:
+
+  # aws_ebs_encryption_by_default.main["apps-devstg-us-east-1"] will be updated in-place
+  # (imported from "523857393444")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = true -> false
+        id      = "523857393444"
+    }
+
+  # aws_ebs_encryption_by_default.main["apps-devstg-us-east-2"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = false
+        id      = "523857393444"
+    }
+
+  # aws_ebs_encryption_by_default.main["apps-prd-us-east-1"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = true
+        id      = "802787198489"
+    }
+
+  # aws_ebs_encryption_by_default.main["apps-prd-us-east-2"] will be updated in-place
+  # (imported from "802787198489")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = false -> true
+        id      = "802787198489"
+    }
+
+  # aws_ebs_encryption_by_default.main["data-science-us-east-1"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = true
+        id      = "905418344519"
+    }
+
+  # aws_ebs_encryption_by_default.main["data-science-us-east-2"] will be updated in-place
+  # (imported from "905418344519")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = false -> true
+        id      = "905418344519"
+    }
+
+  # aws_ebs_encryption_by_default.main["management-us-east-1"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = true
+        id      = "754065527950"
+    }
+
+  # aws_ebs_encryption_by_default.main["management-us-east-2"] will be updated in-place
+  # (imported from "754065527950")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = false -> true
+        id      = "754065527950"
+    }
+
+  # aws_ebs_encryption_by_default.main["network-us-east-1"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = true
+        id      = "822280187662"
+    }
+
+  # aws_ebs_encryption_by_default.main["network-us-east-2"] will be updated in-place
+  # (imported from "822280187662")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = false -> true
+        id      = "822280187662"
+    }
+
+  # aws_ebs_encryption_by_default.main["security-us-east-1"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = true
+        id      = "900980591242"
+    }
+
+  # aws_ebs_encryption_by_default.main["security-us-east-2"] will be updated in-place
+  # (imported from "900980591242")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = false -> true
+        id      = "900980591242"
+    }
+
+  # aws_ebs_encryption_by_default.main["shared-us-east-1"] will be imported
+    resource "aws_ebs_encryption_by_default" "main" {
+        enabled = true
+        id      = "763606934258"
+    }
+
+  # aws_ebs_encryption_by_default.main["shared-us-east-2"] will be updated in-place
+  # (imported from "763606934258")
+  ~ resource "aws_ebs_encryption_by_default" "main" {
+      ~ enabled = false -> true
+        id      = "763606934258"
+    }
+
+  # aws_s3_account_public_access_block.main["apps-devstg-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "523857393444"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "523857393444"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["apps-devstg-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "523857393444"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "523857393444"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["apps-prd-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "802787198489"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "802787198489"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["apps-prd-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "802787198489"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "802787198489"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["data-science-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "905418344519"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "905418344519"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["data-science-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "905418344519"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "905418344519"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["management-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "754065527950"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "754065527950"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["management-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "754065527950"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "754065527950"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["network-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "822280187662"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "822280187662"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["network-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "822280187662"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "822280187662"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["security-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "900980591242"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "900980591242"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["security-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "900980591242"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "900980591242"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["shared-us-east-1"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "763606934258"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "763606934258"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+  # aws_s3_account_public_access_block.main["shared-us-east-2"] will be imported
+    resource "aws_s3_account_public_access_block" "main" {
+        account_id              = "763606934258"
+        block_public_acls       = true
+        block_public_policy     = true
+        id                      = "763606934258"
+        ignore_public_acls      = false
+        restrict_public_buckets = false
+    }
+
+Plan: 28 to import, 0 to add, 7 to change, 0 to destroy.
+
+Warning: Value for undeclared variable
+
+The root module does not declare a variable named "region" but a value was found in file "/binbash/baseline/config/backend.tfvars". If you meant to use this value, add a "variable" block to the configuration.
+
+To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
+
+Warning: Value for undeclared variable
+
+The root module does not declare a variable named "profile" but a value was found in file "/binbash/baseline/config/backend.tfvars". If you meant to use this value, add a "variable" block to the configuration.
+
+To silence these warnings, use TF_VAR_... environment variables to provide certain "global" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option.
+
+Warning: Values for undeclared variables
+
+In addition to the other similar warnings shown, 3 other variable(s) defined without being declared.
+
+Warning: Provider configuration for_each matches resource
+
+  on account.tf line 5, in resource "aws_ebs_encryption_by_default" "main":
+   5:   for_each = local.account_settings
+
+This provider configuration uses the same for_each expression as a resource, which means that subsequent removal of elements from this collection would cause a planning error.
+
+OpenTofu relies on a provider instance to destroy resource instances that are associated with it, and so the provider instance must outlive all of its resource instances by at least one plan/apply round. For removal of instances to succeed in future you must structure the configuration so that the provider block's for_each expression can produce a superset of the instances of the resources associated with the provider configuration. Refer to the OpenTofu documentation for specific suggestions.
+
+To destroy this object before removing the provider configuration, consider first performing a targeted destroy:
+    tofu apply -destroy -target=aws_ebs_encryption_by_default.main
+
+(and one more similar warning elsewhere)
+
+
+
+Note: You didn't use the -out option to save this plan, so OpenTofu can't guarantee to take exactly these actions if you run "tofu apply" now.

--- a/baseline/security-base/runtime.tf
+++ b/baseline/security-base/runtime.tf
@@ -1,0 +1,135 @@
+
+locals {
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNT PROVIDER OVERRIDES
+  # -----------------------------------------------------------
+  # Purpose: Define per-account runtime settings used to build
+  # provider aliases and resource matrices (one per region).
+  # Notes:
+  # - Profiles map to SSO/credential profiles.
+  # - Regions come from variables (primary/secondary) to keep
+  #   the account footprint consistent across the layer.
+  # ================================================================
+  runtime_accounts = {
+    management = {
+      profile = "bb-management-administrator"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    shared = {
+      profile = "bb-shared-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    security = {
+      profile = "bb-security-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    network = {
+      profile = "bb-network-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    apps-devstg = {
+      profile = "bb-apps-devstg-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    apps-prd = {
+      profile = "bb-apps-prd-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+    data-science = {
+      profile = "bb-data-science-devops"
+      regions = [
+        var.region_primary,
+        var.region_secondary
+      ]
+    }
+  }
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNTS MERGE (BASE + OVERRIDES)
+  # -----------------------------------------------------------
+  # Purpose: Combine the base account configuration (var.accounts)
+  # with the injected runtime overrides above. This preserves any
+  # fields not set at runtime while ensuring profiles/regions are enforced.
+  # Result: local.accounts is the single source of truth for the
+  # rest of this module (providers and resources).
+  # ================================================================
+  accounts = merge(
+    var.accounts,
+    {
+      management = merge(
+        var.accounts.management,
+        local.runtime_accounts.management
+      )
+      security = merge(
+        var.accounts.security,
+        local.runtime_accounts.security
+      )
+      shared = merge(
+        var.accounts.shared,
+        local.runtime_accounts.shared
+      )
+      network = merge(
+        var.accounts.network,
+        local.runtime_accounts.network
+      )
+      apps-devstg = merge(
+        var.accounts.apps-devstg,
+        local.runtime_accounts.apps-devstg
+      )
+      apps-prd = merge(
+        var.accounts.apps-prd,
+        local.runtime_accounts.apps-prd
+      )
+      data-science = merge(
+        var.accounts.data-science,
+        local.runtime_accounts.data-science
+      )
+    }
+  )
+
+  # ================================================================
+  # RUNTIME DEPENDENCY INJECTION: AWS ACCOUNT SETTINGS MATRIX (ACCOUNT x REGION)
+  # -----------------------------------------------------------
+  # Purpose: Expand accounts into a flat map keyed by
+  # "{account}-{region}" to drive for_each on resources.
+  # Details:
+  # - Pulls region/profile/id/email from the merged accounts.
+  # - inputs selects per-account settings from var.inputs,
+  #   falling back to the "default" key when not defined.
+  # Usage: Consumed by resources (e.g., EBS encryption, S3 public
+  # access block) and matching provider aliases via the same key.
+  # Transform accounts variable into accounts_settings structure
+  # ================================================================
+  account_settings = merge([
+    for account, config in local.accounts : {
+      for region in lookup(config, "regions", []) :
+      "${account}-${region}" => {
+        region = region
+        email = lookup(config, "email", null)
+        profile = lookup(config, "profile", null)
+        inputs = try(var.inputs[account], var.inputs["default"])
+      }
+    }
+  ]...) 
+}
+  
+  

--- a/baseline/security-base/settings.auto.tfvars
+++ b/baseline/security-base/settings.auto.tfvars
@@ -1,0 +1,63 @@
+environment = "dev"
+sso_role = "DevOps"
+
+inputs = {
+  "apps-devstg" = {
+    module_version = "2.3.0"
+    ebs_encryption = false
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:123456789012:monitoring-security"
+    send_sns = true
+  }
+  "apps-prd" = {
+    module_version = "2.2.0"
+    ebs_encryption = true
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:923456789012:monitoring-security"
+    send_sns = true
+  }
+  "data-science" = {
+    module_version = "2.2.0"
+    ebs_encryption = true
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:923456789012:monitoring-security"
+    send_sns = true
+  }
+  "network" = {
+    module_version = "2.2.0"
+    ebs_encryption = true
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:923456789012:monitoring-security"
+    send_sns = true
+  }
+  "shared" = {
+    module_version = "2.2.0"
+    ebs_encryption = true
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:923456789012:monitoring-security"
+    send_sns = true
+  }
+  "security" = {
+    module_version = "2.2.0"
+    ebs_encryption = true
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:900980591242:monitoring-security"
+    send_sns = true
+  }
+  "default" = {
+    module_version = "2.9.1"
+    ebs_encryption = true
+    block_public_acls = true
+    block_public_policy = true
+    sns_topic_name_monitoring_security = "arn:aws:sns:us-east-1:705418344519:monitoring-security"
+    send_sns = true
+  }
+}
+
+

--- a/baseline/security-base/variables.tf
+++ b/baseline/security-base/variables.tf
@@ -1,0 +1,19 @@
+#=============================#
+# Notifications               #
+#=============================#
+#
+# AWS SNS -> Lambda -> Slack: tools-monitoring-sec
+#
+variable "sns_topic_name_monitoring_sec" {
+  description = ""
+  default     = "sns-topic-slack-notify-monitoring-sec"
+}
+
+#=============================#
+# Settings Variables          #
+#=============================#
+variable "inputs" {
+  description = "Global inputs"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## What?

* Introduced a new `baseline` level in the Leverage framework structure, providing foundational infrastructure layers that must be deployed before other account-level resources
* Added `baseline/base-tf-backend` layer for centralized Terraform state backend management (S3 buckets and DynamoDB tables) across multiple AWS accounts and regions
* Added `baseline/security-base` layer for account-level security configurations including EBS encryption by default and S3 public access blocks
* Implemented Terraform import blocks (`imports.tf`) to migrate existing pre-provisioned resources into Terraform state without recreating them
* Reorganized repository structure by moving `network/` and `security/` directories to `network_account/` and `security_account/` respectively, aligning with the new framework scope
* Updated configuration files across multiple services to use the new framework structure and runtime configuration patterns
* Added migration documentation (`MIGRATION.md`) with step-by-step guide for adopting the new security-base framework version

## Why?

* Establishes a clear baseline layer that must be provisioned first, ensuring foundational infrastructure (state backends and account-level security) exists before other resources
* Enables centralized management of Terraform state backends across all accounts, improving consistency and reducing configuration drift
* Supports multi-account, multi-region architectures with a unified configuration approach, making it easier to manage complex AWS Organizations setups
* Uses Terraform import blocks to adopt existing infrastructure without downtime or resource recreation, enabling safe migration of legacy resources
* Aligns with the new Leverage framework version architecture, providing a standardized structure that improves maintainability and scalability

## References

* `closes #719` - Baseline level implementation for multi-arch support
* Migration guide: `baseline/security-base/MIGRATION.md`
* Leverage Framework Documentation: https://leverage.binbash.co
* Terraform Import Blocks: https://developer.hashicorp.com/terraform/language/import



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terraform modules and configs to manage remote state and instantiate per-account backend resources.
  * Implemented account-level security controls (EBS encryption defaults, S3 account public access blocks) across environments.

* **Documentation**
  * Added README and migration guide explaining backend setup and importing existing resources.

* **Chores**
  * Added provider lockfiles and new variable/settings inputs to pin providers and supply environment/backend defaults.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->