### PR TITLE
feat(bedrock): add PRM aws-apn-id tag to data-science Bedrock layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,7 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 - Project prefix: `${var.project}-${var.environment}-{resource}`
 - AWS profiles: `{project}-{account}-devops` (e.g., `bb-shared-devops`, `bb-network-devops`)
 - Tags: Consistent tagging with `Terraform`, `Environment`, `Layer` via `local.tags`
+- **PRM compliance tag (`aws-apn-id`)**: Present in `data-science/us-east-1/bedrock-agent-kyb`, `bedrock-agentcore`, and `bedrock-kyb-bda` for AWS Partner Revenue Measurement attribution. Value `pc:b6t445987ttlzwgcll8zdt8nv` maps to AWS Marketplace product `prod-zw4ehbg5ayh2m`. **Do NOT add this tag to other layers without explicit Partner Development Manager approval** — the product code attributes consumption to a specific Marketplace listing. For Bedrock model invocations specifically, Resource Tagging only works for Amazon/OSS models via an Application Inference Profile; Anthropic Claude invocations need the User Agent String method instead. See [AWS PRM Bedrock docs](https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/bedrock-best-practices.html).
 
 ### Version Constraints
 - **OpenTofu**: >= 1.0.9 to ~> 1.6 (varies by layer; primary IaC tool)

--- a/data-science/us-east-1/bedrock-agent-kyb/locals.tf
+++ b/data-science/us-east-1/bedrock-agent-kyb/locals.tf
@@ -1,10 +1,11 @@
 locals {
   tags = {
-    Terraform   = "true"
-    Environment = var.environment
-    Purpose     = "bedrock-kyb-agent"
-    Layer       = "bedrock-kyb-agent"
-    Service     = "bedrock-data-automation-agent"
+    Terraform    = "true"
+    Environment  = var.environment
+    Purpose      = "bedrock-kyb-agent"
+    Layer        = "bedrock-kyb-agent"
+    Service      = "bedrock-data-automation-agent"
+    "aws-apn-id" = "pc:b6t445987ttlzwgcll8zdt8nv"
   }
 
   name_prefix = lower(replace("${var.project}-${var.environment}-kyb-agent", "_", "-")) # e.g. bb-prod-kyb-agent

--- a/data-science/us-east-1/bedrock-agentcore/locals.tf
+++ b/data-science/us-east-1/bedrock-agentcore/locals.tf
@@ -1,10 +1,11 @@
 locals {
   tags = {
-    Terraform   = "true"
-    Environment = var.environment
-    Purpose     = "bedrock-agentcore"
-    Layer       = "bedrock-agentcore"
-    Service     = "bedrock-agentcore"
+    Terraform    = "true"
+    Environment  = var.environment
+    Purpose      = "bedrock-agentcore"
+    Layer        = "bedrock-agentcore"
+    Service      = "bedrock-agentcore"
+    "aws-apn-id" = "pc:b6t445987ttlzwgcll8zdt8nv"
   }
 
   name_prefix = lower(replace("${var.project}-${var.environment}-agentcore", "_", "-"))

--- a/data-science/us-east-1/bedrock-kyb-bda/locals.tf
+++ b/data-science/us-east-1/bedrock-kyb-bda/locals.tf
@@ -1,10 +1,11 @@
 locals {
   tags = {
-    Terraform   = "true"
-    Environment = var.environment
-    Purpose     = "bedrock-kyb-bda"
-    Layer       = "bedrock-kyb-bda"
-    Service     = "bedrock-data-automation"
+    Terraform    = "true"
+    Environment  = var.environment
+    Purpose      = "bedrock-kyb-bda"
+    Layer        = "bedrock-kyb-bda"
+    Service      = "bedrock-data-automation"
+    "aws-apn-id" = "pc:b6t445987ttlzwgcll8zdt8nv"
   }
 
   # Sanitized name prefix

--- a/data-science/us-east-1/bedrock-kyb-bda/s3.tf
+++ b/data-science/us-east-1/bedrock-kyb-bda/s3.tf
@@ -140,6 +140,26 @@ resource "aws_s3_bucket_policy" "kyb_input" {
             "aws:SecureTransport" = "false"
           }
         }
+      },
+      {
+        Sid    = "AllowBedrockDataAutomationRead"
+        Effect = "Allow"
+        Principal = {
+          Service = "bedrock.amazonaws.com"
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          aws_s3_bucket.kyb_input.arn,
+          "${aws_s3_bucket.kyb_input.arn}/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
       }
       ], var.enable_encryption ? [
       {
@@ -201,6 +221,26 @@ resource "aws_s3_bucket_policy" "kyb_output" {
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid    = "AllowBedrockDataAutomationWrite"
+        Effect = "Allow"
+        Principal = {
+          Service = "bedrock.amazonaws.com"
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          aws_s3_bucket.kyb_output.arn,
+          "${aws_s3_bucket.kyb_output.arn}/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
         }
       }

--- a/data-science/us-east-1/bedrock-kyb-bda/s3.tf
+++ b/data-science/us-east-1/bedrock-kyb-bda/s3.tf
@@ -149,6 +149,7 @@ resource "aws_s3_bucket_policy" "kyb_input" {
         }
         Action = [
           "s3:GetObject",
+          "s3:GetObjectVersion",
           "s3:ListBucket",
         ]
         Resource = [
@@ -232,6 +233,10 @@ resource "aws_s3_bucket_policy" "kyb_output" {
         }
         Action = [
           "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:DeleteObject",
           "s3:ListBucket",
         ]
         Resource = [


### PR DESCRIPTION
## What?

- Add `aws-apn-id = pc:b6t445987ttlzwgcll8zdt8nv` tag to **47 resources** across 3 data-science Bedrock layers via per-layer `local.tags` maps:
  - `data-science/us-east-1/bedrock-agent-kyb` — 32 resources (Bedrock Agent + Alias, BDA Project, IAM, Lambdas, S3 buckets, CW Log Groups, EventBridge rule, API Gateway)
  - `data-science/us-east-1/bedrock-agentcore` — 5 resources (AgentCore Runtime + Endpoint, IAM, S3 bucket + object)
  - `data-science/us-east-1/bedrock-kyb-bda` — 10 resources (BDA Project + Blueprint, IAM, Lambda, CW Log Group, S3, SQS DLQ, EventBridge)
- Re-add `AllowBedrockDataAutomationRead` / `AllowBedrockDataAutomationWrite` statements to `bedrock-kyb-bda` S3 bucket policies (`kyb_input` / `kyb_output`) to resolve pre-existing drift between deployed state and code.
- Document PRM tag conventions in `CLAUDE.md` to prevent unintended propagation to unrelated layers.

## Why?

- AWS requires Partner Revenue Measurement attribution by **2026-05-31** to preserve binbash's AI Competency Signature Benefits (MDF up to $75K, AI Production Ready funding, premium GTM resources). Missing the deadline blocks new fund requests.
- Tag value `pc:b6t445987ttlzwgcll8zdt8nv` maps to binbash's AWS Marketplace product `prod-zw4ehbg5ayh2m` (*GenAI Assessment for Startups | AI/ML Readiness & Roadmap*), Public, Professional Services delivery.
- PDM Haley Sauer (2026-04-13) confirmed Resource Tagging is the correct mechanism for binbash as an SI.
- The S3 bucket policy drift was discovered while running `tofu plan` for the tag change; the `AllowBedrockDataAutomation*` statements exist in deployed bucket policies but were missing from code. Without this fix, any future `tofu apply` would silently remove BDA service-principal access to the buckets.

### Applied to production
Tags + bucket-policy fix were applied to the `data-science` account before this PR. Plan/apply results:

| Layer | Plan | Apply |
|---|---|---|
| `bedrock-agent-kyb` | 0 add, 32 change, 0 destroy | ✅ |
| `bedrock-agentcore` | 0 add, 5 change, 0 destroy | ✅ |
| `bedrock-kyb-bda` | 1 add, 10 change, 1 destroy (`null_resource.blueprint_version` regen) | ✅ |

### Known PRM caveat (does not block this PR)
Per [AWS PRM Bedrock docs](https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/bedrock-best-practices.html), Bedrock model invocations only attribute via Resource Tagging when (a) routed through a tagged Application Inference Profile and (b) using Amazon or OSS models. The tagged Bedrock Agent / BDA Project / Blueprint resources here will not attribute Claude (Anthropic) invocations through Resource Tagging — tags are harmless but functionally inert for that path. AgentCore Runtime attribution will work when the runtime is invoked. The AI Use Case Lab (Claude on Vercel, primary revenue driver) is being handled via User Agent String in a separate repo — see references.

## References

- Trello: [APN-141 Program PRM Compliance / AI Tagging — GenAI Competency](https://trello.com/c/brfpyOrA/141-apn-141-program-prm-compliance-ai-tagging-genai-competency)
- Confluence: [PRM Compliance / AI Tagging Tracker — May 31 / July 31 2026](https://binbash.atlassian.net/wiki/spaces/BDPS/pages/3262709762/PRM+Compliance+AI+Tagging+Tracker+May+31+July+31+2026)
- AI Use Case Lab follow-up (User Agent String method): binbashar/bb-sales-tools#66
- AWS docs:
  - [PRM Resource Tagging — Included Services](https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/resource-tagging-included-services.html)
  - [PRM Bedrock best practices](https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/bedrock-best-practices.html)
  - [PRM Troubleshooting](https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/troubleshooting.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AWS PRM compliance tag requirements documentation for Bedrock-related infrastructure layers.

* **Configuration**
  * Updated configuration tags across Bedrock layers to include AWS PRM compliance identifier.
  * Standardized tag formatting and alignment across configuration files.

* **Security**
  * Added S3 bucket access permissions for Bedrock service to read from input buckets and write to output buckets with account-level restrictions.

* **DNS**
  * Updated subdomain DNS record from event studio to marketing studio configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/binbashar/le-tf-infra-aws/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->