### PR TITLE
Added pricing permissions to DevOps permissionset

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -117,7 +117,8 @@ data "aws_iam_policy_document" "devops" {
       "wafv2:*",
       "wellarchitected:*",
       "workspaces-web:*",
-      "workspaces:*"
+      "workspaces:*",
+      "pricing:*"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
## What?
* Added `pricing` permission to DevOps permissionset.

## Why?
* To be able to run the new AWS Pricing MCP.

## References
* [MCP Website](https://github.com/awslabs/mcp/tree/main/src/aws-pricing-mcp-server)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Expanded platform permissions to include access to AWS pricing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->