### PR TITLE
feat(dns): add LinkedIn site verification TXT record for binbash.co

### DIFF
--- a/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
+++ b/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
@@ -88,6 +88,9 @@ resource "aws_route53_record" "TXT_google_domain_verification" {
   zone_id = aws_route53_zone.public.id
   name    = "binbash.co"
   type    = "TXT"
-  records = ["google-site-verification=7-ckJxbKpPRrcQ-foy3UIkImTGlp60MUtDgzfudJZmM"]
-  ttl     = 300
+  records = [
+    "google-site-verification=7-ckJxbKpPRrcQ-foy3UIkImTGlp60MUtDgzfudJZmM",
+    "linkedin-site-verification=bbe1c109-7cab-456f-9669-2f66982d41bf",
+  ]
+  ttl = 300
 }


### PR DESCRIPTION
## What?

- Add `linkedin-site-verification=bbe1c109-7cab-456f-9669-2f66982d41bf` value to the existing `binbash.co` TXT record alongside the current Google site verification.
- Both verifications now share the same `aws_route53_record.TXT_google_domain_verification` resource (Route53 only allows one TXT record per `name`+`type` combination; multiple values are stored as separate strings in the same record).

## Why?

- Required for LinkedIn to confirm binbash's ownership of the `binbash.co` domain so the binbash company page can be properly linked / verified on LinkedIn.
- Kept in the same Terraform resource (despite the slightly misleading `TXT_google_domain_verification` resource name) to avoid forcing a destroy+recreate of the Google verification record — Route53 rejects two `aws_route53_record` resources with the same `name`/`type`.

## References

- (none — straightforward DNS record addition)