### PR TITLE
feat(sso): grant s3vectors:* to DataScientist permission set

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -299,6 +299,7 @@ data "aws_iam_policy_document" "data_scientist" {
       "route53domains:*",
       "route53resolver:*",
       "s3:*",
+      "s3vectors:*",
       "sagemaker:*",
       "secretsmanager:*",
       "sns:*",


### PR DESCRIPTION
## What?
* Add the `s3vectors:*` IAM action to the `DataScientist` SSO permission set inline policy (`management/global/sso/policies.tf`).
* Single-line change, placed in alphabetical order between `s3:*` and `sagemaker:*`.
* Inherited automatically by every group assigned the `DataScientist` permission set (`datascientists` in `data-science`, `workshop-genai-1`, `workshop-genai-2`, and `marketplacevalidationbuyers` in `apps-devstg`).

## Why?
* Data Scientists need access to **Amazon S3 Vectors** (vector buckets/indexes for embeddings — e.g. Bedrock Knowledge Bases vector stores).
* `s3vectors` is a **distinct IAM namespace from `s3`**, so the existing `s3:*` does not cover it — it must be granted explicitly.
* The change was applied to AWS via a targeted apply (only the `DataScientist` inline policy resource) and verified: a follow-up `tofu plan` reports **no drift** for the resource. The region condition (`us-east-1`, `us-east-2`, `us-west-2`) already covers the regions where S3 Vectors is available.

## References
* AWS docs — S3 Vectors access management (`s3vectors` IAM namespace): https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-access-management.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded access for the data scientist role to include S3 Vectors actions, enabling use of vector-related S3 capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->