### PR TITLE
Improved layer_name formation code to work with k8s sublayers

### DIFF
--- a/config/common-variables.tf
+++ b/config/common-variables.tf
@@ -145,6 +145,6 @@ locals {
   current_region = [for region in local.regions : region if can(regex(region, "${path.cwd}"))][0]
 
   #Split the full path of the layer using the region, in order to get the layer path (after the region)
-  layer_name = trimprefix(split(local.current_region, "${path.cwd}")[1], "/")
+  layer_name = replace(trimprefix(split(local.current_region, "${path.cwd}")[1], "/"), "/", "_")
 }
 


### PR DESCRIPTION
## What?
* Fix to the way the layer name is created.

## Why?
* In k8s sublayers the final name included a slash, which caused a parameter value verification error when creating Node Groups

```shell
╷
│ Error: creating EKS Node Group (ol-apps-dev-eks-faina:tools_spot-20251210131251878500000003): operation error EKS: CreateNodegroup, https response error StatusCode: 400, RequestID: 0ede000b-033c-4670-8727-845ab1d0248d, InvalidParameterException: Invalid value: k8s-eks-faina/cluster : field must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')
│ 
│   with module.cluster.module.eks_managed_node_group["tools_spot"].aws_eks_node_group.this[0],
│   on .terraform/modules/cluster/modules/eks-managed-node-group/main.tf line 395, in resource "aws_eks_node_group" "this":
│  395: resource "aws_eks_node_group" "this" {
│ 
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration formatting to standardize path representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->