### PR TITLE
ci(claude): wire @claude PR assistant via Amazon Bedrock

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,12 +26,12 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,13 +43,11 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
-        env:
-          CLAUDE_CODE_USE_BEDROCK: "1"
-          ANTHROPIC_MODEL: ${{ vars.BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-6' }}
-          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
         with:
-          # Bedrock auth comes from the AWS credentials configured above.
-          # No OAuth token needed.
+          # Use Amazon Bedrock for inference; AWS creds come from the step above.
+          use_bedrock: "true"
+          claude_args: |
+            --model ${{ vars.BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-6' }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,64 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 3600
+          role-session-name: claude-code-action
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_USE_BEDROCK: "1"
+          ANTHROPIC_MODEL: ${{ vars.BEDROCK_MODEL_ID || 'us.anthropic.claude-sonnet-4-6' }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+        with:
+          # Bedrock auth comes from the AWS credentials configured above.
+          # No OAuth token needed.
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_APPS_PRD_ACCOUNT }}
           role-duration-seconds: 3600
           role-session-name: claude-code-action
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,7 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 
 This repo has the [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) workflow installed (`.github/workflows/claude.yml`). Mention `@claude` in a PR/issue/review comment to trigger an automated review or change.
 
-- **Authentication**: routes through **Amazon Bedrock** using repo-level secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ASSUME_ROLE_ARN`) configured at `Settings → Secrets and variables → Actions`.
+- **Authentication**: routes through **Amazon Bedrock** using repo-level secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ASSUME_ROLE_ARN_APPS_PRD_ACCOUNT`) configured at `Settings → Secrets and variables → Actions`. The account-suffixed secret name leaves room to add `AWS_ASSUME_ROLE_ARN_<OTHER>_ACCOUNT` secrets in future workflows that target a different account with the same `machine.github.actions.le-cli` credentials.
 - **Configuration**: optional repository variables `BEDROCK_MODEL_ID` (defaults to `us.anthropic.claude-sonnet-4-6`) and `AWS_REGION` (defaults to `us-east-1`). Names match the AI Use Case Lab app env vars so the same mental model applies on both sides.
 - **Permissions**: only users with write access to this repo can invoke `@claude`. On this public repo, that gate is what keeps external commenters from draining the Bedrock budget.
 - **Troubleshooting**: if a `@claude` invocation never replies, check the workflow run under the **Actions** tab. `issue_comment`-triggered workflows always run from the **default branch** version of `claude.yml`, so changes to the workflow file in a PR won't take effect until the PR is merged to `master`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,7 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 - **Infracost** workflow for cost impact analysis on PRs
 - Slack notifications on pipeline success/failure
 - PR template at `.github/PULL_REQUEST_TEMPLATE.md` uses What? / Why? / References format
+- **`@claude` PR assistant** (`.github/workflows/claude.yml`) — mention `@claude` in a PR/issue/review comment to trigger a Claude response billed to Amazon Bedrock via repo-level secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ASSUME_ROLE_ARN`). The action's built-in permission gate restricts invocation to users with write access, so external commenters on this public repo cannot drain the Bedrock budget.
 
 ### Common GitHub Usernames
 - exe → `exequielrafaela`, OJ (Diego Ojeda) → `diego-ojeda-binbash`, Alex → `Alx-binbash`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,15 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 - **Infracost** workflow for cost impact analysis on PRs
 - Slack notifications on pipeline success/failure
 - PR template at `.github/PULL_REQUEST_TEMPLATE.md` uses What? / Why? / References format
-- **`@claude` PR assistant** (`.github/workflows/claude.yml`) — mention `@claude` in a PR/issue/review comment to trigger a Claude response billed to Amazon Bedrock via repo-level secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ASSUME_ROLE_ARN`). The action's built-in permission gate restricts invocation to users with write access, so external commenters on this public repo cannot drain the Bedrock budget.
+
+### @claude on PRs
+
+This repo has the [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) workflow installed (`.github/workflows/claude.yml`). Mention `@claude` in a PR/issue/review comment to trigger an automated review or change.
+
+- **Authentication**: routes through **Amazon Bedrock** using repo-level secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ASSUME_ROLE_ARN`) configured at `Settings → Secrets and variables → Actions`.
+- **Configuration**: optional repository variables `BEDROCK_MODEL_ID` (defaults to `us.anthropic.claude-sonnet-4-6`) and `AWS_REGION` (defaults to `us-east-1`). Names match the AI Use Case Lab app env vars so the same mental model applies on both sides.
+- **Permissions**: only users with write access to this repo can invoke `@claude`. On this public repo, that gate is what keeps external commenters from draining the Bedrock budget.
+- **Troubleshooting**: if a `@claude` invocation never replies, check the workflow run under the **Actions** tab. `issue_comment`-triggered workflows always run from the **default branch** version of `claude.yml`, so changes to the workflow file in a PR won't take effect until the PR is merged to `master`.
 
 ### Common GitHub Usernames
 - exe → `exequielrafaela`, OJ (Diego Ojeda) → `diego-ojeda-binbash`, Alex → `Alx-binbash`


### PR DESCRIPTION
## What?
* Add `.github/workflows/claude.yml` — copied **verbatim** from the canonical workflow in `binbashar/bb-sales-tools/main` (`actions/checkout@v6`, `aws-actions/configure-aws-credentials@v6`, `anthropics/claude-code-action@v1` with `use_bedrock: "true"` and `claude_args: --model …` passed as **`with:` inputs**, not step `env:` vars), then renamed the role-ARN secret reference to be account-suffixed (see secrets table below).
* Add a structured `### @claude on PRs` subsection to `CLAUDE.md` mirroring the bb-sales-tools doc layout (Authentication / Configuration / Permissions / Troubleshooting).

## Why?
* Anyone with **write access** to this repo can comment `@claude` (in a PR comment, review comment, review body, or issue body/title) and get a Claude-powered response billed to **Amazon Bedrock in `apps-prd`** — no Anthropic API key, no personal Claude subscription.
* The action's built-in permission gate restricts `@claude` invocation to users with write access; on this public repo that's what keeps external commenters from draining the Bedrock budget.
* **Why `with:` inputs and not `env:` vars** — passing `CLAUDE_CODE_USE_BEDROCK=1` and `ANTHROPIC_MODEL=…` as step `env:` is silently ignored by `claude-code-action@v1`; the action then falls back to the direct Anthropic API path and the run fails for lack of an API key. That regression was caught and fixed in [bb-sales-tools#71](https://github.com/binbashar/bb-sales-tools/pull/71); the canonical form uses `use_bedrock: "true"` + `claude_args: --model …` as workflow **inputs**.
* **Why the account-suffixed secret name** — the same `machine.github.actions.le-cli` credentials can assume `DeployMaster` in any member account (devstg, prd, network, shared, data-science, etc.) thanks to #1079. Using `AWS_ASSUME_ROLE_ARN_APPS_PRD_ACCOUNT` makes the target explicit and leaves room for `AWS_ASSUME_ROLE_ARN_<OTHER>_ACCOUNT` secrets in future workflows that target a different account.
* IAM prereq satisfied by [#1078](https://github.com/binbashar/le-tf-infra-aws/issues/1078) → [#1079](https://github.com/binbashar/le-tf-infra-aws/pull/1079): `DeployMaster` trust + identity policies now allow `sts:TagSession` for `machine.github.actions.le-cli`, which `aws-actions/configure-aws-credentials@v6` needs for the session-tagging it does by default.

## Required repo-level secrets (Settings → Secrets and variables → Actions → Secrets)
| Secret | Value source |
| --- | --- |
| `AWS_ACCESS_KEY_ID` | `machine.github.actions.le-cli` access key (security account) |
| `AWS_SECRET_ACCESS_KEY` | matching secret access key |
| `AWS_ASSUME_ROLE_ARN_APPS_PRD_ACCOUNT` | `DeployMaster` role ARN in `apps-prd` |

## Optional repo variables (defaults fine; override only if needed)
| Variable | Default |
| --- | --- |
| `BEDROCK_MODEL_ID` | `us.anthropic.claude-sonnet-4-6` (real, matches the AI Use Case Lab app — Gemini may flag as a hallucination; ignore) |
| `AWS_REGION` | `us-east-1` |

Names intentionally mirror the AI Use Case Lab app env vars so one mental model applies on both runtime and CI sides.

## Prerequisites — already satisfied, do NOT redo
The AWS-side setup landed during the `bb-sales-tools` rollout and applies org-wide for any consumer of `DeployMaster`:
- Bedrock model access enabled in `apps-prd` / `us-east-1`.
- `DeployMaster` trust + identity policies allow `sts:AssumeRole` AND `sts:TagSession` for `machine.github.actions.le-cli` (via #1079).
- `DeployMaster` permission policy includes `bedrock:Converse`, `bedrock:InvokeModel`, `bedrock:InvokeModelWithResponseStream`, `bedrock:ListFoundationModels`, `bedrock:ListInferenceProfiles`, `bedrock:GetFoundationModel`.

## Gotchas
1. `issue_comment`-triggered workflows **always** read `claude.yml` from the **default branch**. Editing the workflow on a PR branch does nothing until merge. Always smoke-test with a **separate** dummy PR opened *after* this PR has merged.
2. No AWS keys, account IDs, or role ARNs are committed in this PR. All values live in GitHub Secrets/Variables only.
3. Workflow permissions stay read-only (`contents`/`pull-requests`/`issues: read`) so the action can't push code on its own; only model invocation is enabled.

## Test plan
- [ ] Configure the three repo-level secrets above (manually in GitHub UI; no values committed here). Note: the role-ARN secret is named `AWS_ASSUME_ROLE_ARN_APPS_PRD_ACCOUNT` — not the generic `AWS_ASSUME_ROLE_ARN` used in `bb-sales-tools`.
- [ ] Confirm Amazon Bedrock model access for `us.anthropic.claude-sonnet-4-6` is enabled in `apps-prd` / `us-east-1` (already verified for `bb-sales-tools`).
- [ ] Merge this PR to `master`.
- [ ] Open a **separate dummy PR** (with no workflow changes) and comment `@claude review` on it. *(Don't try the smoke test by commenting on this PR — `issue_comment` workflows always read `claude.yml` from the default branch.)*
- [ ] Confirm the workflow run completes green and Claude replies on the dummy PR.

## References
* Canonical workflow on `bb-sales-tools:main`: https://github.com/binbashar/bb-sales-tools/blob/main/.github/workflows/claude.yml
* Original integration: [binbashar/bb-sales-tools#68](https://github.com/binbashar/bb-sales-tools/pull/68)
* Bedrock-config bug fix (env vars → `with:` inputs): [binbashar/bb-sales-tools#71](https://github.com/binbashar/bb-sales-tools/pull/71)
* IAM prereq: [#1078](https://github.com/binbashar/le-tf-infra-aws/issues/1078) → [#1079](https://github.com/binbashar/le-tf-infra-aws/pull/1079)
* `anthropics/claude-code-action`: https://github.com/anthropics/claude-code-action
* `aws-actions/configure-aws-credentials` session tagging: https://github.com/aws-actions/configure-aws-credentials#session-tagging

> Maintenance note: when `bb-sales-tools/claude.yml` is updated, propagate the same change here (and to `le-binbash-investor-portal`) so all three repos stay on the same canonical form. The secret name differs (`AWS_ASSUME_ROLE_ARN_APPS_PRD_ACCOUNT` here vs `AWS_ASSUME_ROLE_ARN` upstream) — keep that one line different when syncing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude code action integration now available. Mention `@claude` in pull request, issue, or review comments to trigger automated code analysis and suggestions.

* **Documentation**
  * New documentation provides instructions for using the Claude code action integration and authentication configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/binbashar/le-tf-infra-aws/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->