### PR TITLE
feat(ai-sdlc): claude-bedrock launcher multi-account/role + Sonnet 5

### DIFF
--- a/doc/ai-sdlc/bin/claude-bedrock
+++ b/doc/ai-sdlc/bin/claude-bedrock
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# claude-bedrock — launch Claude Code against Amazon Bedrock (binbash SSO)
+#
+# Two SEPARATE Bedrock integrations live in this repo, in different accounts:
+#   • CI @claude PR reviewer  → apps-prd  (see doc/ai-sdlc/README.md §4)
+#   • local human sessions    → this launcher (ACCOUNT + ROLE chosen at launch)
+#
+# You pick the ACCOUNT and SSO ROLE interactively (or via env); the launcher sets
+# the matching profile, the models that account actually has, and the credential
+# auto-refresh layer. Model availability differs per account:
+#   apps-prd      → Opus 4.8 / Sonnet 5 live today
+#   data-science  → Opus 4.6 / Sonnet 4.6 (Opus 4.8 & Sonnet 5 quota pending)
+# Role: devops | datascientist (not everyone has DevOps; pick what you have).
+#
+# Non-interactive / overrides (env wins over the prompts; required under `-p`):
+#   CLAUDE_BEDROCK_ACCOUNT=apps-prd CLAUDE_BEDROCK_ROLE=devops claude-bedrock -p "..."
+#   CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-5 claude-bedrock
+#
+# Install (symlink this committed script onto your PATH):
+#   ln -s "$(git rev-parse --show-toplevel)/doc/ai-sdlc/bin/claude-bedrock" ~/.local/bin/claude-bedrock
+#
+# Shell-exported env vars take precedence over Claude Code settings files, so this
+# wrapper flips a single session to Bedrock without touching settings.local.json —
+# plain `claude` keeps using the native Anthropic endpoints. Credentials refresh
+# automatically when the temp keys go stale (see the preflight block); only an
+# expired SSO *session* needs a manual `leverage aws sso login` (browser).
+set -euo pipefail
+
+export AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-$HOME/.aws/bb/config}"
+export AWS_SHARED_CREDENTIALS_FILE="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/bb/credentials}"
+export AWS_REGION="${CLAUDE_BEDROCK_REGION:-us-east-1}"
+
+# Headless (`-p`/`--print`) must never block on a prompt — treat it as non-interactive.
+headless=0
+for _arg in "$@"; do case "$_arg" in -p | --print) headless=1; break ;; esac; done
+interactive() { [[ "$headless" == 0 && -t 0 && -t 1 ]]; }
+
+# --- Account selection (env > prompt > default) ----------------------------
+if [[ -z "${CLAUDE_BEDROCK_ACCOUNT:-}" ]]; then
+  if interactive; then
+    echo "AWS account for this Amazon Bedrock session:" >&2
+    echo "  1) data-science  [default]  — Opus 4.6 / Sonnet 4.6 (Opus 4.8 & Sonnet 5 quota pending)" >&2
+    echo "  2) apps-prd      (prod)     — Opus 4.8 / Sonnet 5 live" >&2
+    printf "Account [1]: " >&2; read -r _a || _a=""
+    case "$_a" in 2 | apps-prd | prd | prod) CLAUDE_BEDROCK_ACCOUNT="apps-prd" ;; *) CLAUDE_BEDROCK_ACCOUNT="data-science" ;; esac
+  else
+    CLAUDE_BEDROCK_ACCOUNT="data-science"
+  fi
+fi
+account="$CLAUDE_BEDROCK_ACCOUNT"
+
+# --- Role selection (env > prompt > default) -------------------------------
+if [[ -z "${CLAUDE_BEDROCK_ROLE:-}" ]]; then
+  if interactive; then
+    echo "SSO role in ${account}:" >&2
+    echo "  1) devops        [default]" >&2
+    echo "  2) datascientist" >&2
+    printf "Role [1]: " >&2; read -r _r || _r=""
+    case "$_r" in 2 | datascientist | ds | data-scientist) CLAUDE_BEDROCK_ROLE="datascientist" ;; *) CLAUDE_BEDROCK_ROLE="devops" ;; esac
+  else
+    CLAUDE_BEDROCK_ROLE="devops"
+  fi
+fi
+role="$CLAUDE_BEDROCK_ROLE"
+
+export AWS_PROFILE="${CLAUDE_BEDROCK_PROFILE:-bb-${account}-${role}}"
+
+# Roles/accounts differ per user — fail early with the profiles you actually have.
+if ! grep -qE "^\[profile ${AWS_PROFILE}\]" "$AWS_CONFIG_FILE" 2>/dev/null; then
+  echo "ERROR: AWS profile '$AWS_PROFILE' not found in $AWS_CONFIG_FILE." >&2
+  echo "Profiles you have for these accounts:" >&2
+  grep -oE '^\[profile bb-(data-science|apps-prd)-[a-z]+\]' "$AWS_CONFIG_FILE" 2>/dev/null \
+    | sed -E 's/^\[profile (.*)\]/  \1/' | sort -u >&2
+  exit 1
+fi
+
+# --- Account-aware model set + /model picker descriptions ------------------
+# The NAME shown in /model stays the raw us.anthropic.* inference-profile ID
+# (unambiguous evidence you're on Bedrock). _DESCRIPTION labels each row's origin.
+# Availability differs per account — see the header. When data-science's Opus 4.8 /
+# Sonnet 5 quota lands, promote them to the defaults here (and drop the "pending").
+case "$account" in
+  apps-prd)
+    refresh_layer_default="apps-prd/us-east-1/notifications"
+    default_model="us.anthropic.claude-opus-4-8"
+    opus="us.anthropic.claude-opus-4-8";                 opus_desc="Amazon Bedrock · apps-prd account (most capable)"
+    sonnet="us.anthropic.claude-sonnet-5";               sonnet_desc="Amazon Bedrock · apps-prd account (balanced)"
+    haiku="us.anthropic.claude-haiku-4-5-20251001-v1:0"; haiku_desc="Amazon Bedrock · apps-prd account (fast, low-cost)"
+    custom="us.anthropic.claude-opus-4-6-v1";            custom_desc="Amazon Bedrock · apps-prd account (Opus 4.6 fallback)"
+    ;;
+  data-science)
+    refresh_layer_default="data-science/us-east-1/bedrock-agentcore"
+    default_model="us.anthropic.claude-opus-4-6-v1"      # Opus 4.8 quota still pending in this account
+    opus="us.anthropic.claude-opus-4-6-v1";              opus_desc="Amazon Bedrock · data-science account (Opus 4.6; 4.8 quota pending)"
+    sonnet="us.anthropic.claude-sonnet-4-6";             sonnet_desc="Amazon Bedrock · data-science account (Sonnet 4.6; 5 quota pending)"
+    haiku="us.anthropic.claude-haiku-4-5-20251001-v1:0"; haiku_desc="Amazon Bedrock · data-science account (fast, low-cost)"
+    custom="us.anthropic.claude-opus-4-8";               custom_desc="Amazon Bedrock · data-science account (Opus 4.8 — quota pending)"
+    ;;
+  *)
+    echo "ERROR: unknown CLAUDE_BEDROCK_ACCOUNT '$account' (expected: data-science | apps-prd)." >&2
+    exit 1
+    ;;
+esac
+
+export CLAUDE_CODE_USE_BEDROCK=1
+export ANTHROPIC_MODEL="${CLAUDE_BEDROCK_MODEL:-$default_model}"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="$opus"
+export ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION="$opus_desc"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="$sonnet"
+export ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION="$sonnet_desc"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="$haiku"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION="$haiku_desc"
+export ANTHROPIC_CUSTOM_MODEL_OPTION="$custom"
+export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="$custom"
+export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="$custom_desc"
+
+# --- Locate the le-tf-infra-aws checkout (for the credential auto-refresh) --
+# Override with CLAUDE_BEDROCK_REPO; otherwise derive it from this script's own
+# location (works when the script lives in — or is symlinked into — the repo).
+if [[ -z "${CLAUDE_BEDROCK_REPO:-}" ]]; then
+  src="${BASH_SOURCE[0]}"
+  while [[ -h "$src" ]]; do
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    if [[ "$src" != /* ]]; then src="$dir/$src"; fi
+  done
+  script_dir="$(cd -P "$(dirname "$src")" && pwd)"
+  CLAUDE_BEDROCK_REPO="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+CLAUDE_BEDROCK_REFRESH_LAYER="${CLAUDE_BEDROCK_REFRESH_LAYER:-$refresh_layer_default}"
+
+creds_ok() { aws sts get-caller-identity --output text --query Account >/dev/null 2>&1; }
+
+# --- Preflight + auto-refresh ----------------------------------------------
+# Leverage temp credentials go stale independently of the SSO token. When the check
+# fails, auto-run `leverage tofu refresh-credentials` from this account's layer
+# (mints fresh keys into ~/.aws/bb/credentials — it never touches state or infra).
+# Note: refresh mints the layer's DevOps profile, so a non-DevOps role whose creds
+# aren't already minted falls through to the manual hint. Disable with
+# CLAUDE_BEDROCK_AUTO_REFRESH=0.
+if ! creds_ok; then
+  leverage_bin="$CLAUDE_BEDROCK_REPO/.venv/bin/leverage"
+  [[ -x "$leverage_bin" ]] || leverage_bin="$(command -v leverage || true)"
+  refresh_dir="$CLAUDE_BEDROCK_REPO/$CLAUDE_BEDROCK_REFRESH_LAYER"
+  if [[ "${CLAUDE_BEDROCK_AUTO_REFRESH:-1}" == "1" && "$role" == "devops" && -n "$CLAUDE_BEDROCK_REPO" && -x "$leverage_bin" && -d "$refresh_dir" ]]; then
+    echo "claude-bedrock: temp credentials stale, refreshing via 'leverage tofu refresh-credentials'..." >&2
+    ( cd "$refresh_dir" && "$leverage_bin" tofu refresh-credentials </dev/null ) || true
+  fi
+  if ! creds_ok; then
+    echo "ERROR: no valid AWS credentials for profile '$AWS_PROFILE' after auto-refresh." >&2
+    echo "Fix (from your le-tf-infra-aws checkout):" >&2
+    echo "  .venv/bin/leverage aws sso login          # if the SSO session expired (browser)" >&2
+    echo "  cd $CLAUDE_BEDROCK_REFRESH_LAYER && .venv/bin/leverage tofu refresh-credentials" >&2
+    exit 1
+  fi
+fi
+
+# Export static credentials into the environment. Env-key credentials outrank
+# profile resolution in the AWS SDK chain, so a project settings.local.json that
+# pins AWS_PROFILE to another account cannot redirect the Bedrock session.
+eval "$(aws configure export-credentials --profile "$AWS_PROFILE" --format env)"
+
+echo "claude-bedrock: account=$account role=$role profile=$AWS_PROFILE region=$AWS_REGION model=$ANTHROPIC_MODEL" >&2
+exec claude "$@"

--- a/doc/ai-sdlc/bin/claude-bedrock
+++ b/doc/ai-sdlc/bin/claude-bedrock
@@ -20,11 +20,12 @@
 # Install (symlink this committed script onto your PATH):
 #   ln -s "$(git rev-parse --show-toplevel)/doc/ai-sdlc/bin/claude-bedrock" ~/.local/bin/claude-bedrock
 #
-# Shell-exported env vars take precedence over Claude Code settings files, so this
-# wrapper flips a single session to Bedrock without touching settings.local.json —
-# plain `claude` keeps using the native Anthropic endpoints. Credentials refresh
-# automatically when the temp keys go stale (see the preflight block); only an
-# expired SSO *session* needs a manual `leverage aws sso login` (browser).
+# Mode-dependent env vars are deliberately kept OUT of settings.local.json, so the
+# values this wrapper exports are what take effect (a settings `env` block would
+# otherwise override the shell — see the doc §1). Plain `claude` keeps using the
+# native Anthropic endpoints. Credentials refresh automatically when the temp keys go
+# stale (see the preflight block); only an expired SSO *session* needs a manual
+# `leverage aws sso login` (browser).
 set -euo pipefail
 
 export AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-$HOME/.aws/bb/config}"
@@ -112,7 +113,6 @@ export ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION="$sonnet_desc"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="$haiku"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION="$haiku_desc"
 export ANTHROPIC_CUSTOM_MODEL_OPTION="$custom"
-export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="$custom"
 export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="$custom_desc"
 
 # --- Locate the le-tf-infra-aws checkout (for the credential auto-refresh) --
@@ -156,9 +156,10 @@ if ! creds_ok; then
   fi
 fi
 
-# Export static credentials into the environment. Env-key credentials outrank
-# profile resolution in the AWS SDK chain, so a project settings.local.json that
-# pins AWS_PROFILE to another account cannot redirect the Bedrock session.
+# Materialize the chosen profile's temporary credentials as env keys for the session
+# (the bb profiles live in a non-default AWS config file). This relies on AWS_PROFILE
+# being absent from settings.local.json: a pinned AWS_PROFILE there still wins
+# (§1 — AWS_PROFILE beats env-key creds), so keep it out of settings.
 eval "$(aws configure export-credentials --profile "$AWS_PROFILE" --format env)"
 
 echo "claude-bedrock: account=$account role=$role profile=$AWS_PROFILE region=$AWS_REGION model=$ANTHROPIC_MODEL" >&2

--- a/doc/ai-sdlc/claude-code-bedrock.md
+++ b/doc/ai-sdlc/claude-code-bedrock.md
@@ -1,14 +1,23 @@
-# Claude Code on AWS Bedrock — local sessions (data-science account)
+# Claude Code on AWS Bedrock — local sessions
 
-How to run **local Claude Code sessions against Amazon Bedrock** in the
-`data-science` account, while keeping the **native Anthropic API as the
-default** for everyday sessions. This complements the CI-side `@claude` PR
-reviewer (see [`README.md`](README.md) §4), which already routes through
-Bedrock in `apps-prd`.
+How to run **local Claude Code sessions against Amazon Bedrock** in the binbash
+accounts, while keeping the **native Anthropic API as the default** for everyday
+sessions.
+
+> **Two separate Bedrock integrations live in this repo — different accounts,
+> different purposes. Don't conflate them:**
+>
+> | Integration | Account | Who / what runs it |
+> | --- | --- | --- |
+> | CI `@claude` PR reviewer | **`apps-prd`** (prod) | GitHub Actions — see [`README.md`](README.md) §4 |
+> | `claude-bedrock` local sessions | **`apps-prd`** or **`data-science`** (you pick) | humans, on their own machines (this doc) |
+>
+> The launcher targets whichever account + role you choose at launch; it never
+> touches the native Anthropic API.
 
 ```text
-claude            → native Anthropic API (subscription login)   [default]
-claude-bedrock    → Amazon Bedrock, data-science account        [opt-in]
+claude            → native Anthropic API (subscription login)            [default]
+claude-bedrock    → Amazon Bedrock — account + role chosen at launch      [opt-in]
 ```
 
 ---
@@ -44,170 +53,162 @@ project `.claude/settings.local.json` may keep the always-true values only:
 ```
 
 Keep `CLAUDE_CODE_USE_BEDROCK`, `AWS_PROFILE`, and `ANTHROPIC_MODEL` **out**
-of every settings `env` block. The shell (wrapper) provides them per
-invocation.
+of every settings `env` block. The launcher provides them per invocation.
 
 ## 2. Prerequisites
 
-- Leverage CLI SSO session and fresh per-profile credentials:
+- A Leverage CLI **SSO session**:
 
   ```bash
   leverage aws sso login                 # browser; refreshes the SSO token
-  cd data-science/us-east-1/bedrock-agentcore
-  leverage tofu refresh-credentials      # writes bb-data-science-devops temp keys
   ```
 
-- The target models must be **entitled** in the account *and* have non-zero
-  **service quotas** (see §5 — these are two separate gates).
+  The per-profile temp credentials are refreshed **automatically** by the launcher
+  when they go stale (see §3.2) — you only run `leverage aws sso login` yourself
+  when the SSO *session* itself has expired.
+
+- Access to the account you want (see §4) with a role that has `bedrock:*`
+  (DevOps or DataScientist), and the target model **enabled + quota'd** in that
+  account (see §5 — three separate gates).
 
 ## 3. Install the `claude-bedrock` launcher
 
-Save as `~/.local/bin/claude-bedrock` and `chmod +x` it:
+The launcher is committed at [`doc/ai-sdlc/bin/claude-bedrock`](bin/claude-bedrock).
+Symlink it onto your `PATH` — nothing to copy or keep in sync, and it auto-locates
+this repo from its own path for the credential auto-refresh (§3.2):
 
 ```bash
-#!/usr/bin/env bash
-#
-# claude-bedrock — launch Claude Code against Amazon Bedrock (data-science account)
-#
-# Shell-exported env vars only take effect because the project settings.local.json
-# does NOT pin CLAUDE_CODE_USE_BEDROCK / AWS_PROFILE — plain `claude` keeps using
-# the native Anthropic endpoints.
-#
-# Model override:  CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6 claude-bedrock
-set -euo pipefail
-
-export AWS_CONFIG_FILE="$HOME/.aws/bb/config"
-export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/bb/credentials"
-export AWS_PROFILE="${CLAUDE_BEDROCK_PROFILE:-bb-data-science-devops}"
-export AWS_REGION="${CLAUDE_BEDROCK_REGION:-us-east-1}"
-
-export CLAUDE_CODE_USE_BEDROCK=1
-export ANTHROPIC_MODEL="${CLAUDE_BEDROCK_MODEL:-us.anthropic.claude-opus-4-8}"
-export ANTHROPIC_DEFAULT_OPUS_MODEL="us.anthropic.claude-opus-4-8"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="us.anthropic.claude-sonnet-4-6"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="us.anthropic.claude-haiku-4-5-20251001-v1:0"
-
-# A SECOND, explicit Opus row (4.6) next to the 4.8 alias in the /model picker —
-# see "Pinning a second Opus version in the /model picker" below.
-export ANTHROPIC_CUSTOM_MODEL_OPTION="us.anthropic.claude-opus-4-6-v1"
-export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="us.anthropic.claude-opus-4-6-v1"
-export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Cross-region inference profile (Amazon Bedrock)"
-
-# Preflight: Leverage temp credentials go stale independently of the SSO token.
-if ! aws sts get-caller-identity --output text --query Account >/dev/null 2>&1; then
-  echo "ERROR: AWS credentials for profile '$AWS_PROFILE' are stale or missing." >&2
-  echo "Fix (from the le-tf-infra-aws repo):" >&2
-  echo "  leverage aws sso login   # only if the SSO token itself expired" >&2
-  echo "  cd data-science/us-east-1/bedrock-agentcore && leverage tofu refresh-credentials" >&2
-  exit 1
-fi
-
-# Export static credentials into the environment. Env-key credentials outrank
-# profile resolution in the AWS SDK chain, so a settings file that pins
-# AWS_PROFILE to another account cannot redirect the Bedrock session.
-eval "$(aws configure export-credentials --profile "$AWS_PROFILE" --format env)"
-
-echo "claude-bedrock: profile=$AWS_PROFILE region=$AWS_REGION model=$ANTHROPIC_MODEL"
-exec claude "$@"
+ln -s "$(git rev-parse --show-toplevel)/doc/ai-sdlc/bin/claude-bedrock" ~/.local/bin/claude-bedrock
 ```
 
 Usage:
 
 ```bash
-claude-bedrock                                              # Opus 4.8 on Bedrock
-CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6 claude-bedrock   # Sonnet 4.6
-claude-bedrock -p "one-shot prompt"                         # headless print mode
+claude-bedrock                                   # prompts for account + role, then launches
+claude-bedrock -p "one-shot prompt"              # headless print mode (no prompts; env/defaults)
+CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-5 claude-bedrock   # force a model for this run
 ```
 
-Bedrock model IDs use the **cross-region inference-profile** form (`us.`
-prefix), but the **suffix is inconsistent across versions — don't extrapolate
-one ID from another.** Opus 4.8 is bare (`us.anthropic.claude-opus-4-8`), Opus
-4.6 carries a `-v1` (`us.anthropic.claude-opus-4-6-v1`), Opus 4.5 a dated
-`-vN:0` (`us.anthropic.claude-opus-4-5-20251101-v1:0`), and Haiku 4.5 likewise
-(`us.anthropic.claude-haiku-4-5-20251001-v1:0`). Always confirm the exact ID
-from the account rather than guessing:
+### 3.1 Account + role selection
+
+On launch the wrapper asks which **account** and **SSO role** to use, then sets the
+matching profile (`bb-<account>-<role>`), the models that account actually has, and
+the credential-refresh layer. Non-interactively (or under `-p`) it uses the env vars
+/ defaults instead of prompting.
+
+| Account | Models available today | Default role |
+| --- | --- | --- |
+| **`data-science`** (default) | Opus 4.6 / Sonnet 4.6 / Haiku 4.5 — **Opus 4.8 & Sonnet 5 quota pending** (§5) | `devops` |
+| **`apps-prd`** (prod) | **Opus 4.8 / Sonnet 5** / Haiku 4.5 — live today | `devops` |
+
+Not everyone has DevOps (some users only have DataScientist, etc.), so the role is a
+choice too. The launcher validates `bb-<account>-<role>` against your
+`~/.aws/bb/config` and, if it's missing, prints the profiles you *do* have.
+
+Overrides (env wins over the prompts):
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `CLAUDE_BEDROCK_ACCOUNT` | `data-science` | `data-science` \| `apps-prd` |
+| `CLAUDE_BEDROCK_ROLE` | `devops` | `devops` \| `datascientist` |
+| `CLAUDE_BEDROCK_MODEL` | account default | active model for this session |
+| `CLAUDE_BEDROCK_PROFILE` | `bb-<account>-<role>` | override the whole profile |
+| `CLAUDE_BEDROCK_REPO` | auto-derived from the script path | your `le-tf-infra-aws` checkout |
+| `CLAUDE_BEDROCK_AUTO_REFRESH` | `1` | `0` to skip the auto-refresh (§3.2) |
+
+### 3.2 Automatic credential refresh
+
+Leverage temp credentials go stale independently of the SSO token. On each run the
+launcher checks `aws sts get-caller-identity`; if it fails, it auto-runs
+`leverage tofu refresh-credentials` from the chosen account's layer
+(`data-science/us-east-1/bedrock-agentcore` or `apps-prd/us-east-1/notifications`)
+to mint fresh keys into `~/.aws/bb/credentials`. That call only writes local
+credentials — it never runs `plan`/`apply` or touches state or infra, which is why
+it's safe to automate and safe to ship in this public repo. The wrapper also confers
+no access on its own: with no valid SSO session the refresh fails closed and it exits.
+
+**Caveat — roles:** `refresh-credentials` mints the layer's **DevOps** profile, so
+the auto-refresh only covers `role=devops`. A non-DevOps role whose static creds
+aren't already minted falls through to the manual hint (run `leverage aws sso login`
+and mint that role's creds). Only an **expired SSO session** ever needs the manual,
+non-automatable browser login.
+
+### 3.3 The `/model` picker
+
+In a Bedrock session the `/model` list is built from the launcher's env vars, not a
+fixed catalog — each `ANTHROPIC_DEFAULT_*_MODEL` (and `ANTHROPIC_CUSTOM_MODEL_OPTION`)
+injects one row (verified on Claude Code `v2.1.172`). Each accepts `_NAME` and
+`_DESCRIPTION` suffix variables ([model-config docs](https://code.claude.com/docs/en/model-config));
+the launcher sets only `_DESCRIPTION` — labelling every row **Amazon Bedrock ·
+`<account>` account** so the routing is obvious — and leaves the **name** as the raw
+`us.anthropic.*` inference-profile ID (unambiguous evidence you're on Bedrock, not the
+native API). Example rows for an **apps-prd** session:
+
+| Picker row (name — description) | Driven by |
+| --- | --- |
+| `us.anthropic.claude-sonnet-5` — *Amazon Bedrock · apps-prd account (balanced)* | `ANTHROPIC_DEFAULT_SONNET_MODEL` + `_DESCRIPTION` |
+| `us.anthropic.claude-opus-4-8` — *Amazon Bedrock · apps-prd account (most capable)* | `ANTHROPIC_DEFAULT_OPUS_MODEL` + `_DESCRIPTION` |
+| `us.anthropic.claude-haiku-…` — *Amazon Bedrock · apps-prd account (fast, low-cost)* | `ANTHROPIC_DEFAULT_HAIKU_MODEL` + `_DESCRIPTION` |
+| `us.anthropic.claude-opus-4-6-v1` — *Amazon Bedrock · apps-prd account (Opus 4.6 fallback)* | `ANTHROPIC_CUSTOM_MODEL_OPTION` trio |
+
+A `data-science` session shows the same shape with that account's models (Opus 4.6 /
+Sonnet 4.6, plus Opus 4.8 as a "quota pending" custom row). `ANTHROPIC_CUSTOM_MODEL_OPTION`
+adds exactly **one** extra row; for several extra models the mechanism is the
+`availableModels` / `modelOverrides` settings keys, but those live in a settings file
+(subject to the §1 leak caveat), so the single env-var row fits this dual-mode wrapper.
+
+**Bedrock model-ID caveat:** IDs use the cross-region inference-profile form (`us.`
+prefix), but the **suffix is inconsistent across versions — don't extrapolate one ID
+from another.** Current-generation models are bare — Opus 4.8
+(`us.anthropic.claude-opus-4-8`), Sonnet 5 (`us.anthropic.claude-sonnet-5`) — while
+older ones carry suffixes: Opus 4.6 a `-v1`, Opus 4.5 a dated `-vN:0`, Haiku 4.5
+likewise (`us.anthropic.claude-haiku-4-5-20251001-v1:0`). Always confirm from the
+account:
 
 ```bash
-aws bedrock list-inference-profiles --region us-east-1 --profile bb-data-science-devops \
+aws bedrock list-inference-profiles --region us-east-1 --profile bb-<account>-devops \
   --query "inferenceProfileSummaries[?contains(inferenceProfileId,'anthropic')].inferenceProfileId" --output text
 ```
 
-### Pinning a second Opus version in the `/model` picker
-
-In a Bedrock session the `/model` list is built from the launcher's env vars,
-not a fixed catalog — each variable injects one row (verified on Claude Code
-`v2.1.172`):
-
-| Picker row | Driven by |
-| --- | --- |
-| `us.anthropic.claude-sonnet-4-6` — *Custom Sonnet model* | `ANTHROPIC_DEFAULT_SONNET_MODEL` |
-| `us.anthropic.claude-opus-4-8` — *Custom Opus model* | `ANTHROPIC_DEFAULT_OPUS_MODEL` |
-| `us.anthropic.claude-haiku-…` — *Custom Haiku model* | `ANTHROPIC_DEFAULT_HAIKU_MODEL` |
-| **Opus 4.8 ✔** (active) | `ANTHROPIC_MODEL` |
-
-There is only one Opus slot, so to switch between Opus **4.8** and **4.6** in the
-same session the launcher adds one more row via the
-`ANTHROPIC_CUSTOM_MODEL_OPTION` trio (its `_NAME` / `_DESCRIPTION` companions set
-the label):
-
-```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION="us.anthropic.claude-opus-4-6-v1"
-export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="us.anthropic.claude-opus-4-6-v1"
-export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Cross-region inference profile (Amazon Bedrock)"
-```
-
-Open `/model` and a **`us.anthropic.claude-opus-4-6-v1`** row appears next to Opus
-4.8; `s` switches the current session to it. (Env vars are read at launch, so relaunch `claude-bedrock`
-for the row to show.) Because the launcher re-pins `ANTHROPIC_MODEL` on every run,
-the picker's `Enter` ("set as default") won't survive a relaunch — to *start* on
-4.6 use the existing override:
-`CLAUDE_BEDROCK_MODEL=us.anthropic.claude-opus-4-6-v1 claude-bedrock`. This is the
-Opus that actually **invokes** today: per §5 the 4.8 TPM quota (`L-DB99DCDB`) is
-still 0, so selecting Opus 4.8 fails with `AccessDenied` (not available for this
-account) while 4.6 works — and the pin keeps working unchanged once that quota
-lands.
-
-**Keep this in the wrapper, never in a settings `env` block.** Per §1 a settings
-`env` block also applies to plain `claude` (native Anthropic API), where a
-Bedrock inference-profile ID like `us.anthropic.claude-opus-4-6-v1` is rejected as
-`dispatching to firstParty` (the §6 404). Exporting it from the launcher keeps
-it scoped to Bedrock sessions.
-
-`ANTHROPIC_CUSTOM_MODEL_OPTION` adds exactly **one** extra row. To pin several
-models the mechanism is the `availableModels` + `modelOverrides` settings keys
-instead — but those live in a settings file (subject to the §1 leak caveat), so
-the single env-var row is the right fit for this dual-mode wrapper.
-
 ## 4. Who can enable model access (permission sets)
 
-Bedrock model access is an **account-level grant**: once enabled by anyone,
-every principal in the account with `bedrock:InvokeModel*` can consume the
-model. Per [`management/global/sso/policies.tf`](../../management/global/sso/policies.tf):
+Bedrock model access is an **account-level grant**: once enabled by anyone, every
+principal in the account with `bedrock:InvokeModel*` can consume the model. Per
+[`management/global/sso/policies.tf`](../../management/global/sso/policies.tf):
 
-| Permission set | `aws-marketplace:*` + `bedrock:*` (manage model access) | `servicequotas:*` (file quota increases) |
+| Permission set | `aws-marketplace:*` + `bedrock:*` (manage + invoke) | `servicequotas:*` (file quota increases) |
 | --- | --- | --- |
-| **DevOps** | ✅ (verified live) | ✅ (verified live) |
-| **DataScientist** | ✅ (inline policy) | ❌ — quota requests must go through DevOps/Administrator |
+| **DevOps** | ✅ (region-conditioned to us-east-1/us-east-2/us-west-2) | ✅ |
+| **DataScientist** | ✅ (same region condition) | ❌ — quota requests go through DevOps/Administrator |
 
-So either DevOps or DataScientist can accept a model agreement; only
-DevOps/Administrator can file the service-quota increases that newer models
-also need.
+Both `bedrock:*` grants are conditioned on `aws:RequestedRegion ∈
+{us-east-1, us-east-2, us-west-2}`, which covers the regions the `us.` cross-region
+inference profiles route to — so IAM is **not** what blocks a new model (verified: the
+DevOps role invokes Sonnet 4.6 / Opus 4.6 / Haiku 4.5 today). What's missing for a new
+model is gate 1/2 below, not IAM.
 
-## 5. Model entitlement state (data-science, us-east-1)
+## 5. Model availability — the three gates (checked 2026-07-17, us-east-1)
 
-Checked 2026-06-10. **Entitlement and quota are separate gates** — a model can
-be fully subscribed yet still refuse invokes because AWS ships some new models
-with **all token quotas at 0**.
+Three **independent** gates must all pass to invoke a model. A model can clear one or
+two and still refuse:
 
-| Model | Agreement | Token quotas | Invokable |
-| --- | --- | --- | --- |
-| Sonnet 4.6, Opus 4.5/4.6, Haiku 4.5 | ✅ | 6M TPM-class | ✅ |
-| **Opus 4.8** | ✅ (accepted 2026-06-10) | **0 — increase pending** | ❌ until quota granted |
-| Opus 4.7 | ✅ | 0 | ❌ |
+1. **Model access** — the agreement is accepted for that model, per account (Bedrock
+   console → *Model access*).
+2. **Service quota (TPM)** — non-zero, per model, per account, and per profile family
+   (`us.` cross-region vs `global.` global-cross-region have *separate* quotas).
+3. **IAM** — your SSO role allows `bedrock:InvokeModel*` (see §4 — DevOps/DataScientist do).
 
-A quota increase for *Cross-region model inference tokens per minute for
-Anthropic Claude Opus 4.8* (`L-DB99DCDB`) to the AWS default (30M) was filed on
-2026-06-10 → status `CASE_OPENED`. Check progress with:
+| Model | `apps-prd` | `data-science` |
+| --- | --- | --- |
+| Opus 4.6, Sonnet 4.6, Haiku 4.5 | ✅ | ✅ |
+| **Opus 4.8** | ✅ | ⏳ **quota pending** |
+| **Sonnet 5** | ✅ | ⏳ **quota pending** |
+| Fable 5 | ❌ no access | ❌ no access |
+
+So **use `apps-prd` for Opus 4.8 / Sonnet 5 today**; in `data-science` they return
+*"not available for this account"* — a gate-1/2 (access/quota) block, **not** IAM.
+Quota-increase cases for data-science's *Global cross-region* Opus 4.8 (30M TPM) and
+Sonnet 5 (6M TPM) are filed and `Case Opened`. Check any quota with:
 
 ```bash
 aws service-quotas get-service-quota --service-code bedrock \
@@ -215,17 +216,20 @@ aws service-quotas get-service-quota --service-code bedrock \
   --profile bb-data-science-devops --query 'Quota.Value'
 ```
 
-Once it returns non-zero, `claude-bedrock` works with Opus 4.8 as-is. Until
-then use `CLAUDE_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6`.
+> **The console's IAM-worded error is misleading.** The Bedrock console playground may
+> surface a missing model as *"not authorized to perform bedrock:InvokeModelWithResponseStream"*,
+> but the reproducible gate is access/quota (`converse` returns *"not available for this
+> account"*). The role's `bedrock:*` is fine — don't go editing permission sets for this.
 
 ## 6. Troubleshooting
 
 | Symptom | Root cause | Fix |
 | --- | --- | --- |
-| `There's an issue with the selected model (us.anthropic....)` and debug log shows `dispatching to firstParty` | `CLAUDE_CODE_USE_BEDROCK` pinned/overridden by a settings `env` block — the Bedrock model ID was sent to the native Anthropic API (404) | Remove the key from every settings `env` block (§1) |
-| `Failed to authenticate. API Error: 403 The security token included in the request is invalid` | `AWS_PROFILE` pinned in a settings `env` block to a profile with stale credentials — it outranks the wrapper's profile *and* env-key credentials | Remove the `AWS_PROFILE` pin (§1); refresh credentials |
-| `AccessDeniedException: <model> is not available for this account` on invoke, while `list-inference-profiles` shows it `ACTIVE` | Model agreement not accepted, **or** (if `get-foundation-model-availability` is all green) token quotas are 0 | Accept the agreement (Bedrock console → Model access, or `create-foundation-model-agreement`); then request the TPM quota (§5) |
-| Wrapper preflight fails on `sts get-caller-identity` | Leverage temp credentials expired (SSO token may still be valid) | `leverage tofu refresh-credentials` from any data-science layer; `leverage aws sso login` only if the SSO token itself expired |
+| `AccessDeniedException: <model> is not available for this account` (or a console `InvokeModelWithResponseStream` error) | Model **access or quota** not granted for that model **in that account** (gate 1/2, §5) — **not** IAM | Use `apps-prd` (has Opus 4.8 / Sonnet 5), or enable access + wait for the data-science quota case |
+| `There's an issue with the selected model (us.anthropic....)`; debug log shows `dispatching to firstParty` | `CLAUDE_CODE_USE_BEDROCK` pinned/overridden by a settings `env` block — the Bedrock model ID went to the native Anthropic API (404) | Remove the key from every settings `env` block (§1) |
+| `403 The security token included in the request is invalid` | `AWS_PROFILE` pinned in a settings `env` block to a stale profile — it outranks the wrapper | Remove the `AWS_PROFILE` pin (§1); refresh credentials |
+| `ERROR: AWS profile 'bb-…' not found` | You don't have that account/role combo | Pick a profile the launcher lists (from your `~/.aws/bb/config`) |
+| `ERROR: no valid AWS credentials … after auto-refresh` | SSO session expired, or a non-DevOps role whose creds aren't minted (§3.2) | `leverage aws sso login` (browser), then re-run; for non-DevOps, mint that role's creds |
 
 To see the real API error behind Claude Code's masked message:
 
@@ -234,5 +238,5 @@ claude-bedrock -p "test" --debug --debug-file /tmp/claude-debug.log
 grep -E "dispatching to|API error" /tmp/claude-debug.log
 ```
 
-`dispatching to firstParty` = native Anthropic API; Bedrock-mode sessions must
-not show `firstParty` with a `us.anthropic.*` model.
+`dispatching to firstParty` = native Anthropic API; Bedrock-mode sessions must not
+show `firstParty` with a `us.anthropic.*` model.

--- a/doc/ai-sdlc/claude-code-bedrock.md
+++ b/doc/ai-sdlc/claude-code-bedrock.md
@@ -205,10 +205,13 @@ two and still refuse:
 | **Sonnet 5** | ✅ | ⏳ **quota pending** |
 | Fable 5 | ❌ no access | ❌ no access |
 
-So **use `apps-prd` for Opus 4.8 / Sonnet 5 today**; in `data-science` they return
-*"not available for this account"* — a gate-1/2 (access/quota) block, **not** IAM.
-Quota-increase cases for data-science's *Global cross-region* Opus 4.8 (30M TPM) and
-Sonnet 5 (6M TPM) are filed and `Case Opened`. Check any quota with:
+So **use `apps-prd` for Opus 4.8 / Sonnet 5 today**; in `data-science` the launcher's
+`us.` profiles return *"not available for this account"* — a gate-1/2 (access/quota)
+block, **not** IAM. Heads-up: the pending Service Quotas cases you may see are for the
+separate **`global.*`** family (*Global cross-region* Opus 4.8 / Sonnet 5), which the
+launcher does **not** use (and which the region condition blocks by design, §4) — so
+they won't unblock the launcher on their own. Turning on data-science's **`us.`**
+models is its own model-access + `us.`-quota step. Check a quota with:
 
 ```bash
 aws service-quotas get-service-quota --service-code bedrock \


### PR DESCRIPTION
## What?

Commit the `claude-bedrock` local launcher into the repo at `doc/ai-sdlc/bin/claude-bedrock` (previously a copy-paste block in the doc) and make it **account- and role-aware**; rewrite `doc/ai-sdlc/claude-code-bedrock.md` to match.

- **Account** (`data-science` | `apps-prd`) + **role** (`devops` | `datascientist`) chosen at launch — interactive, env-overridable (`CLAUDE_BEDROCK_ACCOUNT` / `CLAUDE_BEDROCK_ROLE`), headless-safe under `-p`; invalid combos fail with the profiles you actually have.
- **Account-aware models** + `/model` picker `_DESCRIPTION` labels, verified live:
  - `apps-prd` → **Opus 4.8 / Sonnet 5** (invoke ✅)
  - `data-science` → Opus 4.6 / Sonnet 4.6 (Opus 4.8 & Sonnet 5 quota still pending)
- Repo path **auto-derived** from the script location (no personal paths); install by symlinking onto `PATH`. Automatic `leverage tofu refresh-credentials` on stale creds (per-account anchor, DevOps).
- Doc: the **three invocation gates** (model access / quota / IAM), accurate per-account availability, install-by-symlink, refreshed troubleshooting.

No Terraform changes — bash launcher + markdown only.

## Why?

Sonnet 5 and Opus 4.8 are live on Bedrock in `apps-prd`; users with prd access can now use them for local Claude Code sessions (validated: `/model` switches Sonnet 5 / Opus 4.8 / Opus 4.6 / Haiku 4.5, all responding). `data-science` users keep working models until that account's quota lands. Committing the launcher gives collaborators one drift-free, portable source instead of a copy-paste block, and the doc now reflects the real per-account state (including that a profile showing `ACTIVE` is not the same as being invocable).

## References

- Claude Code `/model` `_DESCRIPTION` env vars: https://code.claude.com/docs/en/model-config
- Follow-up (separate, not in this PR): enable Opus 4.8 / Sonnet 5 access + quota in `data-science` (Service Quotas cases pending), and — to use `global.*` inference profiles / the Bedrock console — widen the DevOps/DataScientist Bedrock region condition in `management/global/sso/policies.tf`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a launcher for starting Claude Code sessions through Amazon Bedrock.
  - Supports account, role, region, profile, model, and custom configuration selection.
  - Automatically verifies credentials and can refresh eligible temporary credentials before launching.

- **Documentation**
  - Updated the Bedrock local-session guide with setup, model selection, permissions, troubleshooting, and account-routing guidance.
  - Clarified model availability requirements and the meaning of Bedrock session routing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->