### PR TITLE
fix(apps-prd): gate aws-startups-accelerate CloudFront error-rate alarms on min request volume

### DIFF
--- a/apps-prd/us-east-1/app-aws-startups-accelerate/monitoring.tf
+++ b/apps-prd/us-east-1/app-aws-startups-accelerate/monitoring.tf
@@ -4,21 +4,57 @@
 #
 # CloudFront metrics are emitted in us-east-1 with Region = "Global".
 #
+# Low-traffic guard: *ErrorRate are percentage metrics, so on a near-idle
+# static site a handful of internet background-radiation scanner 404s (probes
+# for /.env, /wp-config.php, /.git/config, ...) reads as ~100% and pages a
+# false alarm. Each alarm therefore evaluates a metric-math expression that
+# gates the error rate on a minimum request volume per period
+# (var.alarm_min_requests_per_period): below the floor the expression reports
+# 0 and the alarm stays OK; at or above it the true error rate is evaluated.
+#
 resource "aws_cloudwatch_metric_alarm" "cf_5xx_error_rate" {
   alarm_name          = "${var.project}-${var.environment}-${local.app_subdomain}-cf-5xx-error-rate"
-  alarm_description   = "CloudFront 5xxErrorRate above ${var.alarm_5xx_error_rate_threshold}% for ${local.app_fqdn}"
-  namespace           = "AWS/CloudFront"
-  metric_name         = "5xxErrorRate"
-  statistic           = "Average"
+  alarm_description   = "CloudFront 5xxErrorRate >= ${var.alarm_5xx_error_rate_threshold}% over a period with >= ${var.alarm_min_requests_per_period} requests for ${local.app_fqdn}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = var.alarm_5xx_error_rate_threshold
-  period              = 300
   evaluation_periods  = 2
   treat_missing_data  = "notBreaching"
 
-  dimensions = {
-    DistributionId = module.aws_startups_accelerate.cf_id
-    Region         = "Global"
+  metric_query {
+    id          = "gated_5xx_rate"
+    expression  = "IF(requests >= ${var.alarm_min_requests_per_period}, rate_5xx, 0)"
+    label       = "5xxErrorRate (gated on >= ${var.alarm_min_requests_per_period} req/period)"
+    return_data = true
+  }
+
+  metric_query {
+    id          = "requests"
+    return_data = false
+    metric {
+      namespace   = "AWS/CloudFront"
+      metric_name = "Requests"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        DistributionId = module.aws_startups_accelerate.cf_id
+        Region         = "Global"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "rate_5xx"
+    return_data = false
+    metric {
+      namespace   = "AWS/CloudFront"
+      metric_name = "5xxErrorRate"
+      period      = 300
+      stat        = "Average"
+      dimensions = {
+        DistributionId = module.aws_startups_accelerate.cf_id
+        Region         = "Global"
+      }
+    }
   }
 
   alarm_actions = [data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring]
@@ -29,19 +65,47 @@ resource "aws_cloudwatch_metric_alarm" "cf_5xx_error_rate" {
 
 resource "aws_cloudwatch_metric_alarm" "cf_total_error_rate" {
   alarm_name          = "${var.project}-${var.environment}-${local.app_subdomain}-cf-total-error-rate"
-  alarm_description   = "CloudFront TotalErrorRate above ${var.alarm_total_error_rate_threshold}% for ${local.app_fqdn}"
-  namespace           = "AWS/CloudFront"
-  metric_name         = "TotalErrorRate"
-  statistic           = "Average"
+  alarm_description   = "CloudFront TotalErrorRate >= ${var.alarm_total_error_rate_threshold}% over a period with >= ${var.alarm_min_requests_per_period} requests for ${local.app_fqdn}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = var.alarm_total_error_rate_threshold
-  period              = 300
   evaluation_periods  = 2
   treat_missing_data  = "notBreaching"
 
-  dimensions = {
-    DistributionId = module.aws_startups_accelerate.cf_id
-    Region         = "Global"
+  metric_query {
+    id          = "gated_total_rate"
+    expression  = "IF(requests >= ${var.alarm_min_requests_per_period}, rate_total, 0)"
+    label       = "TotalErrorRate (gated on >= ${var.alarm_min_requests_per_period} req/period)"
+    return_data = true
+  }
+
+  metric_query {
+    id          = "requests"
+    return_data = false
+    metric {
+      namespace   = "AWS/CloudFront"
+      metric_name = "Requests"
+      period      = 300
+      stat        = "Sum"
+      dimensions = {
+        DistributionId = module.aws_startups_accelerate.cf_id
+        Region         = "Global"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "rate_total"
+    return_data = false
+    metric {
+      namespace   = "AWS/CloudFront"
+      metric_name = "TotalErrorRate"
+      period      = 300
+      stat        = "Average"
+      dimensions = {
+        DistributionId = module.aws_startups_accelerate.cf_id
+        Region         = "Global"
+      }
+    }
   }
 
   alarm_actions = [data.terraform_remote_state.notifications.outputs.sns_topic_arn_monitoring]

--- a/apps-prd/us-east-1/app-aws-startups-accelerate/variables.tf
+++ b/apps-prd/us-east-1/app-aws-startups-accelerate/variables.tf
@@ -62,6 +62,25 @@ variable "alarm_total_error_rate_threshold" {
   }
 }
 
+variable "alarm_min_requests_per_period" {
+  description = <<-EOT
+    Minimum CloudFront Requests in a 5-minute period before the error-rate
+    alarms evaluate. CloudFront's *ErrorRate metrics are percentages, so on a
+    near-idle site a handful of background scanner 404s (e.g. probes for
+    /.env, /wp-config.php) reads as ~100% and pages a false alarm. Below this
+    floor the alarm expression reports 0 (stays OK); at or above it, the real
+    error rate is evaluated. Raise as legitimate traffic grows; lower to
+    increase sensitivity at low traffic.
+  EOT
+  type        = number
+  default     = 50
+
+  validation {
+    condition     = var.alarm_min_requests_per_period >= 1
+    error_message = "alarm_min_requests_per_period must be at least 1."
+  }
+}
+
 #
 # CloudFront access logs
 #


### PR DESCRIPTION
## What?

Gate the two CloudFront error-rate CloudWatch alarms for `aws-startups-accelerate.binbash.co` on a **minimum request volume**, so a percentage-based error rate is only evaluated when there is enough traffic for it to be meaningful.

- `monitoring.tf`: both `cf_5xx_error_rate` and `cf_total_error_rate` now use a metric-math expression `IF(requests >= var.alarm_min_requests_per_period, rate, 0)` instead of a raw `*ErrorRate` metric. **In-place update — no alarm recreation.**
- `variables.tf`: new tunable `alarm_min_requests_per_period` (default `50`).

## Why?

The `bb-apps-prd-aws-startups-accelerate-cf-total-error-rate` alarm flapped ALARM/OK several times on 2026-06-18, reporting up to 100% TotalErrorRate. Investigation (CloudWatch metrics + CloudFront access logs) showed this was a **false positive — not an outage and not an app issue**:

- **0% 5xxErrorRate** for the entire day; the site served HTTP 200 throughout.
- Traffic is ~**117 requests / 24h** — a near-idle static site.
- Every error was a **404 from internet background-radiation scanners** (LeakIX `l9scan`, 7 known scanner IPs) probing non-existent paths like `/.env`, `/wp-config.php`, `/.git/config`, `//wp-includes/...`. The site correctly returns 404 for these.

Because `TotalErrorRate` is a percentage, 2–4 scanner 404s in an otherwise empty 5-minute window reads as "100%". The request-volume gate suppresses this noise while preserving detection of real degradation when traffic is present (a genuine origin break across real visitors still trips the alarm once a period sees ≥ the floor).

The app repo (`bb-ai-sales-tools`) is serving correctly and needs no change — this is purely a monitoring-config fix, so it belongs in this infra repo.

## References

- Follow-up to #1097 (initial S3 + CloudFront hosting for aws-startups-accelerate)
- AWS docs: [Using CloudWatch metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) (`IF` expression for low-traffic rate alarms)

<details>
<summary><code>leverage tofu plan</code> — redacted execution plan</summary>

```text
OpenTofu will perform the following actions:

  # aws_cloudwatch_metric_alarm.cf_5xx_error_rate will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "cf_5xx_error_rate" {
      ~ alarm_description         = "CloudFront 5xxErrorRate above 5% for aws-startups-accelerate.binbash.co" -> "CloudFront 5xxErrorRate >= 5% over a period with >= 50 requests for aws-startups-accelerate.binbash.co"
      ~ dimensions                = {
          - "DistributionId" = "E3R84CH5XAD15A" -> null
          - "Region"         = "Global" -> null
        }
        id                        = "bb-apps-prd-aws-startups-accelerate-cf-5xx-error-rate"
      - metric_name               = "5xxErrorRate" -> null
      - namespace                 = "AWS/CloudFront" -> null
      - period                    = 300 -> null
      - statistic                 = "Average" -> null
        tags                      = {
            "Environment" = "apps-prd"
            "Layer"       = "app-aws-startups-accelerate"
            "Terraform"   = "true"
        }
        # (14 unchanged attributes hidden)

      + metric_query {
          + id          = "rate_5xx"
          + return_data = false

          + metric {
              + dimensions  = {
                  + "DistributionId" = "E3R84CH5XAD15A"
                  + "Region"         = "Global"
                }
              + metric_name = "5xxErrorRate"
              + namespace   = "AWS/CloudFront"
              + period      = 300
              + stat        = "Average"
            }
        }
      + metric_query {
          + id          = "requests"
          + return_data = false

          + metric {
              + dimensions  = {
                  + "DistributionId" = "E3R84CH5XAD15A"
                  + "Region"         = "Global"
                }
              + metric_name = "Requests"
              + namespace   = "AWS/CloudFront"
              + period      = 300
              + stat        = "Sum"
            }
        }
      + metric_query {
          + expression  = "IF(requests >= 50, rate_5xx, 0)"
          + id          = "gated_5xx_rate"
          + label       = "5xxErrorRate (gated on >= 50 req/period)"
          + return_data = true
        }
    }

  # aws_cloudwatch_metric_alarm.cf_total_error_rate will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "cf_total_error_rate" {
      ~ alarm_description         = "CloudFront TotalErrorRate above 10% for aws-startups-accelerate.binbash.co" -> "CloudFront TotalErrorRate >= 10% over a period with >= 50 requests for aws-startups-accelerate.binbash.co"
      ~ dimensions                = {
          - "DistributionId" = "E3R84CH5XAD15A" -> null
          - "Region"         = "Global" -> null
        }
        id                        = "bb-apps-prd-aws-startups-accelerate-cf-total-error-rate"
      - metric_name               = "TotalErrorRate" -> null
      - namespace                 = "AWS/CloudFront" -> null
      - period                    = 300 -> null
      - statistic                 = "Average" -> null
        tags                      = {
            "Environment" = "apps-prd"
            "Layer"       = "app-aws-startups-accelerate"
            "Terraform"   = "true"
        }
        # (14 unchanged attributes hidden)

      + metric_query {
          + id          = "rate_total"
          + return_data = false

          + metric {
              + dimensions  = {
                  + "DistributionId" = "E3R84CH5XAD15A"
                  + "Region"         = "Global"
                }
              + metric_name = "TotalErrorRate"
              + namespace   = "AWS/CloudFront"
              + period      = 300
              + stat        = "Average"
            }
        }
      + metric_query {
          + id          = "requests"
          + return_data = false

          + metric {
              + dimensions  = {
                  + "DistributionId" = "E3R84CH5XAD15A"
                  + "Region"         = "Global"
                }
              + metric_name = "Requests"
              + namespace   = "AWS/CloudFront"
              + period      = 300
              + stat        = "Sum"
            }
        }
      + metric_query {
          + expression  = "IF(requests >= 50, rate_total, 0)"
          + id          = "gated_total_rate"
          + label       = "TotalErrorRate (gated on >= 50 req/period)"
          + return_data = true
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced CloudWatch alarms for CloudFront error rates with low-traffic gating to reduce false positives during minimal traffic periods.
  * Configurable minimum request volume threshold for alarm evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->