### PR TITLE
Added new AMI types for newer K8s versions

### DIFF
--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/eks-workers-managed.tf
@@ -75,7 +75,7 @@ module "cluster" {
   # Define Managed Nodes Groups (MNG's) default settings
   eks_managed_node_group_defaults = {
     # Managed Nodes cannot specify custom AMIs, only use the ones allowed by EKS
-    ami_type       = "AL2_x86_64"
+    ami_type       = var.ami_type
     disk_size      = 50
     instance_types = ["t3.medium", "t3a.medium"]
     k8s_labels     = local.tags

--- a/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/variables.tf
+++ b/apps-devstg/us-east-1/k8s-eks-demoapps/cluster/variables.tf
@@ -6,6 +6,16 @@ variable "cluster_version" {
   type        = string
   default     = "1.31"
 }
+# Note that for K8s versions 1.32 and earlier the AMI type could be "AL2_x86_64"
+# For newer versions the newer "AL2023" images must be used, e.g. "AL2023_x86_64_STANDARD"
+# Ref: https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-deprecation-faqs.html
+# Managed Nodes cannot specify custom AMIs, only use the ones allowed by EKS
+variable "ami_type" {
+  description = "The AMI type to be used when creating nodes"
+  type        = string
+  default     = "AL2_x86_64"
+}
+
 
 #
 # Security: K8s EKS API via private endpoint


### PR DESCRIPTION
## What?
* Added a variable to set the AMI Type
* Added notes on AMI Types vs K8s versions

## Why?
* K8s 1.33 and newer need newer AMI Types
* The variable is added so the note on this is close to the K8s version variable, this way a user changing the K8s version should see the AMI Type note

## References
* https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-deprecation-faqs.html



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* EKS worker node AMI type is now configurable through an input variable, enabling customization of the node image selection while maintaining backward compatibility with the Amazon Linux 2 x86_64 default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->