### PR TITLE
fix(iam): allow sts:TagSession on DeployMaster for machine.github.actions.le-cli

### DIFF
--- a/apps-devstg/global/base-identities/roles.tf
+++ b/apps-devstg/global/base-identities/roles.tf
@@ -70,8 +70,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/apps-devstg/global/base-identities/roles.tf
+++ b/apps-devstg/global/base-identities/roles.tf
@@ -66,6 +66,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.shared.id}:root"
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"

--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -70,8 +70,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/apps-prd/global/base-identities/roles.tf
+++ b/apps-prd/global/base-identities/roles.tf
@@ -66,6 +66,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.security.id}:root"
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"

--- a/data-science/global/base-identities/.terraform.lock.hcl
+++ b/data-science/global/base-identities/.terraform.lock.hcl
@@ -6,7 +6,6 @@ provider "registry.opentofu.org/hashicorp/aws" {
   constraints = ">= 4.0.0, ~> 4.10"
   hashes = [
     "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
-    "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
     "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
     "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
     "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",

--- a/data-science/global/base-identities/roles.tf
+++ b/data-science/global/base-identities/roles.tf
@@ -69,8 +69,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/data-science/global/base-identities/roles.tf
+++ b/data-science/global/base-identities/roles.tf
@@ -65,6 +65,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.data-science.id}:root",
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"

--- a/management/global/base-identities/.terraform.lock.hcl
+++ b/management/global/base-identities/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.opentofu.org/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 4.0.0, ~> 4.10"
   hashes = [
+    "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
     "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
     "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
     "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",

--- a/management/global/base-identities/roles.tf
+++ b/management/global/base-identities/roles.tf
@@ -87,6 +87,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.security.id}:root",
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"

--- a/management/global/base-identities/roles.tf
+++ b/management/global/base-identities/roles.tf
@@ -91,8 +91,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/network/global/base-identities/.terraform.lock.hcl
+++ b/network/global/base-identities/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.opentofu.org/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 4.0.0, ~> 4.10"
   hashes = [
+    "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
     "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
     "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
     "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",

--- a/network/global/base-identities/roles.tf
+++ b/network/global/base-identities/roles.tf
@@ -64,6 +64,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.network.id}:root"
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"

--- a/network/global/base-identities/roles.tf
+++ b/network/global/base-identities/roles.tf
@@ -68,8 +68,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -63,6 +63,11 @@ EOF
 #
 # Policy: Assume DeployMaster Role (Cross-Org Accounts)
 #
+# sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging).
+# sts:SetSourceIdentity preserves caller identity for CloudTrail auditing.
+# Both actions must be allowed on the principal's identity policy in addition to the
+# target role's trust policy for cross-account session-tagged AssumeRole to succeed.
+#
 resource "aws_iam_policy" "assume_deploymaster_role" {
   name        = "assume_deploymaster_role"
   description = "Allow assume DeployMaster role in member accounts"
@@ -74,7 +79,9 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
         {
             "Effect": "Allow",
             "Action": [
-                "sts:AssumeRole"
+                "sts:AssumeRole",
+                "sts:TagSession",
+                "sts:SetSourceIdentity"
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",

--- a/security/global/base-identities/groups_policies.tf
+++ b/security/global/base-identities/groups_policies.tf
@@ -80,8 +80,8 @@ resource "aws_iam_policy" "assume_deploymaster_role" {
             "Effect": "Allow",
             "Action": [
                 "sts:AssumeRole",
-                "sts:TagSession",
-                "sts:SetSourceIdentity"
+                "sts:SetSourceIdentity",
+                "sts:TagSession"
             ],
             "Resource": [
                 "arn:aws:iam::${var.accounts.shared.id}:role/DeployMaster",

--- a/security/global/base-identities/roles.tf
+++ b/security/global/base-identities/roles.tf
@@ -199,8 +199,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/security/global/base-identities/roles.tf
+++ b/security/global/base-identities/roles.tf
@@ -195,6 +195,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.security.id}:root",
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"

--- a/shared/global/base-identities/.terraform.lock.hcl
+++ b/shared/global/base-identities/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.opentofu.org/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 4.0.0, ~> 4.10"
   hashes = [
+    "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
     "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
     "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
     "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",

--- a/shared/global/base-identities/roles.tf
+++ b/shared/global/base-identities/roles.tf
@@ -71,8 +71,8 @@ module "iam_assumable_role_deploy_master" {
   # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
   trusted_role_actions = [
     "sts:AssumeRole",
-    "sts:TagSession",
     "sts:SetSourceIdentity",
+    "sts:TagSession",
   ]
 
   create_role = true

--- a/shared/global/base-identities/roles.tf
+++ b/shared/global/base-identities/roles.tf
@@ -67,6 +67,14 @@ module "iam_assumable_role_deploy_master" {
     "arn:aws:iam::${var.accounts.security.id}:root",
   ]
 
+  # sts:TagSession is required by aws-actions/configure-aws-credentials@v4 (session tagging)
+  # sts:SetSourceIdentity preserves caller identity for CloudTrail auditing
+  trusted_role_actions = [
+    "sts:AssumeRole",
+    "sts:TagSession",
+    "sts:SetSourceIdentity",
+  ]
+
   create_role = true
   role_name   = "DeployMaster"
   role_path   = "/"


### PR DESCRIPTION
## What?
* Add `sts:TagSession` and `sts:SetSourceIdentity` to the **trust policy** of the `DeployMaster` role in every account where it is provisioned (`apps-devstg`, `apps-prd`, `data-science`, `network`, `shared`, `management`, `security`) by setting `trusted_role_actions` on each `iam_assumable_role_deploy_master` module call.
* Add the same two actions to the **caller identity policy** `assume_deploymaster_role` in `security/global/base-identities/groups_policies.tf` so cross-account session-tagged `sts:AssumeRole` succeeds end-to-end for the `deploymaster` IAM group (which includes `machine.github.actions.le-cli`).

## Why?
* `aws-actions/configure-aws-credentials@v6` tags STS sessions by default with GitHub metadata (repo, workflow, actor) for CloudTrail observability (same behavior as `@v4` — session tagging is on by default for any non-OIDC flow; `v6` only bumped the runtime to node24). Without `sts:TagSession`, workflows that assume `DeployMaster` from a GitHub Action fail with `is not authorized to perform: sts:TagSession on resource: arn:aws:iam::<APPS_PRD_ACCOUNT_ID>:role/DeployMaster` — surfaced by `bb-sales-tools` PR #68 wiring Amazon Bedrock auth for the `@claude` GitHub Action.
* AWS IAM evaluates session-tagged cross-account `AssumeRole` against **both** the caller's identity policy (in `<SECURITY_ACCOUNT_ID>`) **and** the target role's trust policy. Both surfaces are updated here to make the fix end-to-end.
* `sts:SetSourceIdentity` is paired with `sts:TagSession` so CloudTrail can preserve the original caller identity when the role is later chained — recommended in the AWS session-tags guide.

## Affected layers (8 files)
| Layer | File |
| --- | --- |
| apps-devstg | `apps-devstg/global/base-identities/roles.tf` |
| apps-prd | `apps-prd/global/base-identities/roles.tf` |
| data-science | `data-science/global/base-identities/roles.tf` |
| network | `network/global/base-identities/roles.tf` |
| shared | `shared/global/base-identities/roles.tf` |
| management | `management/global/base-identities/roles.tf` |
| security | `security/global/base-identities/roles.tf` |
| security (identity policy) | `security/global/base-identities/groups_policies.tf` |

Lock file additions (`.terraform.lock.hcl`) are a side effect of `tofu init -reconfigure` on each layer (extra provider hash, no version change).

## Tofu plan diffs (per layer)

Run from each layer with `leverage tofu plan -no-color`. Account IDs redacted with `<*_ACCOUNT_ID>` placeholders. Only the `DeployMaster` / `assume_deploymaster_role` diff is shown; pre-existing drift on other resources is summarized below.

### `apps-prd/global/base-identities`

```diff
  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = [
                            "sts:TagSession",
                          + "sts:SetSourceIdentity",
                            "sts:AssumeRole",
                        ]
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 4 to change, 0 to destroy.
```

> Note: state already contains `sts:TagSession` on this layer (likely an earlier hotfix). Only `sts:SetSourceIdentity` is added by this PR.

### `apps-devstg/global/base-identities`

```diff
  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = "sts:AssumeRole" -> [
                          + "sts:TagSession",
                          + "sts:SetSourceIdentity",
                          + "sts:AssumeRole",
                        ]
                      ~ Principal = {
                          ~ AWS     = [
                                "arn:aws:iam::<SECURITY_ACCOUNT_ID>:root",
                                "arn:aws:iam::<SHARED_ACCOUNT_ID>:root",
                            ]
                        }
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 11 to change, 0 to destroy.
```

### `data-science/global/base-identities`

```diff
  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = "sts:AssumeRole" -> [
                          + "sts:TagSession",
                          + "sts:SetSourceIdentity",
                          + "sts:AssumeRole",
                        ]
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 5 to change, 0 to destroy.
```

### `network/global/base-identities`

```diff
  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = "sts:AssumeRole" -> [
                          + "sts:TagSession",
                          + "sts:SetSourceIdentity",
                          + "sts:AssumeRole",
                        ]
                      ~ Principal = {
                          ~ AWS     = [
                                "arn:aws:iam::<SECURITY_ACCOUNT_ID>:root",
                                "arn:aws:iam::<NETWORK_ACCOUNT_ID>:root",
                            ]
                        }
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 9 to change, 0 to destroy.
```

### `shared/global/base-identities`

```diff
  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = [
                            "sts:TagSession",
                          + "sts:SetSourceIdentity",
                            "sts:AssumeRole",
                        ]
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### `management/global/base-identities`

```diff
  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = [
                            "sts:TagSession",
                          + "sts:SetSourceIdentity",
                            "sts:AssumeRole",
                        ]
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### `security/global/base-identities`

Both the local DeployMaster trust policy **and** the cross-account `assume_deploymaster_role` identity policy change here:

```diff
  # aws_iam_policy.assume_deploymaster_role will be updated in-place
  ~ resource "aws_iam_policy" "assume_deploymaster_role" {
        id     = "arn:aws:iam::<SECURITY_ACCOUNT_ID>:policy/assume_deploymaster_role"
        name   = "assume_deploymaster_role"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action = [
                            "sts:AssumeRole",
                          + "sts:TagSession",
                          + "sts:SetSourceIdentity",
                        ]
                    },
                ]
            }
        )
    }

  # module.iam_assumable_role_deploy_master.aws_iam_role.this[0] will be updated in-place
  ~ resource "aws_iam_role" "this" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = [
                            "sts:TagSession",
                          + "sts:SetSourceIdentity",
                            "sts:AssumeRole",
                        ]
                    },
                ]
            }
        )
        id   = "DeployMaster"
        name = "DeployMaster"
    }

Plan: 0 to add, 5 to change, 0 to destroy.
```

### Pre-existing drift surfaced (out of scope)

Some plans report unrelated changes to resources this PR does not touch:

| Layer | Total changes | Drift (not from this PR) |
| --- | --- | --- |
| apps-prd | 4 | `AWSServiceRoleForOrganizations`, `*ForSupport`, `*ForTrustedAdvisor` (action `string` → list normalization) |
| apps-devstg | 11 | same three service-linked roles + `IAMSelfManagement-*` policy restructuring |
| data-science | 5 | same service-linked role drift |
| network | 9 | service-linked role + IAMSelfManagement drift |
| security | 5 | service-linked role + IAMSelfManagement drift |
| shared | 1 | none — only DeployMaster |
| management | 1 | none — only DeployMaster |

This drift exists on `master` today (visible on any `tofu plan` against these layers) and is **not introduced by this PR**. Separate cleanup PR recommended.

## Test plan
- [ ] Atlantis runs `tofu plan` on this PR; per-layer diffs match the snippets above (modulo benign formatting).
- [ ] After human review and apply, rerun [bb-sales-tools PR #68](https://github.com/binbashar/bb-sales-tools/pull/68) workflow — *Configure AWS credentials* step succeeds against `DeployMaster` in `apps-prd`.
- [ ] CloudTrail event for the resulting `AssumeRole` includes session tags (`GitHub_Actor`, `GitHub_Repository`, `GitHub_Workflow`).
- [ ] Optional smoke check: assume `DeployMaster` from a Jenkins/Atlantis worker that does **not** send session tags — should remain unaffected (adding allowed actions is non-restrictive).

## References
* closes #1078
* AWS docs — IAM session tags: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html
* `aws-actions/configure-aws-credentials` session tagging: https://github.com/aws-actions/configure-aws-credentials#session-tagging
* Triggering workflow run: https://github.com/binbashar/bb-sales-tools/actions/runs/26371796488/job/77625142211
* Triggering PR: https://github.com/binbashar/bb-sales-tools/pull/68

> Note: this PR does **not** apply infrastructure. Stop and review the planned diffs before running `apply` / merging to let Atlantis apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Updated AWS provider versions across all infrastructure-as-code configurations in multiple environments to maintain compatibility and security standards
- Enhanced identity and access management role configurations to support improved session management, session tagging, and CloudTrail audit trail tracking capabilities
- Updated authentication policies for secure cross-account credential delegation with enhanced source identity verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/binbashar/le-tf-infra-aws/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
