### PR TITLE
Added comment on what Ubuntu release to use

### DIFF
--- a/apps-devstg/us-east-1/ec2-fleet-ansible --/variables.tf
+++ b/apps-devstg/us-east-1/ec2-fleet-ansible --/variables.tf
@@ -1,6 +1,13 @@
 #=============================#
 #  EC2 Attributes             #
 #=============================#
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   type        = string
   description = "AWS AMI Operating System Identificator"

--- a/apps-prd/us-east-1/ec2-fleet --/variables.tf
+++ b/apps-prd/us-east-1/ec2-fleet --/variables.tf
@@ -1,6 +1,13 @@
 #=============================#
 #  EC2 Attributes             #
 #=============================#
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   type        = string
   description = "AWS AMI Operating System Identificator"

--- a/shared/us-east-1/ec2-fleet --/variables.tf
+++ b/shared/us-east-1/ec2-fleet --/variables.tf
@@ -1,6 +1,13 @@
 #=============================#
 #  EC2 Attributes             #
 #=============================#
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   type        = string
   description = "AWS AMI Operating System Identificator"

--- a/shared/us-east-1/tools-eskibana --/variables.tf
+++ b/shared/us-east-1/tools-eskibana --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/shared/us-east-1/tools-jenkins --/variables.tf
+++ b/shared/us-east-1/tools-jenkins --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/shared/us-east-1/tools-prometheus-grafana --/variables.tf
+++ b/shared/us-east-1/tools-prometheus-grafana --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/shared/us-east-1/tools-vault --/variables.tf
+++ b/shared/us-east-1/tools-vault --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/shared/us-east-1/tools-vpn-server/variables.tf
+++ b/shared/us-east-1/tools-vpn-server/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"

--- a/shared/us-east-1/tools-webhooks --/variables.tf
+++ b/shared/us-east-1/tools-webhooks --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/shared/us-east-2/tools-eskibana --/variables.tf
+++ b/shared/us-east-2/tools-eskibana --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/shared/us-east-2/tools-prometheus-grafana --/variables.tf
+++ b/shared/us-east-2/tools-prometheus-grafana --/variables.tf
@@ -19,6 +19,13 @@ variable "name" {
 #
 # EC2 Attributes
 #
+# NOTE: when changing the OS version keep in mind:
+# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
+# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
+#     - Note you should look in public images
+#     - Change the region to your desired one
+# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
+#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
 variable "aws_ami_os_id" {
   description = "AWS AMI Operating System Identificator"
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"


### PR DESCRIPTION
## What?
* Added the following comment to variables files in which the OS version is being selected:

```shell
# NOTE: when changing the OS version keep in mind:
# - You can get the AMI ID from this page: https://cloud-images.ubuntu.com/locator/ec2/
# - Then, using the ID, get the OS_ID (the aws_ami_os_id string) from here: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=public-images;v=3;$case=tags:false%5C,client:false;$regex=tags:false%5C,client:false
#     - Note you should look in public images
#     - Change the region to your desired one
# - IMPORTANT: when using UBUNTU prioritize LTS (Long Term Support) releases to ensure system stability and extended security updates!
#     - You can check releases here: https://en.wikipedia.org/wiki/Ubuntu_version_history
```

## Why?
* Because it is very important to choose LTS versions when using UBUNTU.
* This ensures support for an extended period of time.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default Ubuntu image selections to infrastructure configurations for streamlined deployment setup.

* **Documentation**
  * Expanded guidance documentation across multiple environments to help users select appropriate Ubuntu operating system versions and locate necessary AMI identifiers, including best practices for LTS releases and region-specific considerations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->