### PR TITLE
fix: grant AWS Marketplace SSO access

### DIFF
--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -234,6 +234,20 @@ module "account_assignments" {
       principal_name      = local.groups["marketplaceandpartnercentral"].name
       account             = var.accounts.management.id
     },
+    {
+      permission_set_arn  = module.permission_sets.permission_sets["MarketplaceAndPartnerCentral"].arn
+      permission_set_name = "MarketplaceAndPartnerCentral"
+      principal_type      = local.principal_type_group
+      principal_name      = local.groups["marketplacevalidationsellers"].name
+      account             = var.accounts.data-science.id
+    },
+    {
+      permission_set_arn  = module.permission_sets.permission_sets["MarketplaceBuyer"].arn
+      permission_set_name = "MarketplaceBuyer"
+      principal_type      = local.principal_type_group
+      principal_name      = local.groups["marketplacevalidationbuyers"].name
+      account             = var.accounts.apps-devstg.id
+    },
 
     # -------------------------------------------------------------------------
     # DataScientist Permissions
@@ -244,6 +258,13 @@ module "account_assignments" {
       principal_type      = local.principal_type_group
       principal_name      = local.groups["datascientists"].name
       account             = var.accounts.data-science.id
+    },
+    {
+      permission_set_arn  = module.permission_sets.permission_sets["DataScientist"].arn
+      permission_set_name = "DataScientist"
+      principal_type      = local.principal_type_group
+      principal_name      = local.groups["marketplacevalidationbuyers"].name
+      account             = var.accounts.apps-devstg.id
     },
     {
       permission_set_arn  = module.permission_sets.permission_sets["DataScientist"].arn

--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -206,6 +206,8 @@ locals {
       groups = [
         "devops",
         "administrators",
+        "marketplacevalidationsellers",
+        "marketplacevalidationbuyers",
       ]
     }
     "manuel.quinteros" = {
@@ -319,6 +321,14 @@ locals {
     marketplaceandpartnercentral = {
       name        = "MarketplaceAndPartnerCentral"
       description = "Provides access to the AWS Marketplace Seller and AWS Partner Central (APN)."
+    }
+    marketplacevalidationsellers = {
+      name        = "MarketplaceValidationSellers"
+      description = "Provides access to AWS MarketPlace seller validation."
+    }
+    marketplacevalidationbuyers = {
+      name        = "MarketplaceValidationBuyers"
+      description = "Provides access to AWS MarketPlace buyer validation."
     }
     datascientists = {
       name        = "DataScientists"

--- a/management/global/sso/permission_sets.tf
+++ b/management/global/sso/permission_sets.tf
@@ -82,6 +82,16 @@ module "permission_sets" {
       customer_managed_policy_attachments = []
     },
     {
+      name                                = "MarketplaceBuyer"
+      description                         = "Provides access to manage AWS MarketPlace product subscriptions."
+      relay_state                         = local.default_relay_state
+      session_duration                    = local.default_session_duration
+      tags                                = local.tags
+      inline_policy                       = ""
+      policy_attachments                  = ["arn:aws:iam::aws:policy/AWSMarketplaceManageSubscriptions"]
+      customer_managed_policy_attachments = []
+    },
+    {
       name                                = "DataScientist"
       description                         = "Provides access to AWS services that have to do with Data Science and MLOps."
       relay_state                         = local.default_relay_state


### PR DESCRIPTION
## Summary

- Grants AWS Marketplace and Partner Central access in `data-science` through a dedicated group.
- Adds a dedicated AWS Marketplace buyer permission set using `AWSMarketplaceManageSubscriptions`.
- Assigns buyer Marketplace subscription access and Data Science access in `apps-devstg` through a dedicated buyer group.
- Uses the existing IAM Identity Center group-based account assignment pattern.

## Access model

- Users gain seller capabilities by belonging to the `MarketplaceValidationSellers` group, which is assigned `MarketplaceAndPartnerCentral` in `data-science`.
- Users gain buyer capabilities by belonging to the `MarketplaceValidationBuyers` group, which is assigned `MarketplaceBuyer` and `DataScientist` in `apps-devstg`.

## Notes

- AWS IAM Identity Center account access remains group-based.
- Buyer subscription management is separated from workload/Data Science access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new marketplace permission sets (MarketplaceBuyer and MarketplaceAndPartnerCentral) enabling SSO-based marketplace access
  * Established new user groups for marketplace validation, supporting both sellers and buyers with distinct access configurations
  * Configured SSO account assignments across multiple environments to provide marketplace access to designated user groups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->