### PR TITLE
fix: grant Nestor Marketplace validation access

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -271,7 +271,9 @@ locals {
       email      = "nestor.navarro@binbash.com.ar"
       groups = [
         "datascientists",
-        "devops"
+        "devops",
+        "marketplacevalidationbuyers",
+        "marketplacevalidationsellers",
       ]
     }
     "nicolas.suarez" = {


### PR DESCRIPTION
## Summary
- Adds Nestor Navarro to the Marketplace validation seller and buyer groups.

## Access model
- `MarketplaceValidationSellers` grants seller/Partner Central validation access in the data-science account.
- `MarketplaceValidationBuyers` grants Marketplace subscription validation access in the apps-devstg account.
- Existing `DevOps` and `DataScientists` access remains unchanged.

## Test Plan
- [x] `tofu fmt -check -recursive management/global/sso`
- [ ] `tofu validate` (blocked locally: missing AWS shared config profile `bb-management-oaar`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control configuration to grant additional marketplace validation permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->