### PR TITLE
feat(dns): migrate event-studio.binbash.co to mkt-studio.binbash.co

### DIFF
--- a/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
+++ b/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
@@ -44,9 +44,9 @@ resource "aws_route53_record" "CNAME_ai_lab_binbash_co" {
   ttl     = 300
 }
 
-resource "aws_route53_record" "CNAME_event_studio_binbash_co" {
+resource "aws_route53_record" "CNAME_mkt_studio_binbash_co" {
   zone_id = aws_route53_zone.public.id
-  name    = "event-studio.binbash.co"
+  name    = "mkt-studio.binbash.co"
   records = ["c86285d79d05996d.vercel-dns-016.com."]
   type    = "CNAME"
   ttl     = 300


### PR DESCRIPTION
## What?
* Rename the public Route53 CNAME `event-studio.binbash.co` to `mkt-studio.binbash.co` in the `shared/global/base-dns/binbash.co` layer.
* CNAME target is unchanged (`c86285d79d05996d.vercel-dns-016.com.`) — same Vercel project (`binbash-event-studio`).

## Why?
* The Vercel project's custom domain is being rebranded from `event-studio` to `mkt-studio`.
* `mkt-studio.binbash.co` is already added in the Vercel dashboard but flagged as `Invalid Configuration` until the matching CNAME exists in Route53.
* This change resolves the Vercel domain validation and retires the legacy `event-studio` hostname.

## Plan output (`shared/global/base-dns/binbash.co`)

```text
OpenTofu will perform the following actions:

  # aws_route53_record.CNAME_event_studio_binbash_co will be destroyed
  # (because aws_route53_record.CNAME_event_studio_binbash_co is not in configuration)
  - resource "aws_route53_record" "CNAME_event_studio_binbash_co" {
      - fqdn                             = "event-studio.binbash.co" -> null
      - name                             = "event-studio.binbash.co" -> null
      - records                          = [
          - "c86285d79d05996d.vercel-dns-016.com.",
        ] -> null
      - ttl                              = 300 -> null
      - type                             = "CNAME" -> null
    }

  # aws_route53_record.CNAME_mkt_studio_binbash_co will be created
  + resource "aws_route53_record" "CNAME_mkt_studio_binbash_co" {
      + name            = "mkt-studio.binbash.co"
      + records         = [
          + "c86285d79d05996d.vercel-dns-016.com.",
        ]
      + ttl             = 300
      + type            = "CNAME"
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

## Post-apply impact
* `event-studio.binbash.co` will return NXDOMAIN — any existing external links to that hostname will break. Confirm there are no critical inbound links before merging.
* `mkt-studio.binbash.co` will validate in the Vercel `binbash-event-studio` project and become the new production domain.

## References
* Vercel project: `vercel.com/binbash/binbash-event-studio` (Domains → `mkt-studio.binbash.co`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * DNS configuration updated: event-studio.binbash.co subdomain removed; mkt-studio.binbash.co subdomain added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->