### PR TITLE
docs(ai-sdlc): document Claude Code on AWS Bedrock for local sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ Anthropic API, so prompts and code stay inside our `apps-prd` AWS account.
 See [`doc/ai-sdlc/`](doc/ai-sdlc/) for the full workflow, configuration knobs,
 and architecture diagrams.
 
+### Claude Code on AWS Bedrock (local sessions)
+
+Local Claude Code sessions can also route through **Amazon Bedrock** in the
+`data-science` account on demand — via a `claude-bedrock` launcher that flips a
+single session to Bedrock while plain `claude` keeps using the native Anthropic
+API. Setup, model entitlements/quotas, and troubleshooting:
+[`doc/ai-sdlc/claude-code-bedrock.md`](doc/ai-sdlc/claude-code-bedrock.md).
+
 ## Leverage CLI Reference
 
 ### Project-wide commands

--- a/doc/ai-sdlc/README.md
+++ b/doc/ai-sdlc/README.md
@@ -4,6 +4,10 @@ How a change reaches `master` in this repo: who reviews it, which AI/automation
 runs at each step, and how the on-demand `@claude` assistant routes through
 **AWS Bedrock** instead of the public Anthropic API.
 
+> **Local sessions too:** developers can route their own Claude Code sessions
+> through Bedrock (data-science account) on demand — see
+> [`claude-code-bedrock.md`](claude-code-bedrock.md).
+
 ![AI-Driven SDLC overview](../diagrams/ai-sdlc.png)
 
 > Source: [`doc/diagrams/ai-sdlc.py`](../diagrams/ai-sdlc.py) — re-render with

--- a/doc/ai-sdlc/claude-code-bedrock.md
+++ b/doc/ai-sdlc/claude-code-bedrock.md
@@ -1,0 +1,177 @@
+# Claude Code on AWS Bedrock — local sessions (data-science account)
+
+How to run **local Claude Code sessions against Amazon Bedrock** in the
+`data-science` account, while keeping the **native Anthropic API as the
+default** for everyday sessions. This complements the CI-side `@claude` PR
+reviewer (see [`README.md`](README.md) §4), which already routes through
+Bedrock in `apps-prd`.
+
+```text
+claude            → native Anthropic API (subscription login)   [default]
+claude-bedrock    → Amazon Bedrock, data-science account        [opt-in]
+```
+
+---
+
+## 1. How the routing works (and why it broke before)
+
+Claude Code switches to Bedrock when `CLAUDE_CODE_USE_BEDROCK=1` plus AWS
+credentials/region are present in its environment. Two precedence rules govern
+the whole setup — both verified empirically on Claude Code `v2.1.172`:
+
+1. **A settings-file `env` block overrides shell-exported variables.** Any
+   variable defined under `env` in `.claude/settings.local.json` (or any other
+   settings scope) wins over the same variable exported in your shell before
+   launching `claude`. The official docs state the opposite; the observed
+   behavior is settings-wins.
+2. **`AWS_PROFILE` beats env-key credentials.** When `AWS_PROFILE` reaches the
+   AWS JS SDK inside Claude Code, the profile is used even if valid
+   `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` are also
+   present in the environment.
+
+Consequence: **mode-dependent variables must never be pinned in a settings
+`env` block** — otherwise no shell wrapper can flip a session to Bedrock. The
+project `.claude/settings.local.json` may keep the always-true values only:
+
+```json
+{
+  "env": {
+    "AWS_CONFIG_FILE": "/Users/<you>/.aws/bb/config",
+    "AWS_SHARED_CREDENTIALS_FILE": "/Users/<you>/.aws/bb/credentials",
+    "AWS_REGION": "us-east-1"
+  }
+}
+```
+
+Keep `CLAUDE_CODE_USE_BEDROCK`, `AWS_PROFILE`, and `ANTHROPIC_MODEL` **out**
+of every settings `env` block. The shell (wrapper) provides them per
+invocation.
+
+## 2. Prerequisites
+
+- Leverage CLI SSO session and fresh per-profile credentials:
+
+  ```bash
+  leverage aws sso login                 # browser; refreshes the SSO token
+  cd data-science/us-east-1/bedrock-agentcore
+  leverage tofu refresh-credentials      # writes bb-data-science-devops temp keys
+  ```
+
+- The target models must be **entitled** in the account *and* have non-zero
+  **service quotas** (see §5 — these are two separate gates).
+
+## 3. Install the `claude-bedrock` launcher
+
+Save as `~/.local/bin/claude-bedrock` and `chmod +x` it:
+
+```bash
+#!/usr/bin/env bash
+#
+# claude-bedrock — launch Claude Code against Amazon Bedrock (data-science account)
+#
+# Shell-exported env vars only take effect because the project settings.local.json
+# does NOT pin CLAUDE_CODE_USE_BEDROCK / AWS_PROFILE — plain `claude` keeps using
+# the native Anthropic endpoints.
+#
+# Model override:  CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6 claude-bedrock
+set -euo pipefail
+
+export AWS_CONFIG_FILE="$HOME/.aws/bb/config"
+export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/bb/credentials"
+export AWS_PROFILE="${CLAUDE_BEDROCK_PROFILE:-bb-data-science-devops}"
+export AWS_REGION="${CLAUDE_BEDROCK_REGION:-us-east-1}"
+
+export CLAUDE_CODE_USE_BEDROCK=1
+export ANTHROPIC_MODEL="${CLAUDE_BEDROCK_MODEL:-us.anthropic.claude-opus-4-8}"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="us.anthropic.claude-opus-4-8"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="us.anthropic.claude-sonnet-4-6"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+# Preflight: Leverage temp credentials go stale independently of the SSO token.
+if ! aws sts get-caller-identity --output text --query Account >/dev/null 2>&1; then
+  echo "ERROR: AWS credentials for profile '$AWS_PROFILE' are stale or missing." >&2
+  echo "Fix (from the le-tf-infra-aws repo):" >&2
+  echo "  leverage aws sso login   # only if the SSO token itself expired" >&2
+  echo "  cd data-science/us-east-1/bedrock-agentcore && leverage tofu refresh-credentials" >&2
+  exit 1
+fi
+
+# Export static credentials into the environment. Env-key credentials outrank
+# profile resolution in the AWS SDK chain, so a settings file that pins
+# AWS_PROFILE to another account cannot redirect the Bedrock session.
+eval "$(aws configure export-credentials --profile "$AWS_PROFILE" --format env)"
+
+echo "claude-bedrock: profile=$AWS_PROFILE region=$AWS_REGION model=$ANTHROPIC_MODEL"
+exec claude "$@"
+```
+
+Usage:
+
+```bash
+claude-bedrock                                              # Opus 4.8 on Bedrock
+CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6 claude-bedrock   # Sonnet 4.6
+claude-bedrock -p "one-shot prompt"                         # headless print mode
+```
+
+Bedrock model IDs use the **cross-region inference-profile** form (`us.`
+prefix, no version suffix for Opus/Sonnet): `us.anthropic.claude-opus-4-8`,
+`us.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`.
+
+## 4. Who can enable model access (permission sets)
+
+Bedrock model access is an **account-level grant**: once enabled by anyone,
+every principal in the account with `bedrock:InvokeModel*` can consume the
+model. Per [`management/global/sso/policies.tf`](../../management/global/sso/policies.tf):
+
+| Permission set | `aws-marketplace:*` + `bedrock:*` (manage model access) | `servicequotas:*` (file quota increases) |
+| --- | --- | --- |
+| **DevOps** | ✅ (verified live) | ✅ (verified live) |
+| **DataScientist** | ✅ (inline policy) | ❌ — quota requests must go through DevOps/Administrator |
+
+So either DevOps or DataScientist can accept a model agreement; only
+DevOps/Administrator can file the service-quota increases that newer models
+also need.
+
+## 5. Model entitlement state (data-science, us-east-1)
+
+Checked 2026-06-10. **Entitlement and quota are separate gates** — a model can
+be fully subscribed yet still refuse invokes because AWS ships some new models
+with **all token quotas at 0**.
+
+| Model | Agreement | Token quotas | Invokable |
+| --- | --- | --- | --- |
+| Sonnet 4.6, Opus 4.5/4.6, Haiku 4.5 | ✅ | 6M TPM-class | ✅ |
+| **Opus 4.8** | ✅ (accepted 2026-06-10) | **0 — increase pending** | ❌ until quota granted |
+| Opus 4.7 | ✅ | 0 | ❌ |
+
+A quota increase for *Cross-region model inference tokens per minute for
+Anthropic Claude Opus 4.8* (`L-DB99DCDB`) to the AWS default (30M) was filed on
+2026-06-10 → status `CASE_OPENED`. Check progress with:
+
+```bash
+aws service-quotas get-service-quota --service-code bedrock \
+  --quota-code L-DB99DCDB --region us-east-1 \
+  --profile bb-data-science-devops --query 'Quota.Value'
+```
+
+Once it returns non-zero, `claude-bedrock` works with Opus 4.8 as-is. Until
+then use `CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6`.
+
+## 6. Troubleshooting
+
+| Symptom | Root cause | Fix |
+| --- | --- | --- |
+| `There's an issue with the selected model (us.anthropic....)` and debug log shows `dispatching to firstParty` | `CLAUDE_CODE_USE_BEDROCK` pinned/overridden by a settings `env` block — the Bedrock model ID was sent to the native Anthropic API (404) | Remove the key from every settings `env` block (§1) |
+| `Failed to authenticate. API Error: 403 The security token included in the request is invalid` | `AWS_PROFILE` pinned in a settings `env` block to a profile with stale credentials — it outranks the wrapper's profile *and* env-key credentials | Remove the `AWS_PROFILE` pin (§1); refresh credentials |
+| `AccessDeniedException: <model> is not available for this account` on invoke, while `list-inference-profiles` shows it `ACTIVE` | Model agreement not accepted, **or** (if `get-foundation-model-availability` is all green) token quotas are 0 | Accept the agreement (Bedrock console → Model access, or `create-foundation-model-agreement`); then request the TPM quota (§5) |
+| Wrapper preflight fails on `sts get-caller-identity` | Leverage temp credentials expired (SSO token may still be valid) | `leverage tofu refresh-credentials` from any data-science layer; `leverage aws sso login` only if the SSO token itself expired |
+
+To see the real API error behind Claude Code's masked message:
+
+```bash
+claude-bedrock -p "test" --debug --debug-file /tmp/claude-debug.log
+grep -E "dispatching to|API error" /tmp/claude-debug.log
+```
+
+`dispatching to firstParty` = native Anthropic API; Bedrock-mode sessions must
+not show `firstParty` with a `us.anthropic.*` model.


### PR DESCRIPTION
## What?

Adds a dedicated guide (`doc/ai-sdlc/claude-code-bedrock.md`) documenting how to run local Claude Code sessions against Amazon Bedrock in the `data-science` account, with pointers from `README.md` and `doc/ai-sdlc/README.md`.

## Why?

Setting this up required resolving three non-obvious issues that are not documented anywhere and would cause future developers to repeat the same debugging cycle:

1. **Claude Code `settings env` blocks override shell env** — the official docs claim environment variables take highest precedence, but empirically (tested on `v2.1.172`) a key in any settings file's `env` block wins over the same key exported in the shell. Any mode-specific variable (`CLAUDE_CODE_USE_BEDROCK`, `AWS_PROFILE`, `ANTHROPIC_MODEL`) pinned in `.claude/settings.local.json` blocks opt-in Bedrock sessions permanently. The project settings were pinning `CLAUDE_CODE_USE_BEDROCK: "0"` (removed, file is gitignored) which is why Bedrock never worked from this repo.

2. **`AWS_PROFILE` in the settings env block outranks env-key credentials** — even when valid `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` are exported, a `AWS_PROFILE` from the settings env block redirects the AWS SDK inside Claude Code to a different profile. This caused the Bedrock session to authenticate with the management account's (expired) credentials instead of the data-science account.

3. **Bedrock entitlement ≠ service quotas** — AWS ships some new models (Opus 4.7/4.8) fully entitled in the marketplace but with **all token quotas at 0**, meaning `InvokeModel` is `AccessDeniedException` even though `GetFoundationModelAvailability` returns green across all fields. A service-quota increase is a separate step required on top of the marketplace agreement. A 30M TPM increase for Opus 4.8 (`L-DB99DCDB`) was filed; Sonnet 4.6/Opus 4.5/4.6/Haiku 4.5 are fully invokable now.

The guide also answers the DevOps vs DataScientist permission-set question: both can accept model agreements (`bedrock:*` + `aws-marketplace:*`); only DevOps can file quota increases (`servicequotas:*`).

## References

- `~/.local/bin/claude-bedrock` launcher (not in repo — installed on developer machines)
- AWS Bedrock model access: <https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html>
- Quota request ID: `5b4e791b640a4d01979801d782a856a07Urzcn9c` (status: `CASE_OPENED`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for routing Claude Code sessions through AWS Bedrock in the data-science AWS account.
  * Included setup prerequisites, launcher script configuration, available models, quota information, and troubleshooting guidance for common issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->