### PR TITLE
chore: add Claude Code project settings with plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "enabledPlugins": {
+    "claude-md-management@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "enabledPlugins": {
     "claude-md-management@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true
   }


### PR DESCRIPTION
## What?
- Add `.claude/settings.json` with enabled plugins configuration

## Why?
- Enables shared Claude Code plugins (claude-md-management, context7, code-review, github, security-guidance) for all project contributors