### PR TITLE
feat(ses): add SES infrastructure for AI Lab notifications

### DIFF
--- a/apps-prd/global/base-identities/policies.tf
+++ b/apps-prd/global/base-identities/policies.tf
@@ -159,6 +159,8 @@ resource "aws_iam_policy" "deploy_master_access" {
                 "route53:*",
                 "route53domains:*",
                 "s3:*",
+                "ses:SendEmail",
+                "ses:SendRawEmail",
                 "sns:*",
                 "sqs:*",
                 "ssm:*",

--- a/apps-prd/global/base-identities/policies.tf
+++ b/apps-prd/global/base-identities/policies.tf
@@ -159,8 +159,6 @@ resource "aws_iam_policy" "deploy_master_access" {
                 "route53:*",
                 "route53domains:*",
                 "s3:*",
-                "ses:SendEmail",
-                "ses:SendRawEmail",
                 "sns:*",
                 "sqs:*",
                 "ssm:*",
@@ -179,6 +177,20 @@ resource "aws_iam_policy" "deploy_master_access" {
                         "us-east-2",
                         "us-west-2"
                     ]
+                }
+            }
+        },
+        {
+            "Sid": "AllowSESForAILab",
+            "Effect": "Allow",
+            "Action": [
+                "ses:SendEmail",
+                "ses:SendRawEmail"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "ses:FromAddress": "noreply@binbash.co"
                 }
             }
         },

--- a/apps-prd/us-east-1/app-ai-lab/.terraform.lock.hcl
+++ b/apps-prd/us-east-1/app-ai-lab/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/apps-prd/us-east-1/app-ai-lab/common-variables.tf
+++ b/apps-prd/us-east-1/app-ai-lab/common-variables.tf
@@ -1,0 +1,1 @@
+../../../config/common-variables.tf

--- a/apps-prd/us-east-1/app-ai-lab/config.tf
+++ b/apps-prd/us-east-1/app-ai-lab/config.tf
@@ -1,0 +1,47 @@
+#=============================#
+# AWS Provider Settings       #
+#=============================#
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+# binbash-shared route53 cross-account SES DNS validation
+provider "aws" {
+  region  = var.region
+  profile = "${var.project}-shared-devops"
+  alias   = "shared-route53"
+}
+
+#=============================#
+# Backend Config (partial)    #
+#=============================#
+terraform {
+  required_version = "~> 1.6"
+
+  required_providers {
+    aws = "~> 5.0"
+  }
+
+  backend "s3" {
+    key = "apps-prd/app-ai-lab/terraform.tfstate"
+  }
+}
+
+#=============================#
+# Data sources                #
+#=============================#
+
+#
+# data type from output for dns
+#
+data "terraform_remote_state" "dns-binbash-co" {
+  backend = "s3"
+
+  config = {
+    region  = var.region
+    profile = "${var.project}-shared-devops"
+    bucket  = "${var.project}-shared-terraform-backend"
+    key     = "shared/dns/binbash.co/terraform.tfstate"
+  }
+}

--- a/apps-prd/us-east-1/app-ai-lab/locals.tf
+++ b/apps-prd/us-east-1/app-ai-lab/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  tags = {
+    Terraform   = "true"
+    Environment = var.environment
+    Layer       = local.layer_name
+  }
+}

--- a/apps-prd/us-east-1/app-ai-lab/outputs.tf
+++ b/apps-prd/us-east-1/app-ai-lab/outputs.tf
@@ -1,0 +1,14 @@
+output "ses_domain_identity_arn" {
+  description = "ARN of the SES domain identity"
+  value       = aws_ses_domain_identity.binbash_co.arn
+}
+
+output "ses_domain_verification_status" {
+  description = "SES domain verification status"
+  value       = aws_ses_domain_identity_verification.binbash_co.id
+}
+
+output "ses_from_email" {
+  description = "Verified sender email address"
+  value       = aws_ses_email_identity.sender.email
+}

--- a/apps-prd/us-east-1/app-ai-lab/ses.tf
+++ b/apps-prd/us-east-1/app-ai-lab/ses.tf
@@ -1,0 +1,48 @@
+#
+# SES Domain Identity for binbash.co in apps-prd account
+#
+resource "aws_ses_domain_identity" "binbash_co" {
+  domain = var.ses_domain
+}
+
+#
+# DKIM for domain verification
+#
+resource "aws_ses_domain_dkim" "binbash_co" {
+  domain = aws_ses_domain_identity.binbash_co.domain
+}
+
+#
+# DNS records for SES domain verification (in shared account DNS zone)
+#
+resource "aws_route53_record" "ses_verification" {
+  provider = aws.shared-route53
+  zone_id  = data.terraform_remote_state.dns-binbash-co.outputs.public_zone_id
+  name     = "_amazonses.${var.ses_domain}"
+  type     = "TXT"
+  ttl      = 600
+  records  = [aws_ses_domain_identity.binbash_co.verification_token]
+}
+
+resource "aws_ses_domain_identity_verification" "binbash_co" {
+  domain = aws_ses_domain_identity.binbash_co.id
+
+  depends_on = [aws_route53_record.ses_verification]
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  provider = aws.shared-route53
+  count    = 3
+  zone_id  = data.terraform_remote_state.dns-binbash-co.outputs.public_zone_id
+  name     = "${aws_ses_domain_dkim.binbash_co.dkim_tokens[count.index]}._domainkey"
+  type     = "CNAME"
+  ttl      = 600
+  records  = ["${aws_ses_domain_dkim.binbash_co.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+#
+# SES email identity for the sender address
+#
+resource "aws_ses_email_identity" "sender" {
+  email = var.ses_from_email
+}

--- a/apps-prd/us-east-1/app-ai-lab/variables.tf
+++ b/apps-prd/us-east-1/app-ai-lab/variables.tf
@@ -1,0 +1,15 @@
+#=================#
+# Layer Variables #
+#=================#
+
+variable "ses_domain" {
+  description = "Domain to configure for SES sending"
+  type        = string
+  default     = "binbash.co"
+}
+
+variable "ses_from_email" {
+  description = "Sender email address for AI Lab notifications"
+  type        = string
+  default     = "noreply@binbash.co"
+}

--- a/infracost.yml
+++ b/infracost.yml
@@ -492,6 +492,11 @@ projects:
       - "../../../config/common.tfvars"
       - "../../config/account.tfvars"
       - "../../config/backend.tfvars"
+  - path: "apps-prd/us-east-1/app-ai-lab"
+    terraform_var_files:
+      - "../../../config/common.tfvars"
+      - "../../config/account.tfvars"
+      - "../../config/backend.tfvars"
   - path: "apps-prd/us-east-1/notifications"
     terraform_var_files:
       - "../../../config/common.tfvars"


### PR DESCRIPTION
## What?

Add AWS SES infrastructure in the `apps-prd` account so the AI Use Case Lab app (`ai-lab.binbash.co`) can send email notifications to the sales team after assessment completion.

Related app PR: https://github.com/binbashar/bb-sales-tools/pull/24

## Why?

The AI Lab app needs to send notification emails (via `ses:SendEmail`) when a user completes the 4-step assessment wizard. The app runs on Vercel and assumes the `DeployMaster` role in `apps-prd` to call SES.

## Changes

### New layer: `apps-prd/us-east-1/app-ai-lab/`
- SES domain identity for `binbash.co` with DKIM verification
- Cross-account DNS records in shared account Route53 zone (using `aws.shared-route53` provider alias, same pattern as `cdn-s3-frontend`)
- SES email identity for `noreply@binbash.co`
- Remote state reference to `shared/dns/binbash.co/terraform.tfstate`

### Updated: `apps-prd/global/base-identities/policies.tf`
- Added `ses:SendEmail` and `ses:SendRawEmail` to DeployMaster policy (scoped by existing region condition: us-east-1, us-east-2, us-west-2)

### Updated: `infracost.yml`
- Added `app-ai-lab` layer entry for cost analysis

## Plan output

### `apps-prd/global/base-identities/` (1 relevant change)

```
# aws_iam_policy.deploy_master_access will be updated in-place
~ resource "aws_iam_policy" "deploy_master_access" {
      id   = "arn:aws:iam::<APPS_PRD_ACCOUNT_ID>:policy/deploy_master_access"
      name = "deploy_master_access"
    ~ policy = jsonencode(
        ~ {
            ~ Statement = [
                ~ {
                    ~ Action = [
                          # (19 unchanged elements hidden)
                          "s3:*",
                        + "ses:SendEmail",
                        + "ses:SendRawEmail",
                          "sns:*",
                          # (6 unchanged elements hidden)
                      ]
                      # (3 unchanged attributes hidden)
                  },
                  # (1 unchanged element hidden)
              ]
              # (1 unchanged attribute hidden)
          }
      )
  }

Plan: 0 to add, 1 to change, 0 to destroy.
```

> Note: 3 additional service role drift changes (Organizations, Support, TrustedAdvisor) from module upgrades are unrelated to this PR.

### `apps-prd/us-east-1/app-ai-lab/` (all new)

```
# aws_ses_domain_identity.binbash_co will be created
+ resource "aws_ses_domain_identity" "binbash_co" {
    + arn                = (known after apply)
    + domain             = "binbash.co"
    + verification_token = (known after apply)
  }

# aws_ses_domain_dkim.binbash_co will be created
+ resource "aws_ses_domain_dkim" "binbash_co" {
    + dkim_tokens = (known after apply)
    + domain      = "binbash.co"
  }

# aws_route53_record.ses_verification will be created
+ resource "aws_route53_record" "ses_verification" {
    + name    = "_amazonses.binbash.co"
    + type    = "TXT"
    + ttl     = 600
    + zone_id = "<SHARED_ROUTE53_ZONE_ID>"
  }

# aws_route53_record.ses_dkim[0..2] will be created (x3)
+ resource "aws_route53_record" "ses_dkim" {
    + type    = "CNAME"
    + ttl     = 600
    + zone_id = "<SHARED_ROUTE53_ZONE_ID>"
  }

# aws_ses_domain_identity_verification.binbash_co will be created
+ resource "aws_ses_domain_identity_verification" "binbash_co" {
    + domain = (known after apply)
  }

# aws_ses_email_identity.sender will be created
+ resource "aws_ses_email_identity" "sender" {
    + email = "noreply@binbash.co"
  }

Plan: 8 to add, 0 to change, 0 to destroy.

Outputs:
+ ses_domain_identity_arn        = (known after apply)
+ ses_domain_verification_status = (known after apply)
+ ses_from_email                 = "noreply@binbash.co"
```

## Deployment order

1. `apps-prd/global/base-identities/` — IAM policy update
2. `apps-prd/us-east-1/app-ai-lab/` — SES + DNS verification

## Post-deployment notes

- SES starts in **sandbox mode** — only verified email addresses can receive mail
- To send to arbitrary `@binbash.com.ar` recipients, request **production access** via AWS Console → SES → Account dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email sending enabled with a verified sender address and domain; DNS verification and DKIM records provisioned.

* **Chores**
  * New application environment and backend configuration deployed.
  * Updated system permissions to allow sending email from the verified address.
  * Provider lockfile and cost reporting entry added; remote state access configured for DNS data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->