### PR TITLE
chore(claude): enable skill-creator + superpowers plugins project-wide

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,8 @@
     "code-review@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "github@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true
+    "security-guidance@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## What?

Adds `skill-creator` and `superpowers` to the project-level Claude Code plugin enables in `.claude/settings.json`, so they apply across all layers — not only the layer where they were initially enabled.

```diff
 "enabledPlugins": {
   "claude-md-management@claude-plugins-official": true,
   "code-review@claude-plugins-official": true,
   "context7@claude-plugins-official": true,
   "github@claude-plugins-official": true,
-  "security-guidance@claude-plugins-official": true
+  "security-guidance@claude-plugins-official": true,
+  "skill-creator@claude-plugins-official": true,
+  "superpowers@claude-plugins-official": true
 }
```

## Why?

Both plugins were enabled mid-session from `management/global/sso/`, which scoped them to that layer only via an untracked `management/global/sso/.claude/settings.json`. Promoting them to the tracked project-level file aligns them with the existing 5 plugins (`claude-md-management`, `code-review`, `context7`, `github`, `security-guidance`) already shared this way.

Keys remain alphabetically sorted to satisfy the `pretty-format-json` pre-commit hook.

## Follow-ups (not in this PR)

- The repo-level `.gitignore` line `!.claude` (no leading slash) re-includes `.claude/` at any depth, so any layer where Claude Code is used picks up an untracked `.claude/`. Anchoring it as `!/.claude` would gitignore layer-level Claude config while keeping the root one tracked. Worth a separate small PR if we want to clean up everyone's `git status`.

## References

- [Claude Code plugin settings docs](https://docs.claude.com/en/docs/claude-code/settings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled skill creator plugin to support enhanced capability development and management.
  * Activated superpowers plugin for extended functionality and improved performance.
  * Security guidance integration remains active for continued protection and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->