### PR TITLE
docs(security): security-monitoring-agent reference layer (closes #541)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-finops-agent-mgmt-design.md
+++ b/docs/superpowers/specs/2026-07-17-finops-agent-mgmt-design.md
@@ -1,0 +1,141 @@
+# AWS FinOps Agent — `management/global/finops-agent` layer design
+
+- **Date:** 2026-07-17
+- **Issue:** [binbashar/le-tf-infra-aws#1003](https://github.com/binbashar/le-tf-infra-aws/issues/1003) — Implement and test AWS DevOps, Security and FinOps frontier agents
+- **Scope of this spec:** the **FinOps Agent** only. The DevOps and Security frontier agents from #1003 are out of scope and get their own specs.
+- **Status:** approved for planning
+
+## Problem
+
+AWS launched the [AWS FinOps Agent](https://aws.amazon.com/finops-agent/) (preview) — an AI agent that answers cost questions, investigates cost anomalies to root cause, and surfaces optimization recommendations, with optional Jira/Slack integrations. We want to stand it up in the **management (payer)** account and manage as much of it as possible with our IaC (OpenTofu via Leverage), consistent with the rest of this repo.
+
+## Key finding that shapes the design
+
+The original framing was "if OpenTofu doesn't support it, fall back to AWS CDK (more current)." Investigation showed that framing does not apply here:
+
+- The agent instance — an **agentspace** — is created only through a **preview API**, `finops-agent:CreateAgentSpace`.
+- **No CloudFormation resource type exists** (`AWS::FinOps::*` / `AWS::FinOpsAgent::*` are absent from the CFN resource reference).
+- Because CDK and the Terraform/OpenTofu `awscc` (Cloud Control) provider are both **generated from the CloudFormation registry**, the absence of a CFN type means **neither CDK nor `awscc` can create the agentspace either**.
+- The plain `hashicorp/aws` provider has **no `aws_finops*` resource** (confirmed against the installed provider 5.100 changelog).
+
+Conclusion: **CDK offers no capability advantage over OpenTofu for this service**, while it would add a foreign toolchain (Node, `cdk bootstrap`, separate state, no Leverage/Atlantis/Infracost integration) to a 100%-OpenTofu repo. The agentspace is unsupported *everywhere*, so it is the one manual step regardless of tool.
+
+What **is** fully IaC-able today with the plain `hashicorp/aws` provider is the meaningful surface: the two IAM roles the service assumes, their permission policies, and the feature prerequisites. The creation wizard explicitly supports **"use an existing role"** in Steps 2 and 3, so OpenTofu creates the roles and the one-time `CreateAgentSpace` merely selects them.
+
+## Chosen approach
+
+**Approach A — OpenTofu layer for everything IaC-able + one documented manual step.**
+
+Rejected alternatives:
+- **B (AWS CDK layer):** can only recreate the same IAM roles/prereqs OpenTofu already does natively (agentspace still unsupported) — foreign toolchain, zero extra capability.
+- **C (fully manual):** leaves IAM roles and prerequisites unmanaged and drifting, against the repo's IaC-first principle.
+
+### Prerequisite scope (decided)
+
+**Roles + Cost Anomaly monitor + Compute Optimizer opt-in (management account only).**
+
+- Cost Anomaly Detection monitor — enables the agent's headline anomaly-investigation feature; org-wide consolidated billing is visible from the payer account.
+- Compute Optimizer opt-in scoped to the management account only (`include_member_accounts = false`) — enables rightsizing recommendations. Management has little compute, so value is limited, but it exercises the full agent feature set end-to-end and is a natural place to later flip to org-wide.
+
+## Placement
+
+`management/global/finops-agent/` — beside the existing billing-owned globals (`cost-mgmt`, `cost-report`, `organizations`).
+
+In `management/global/*`, `var.region` resolves to **us-east-1** via `management/config/backend.tfvars` (`region = "us-east-1"`), which is what Cost Explorer, Cost Anomaly Detection, Compute Optimizer, and the FinOps Agent preview require. Atlantis autodiscover picks the layer up automatically — no `atlantis.yaml` change needed.
+
+## Architecture
+
+```
+┌──────────────────── management account · us-east-1 ────────────────────┐
+│                                                                         │
+│   OpenTofu (this layer)                    Manual (one-time, preview)   │
+│   ─────────────────────                    ─────────────────────────    │
+│   aws_iam_role.agent      ──────┐                                       │
+│     + agent permissions policy  │          Console wizard →             │
+│   aws_iam_role.operator   ──────┼────────► CreateAgentSpace             │
+│     + operator perms policy     │          Step 2: "use existing role"  │
+│     (trust: finops-agent.       │            → agent_role_arn (output)  │
+│      amazonaws.com)             │          Step 3: "use existing role"  │
+│                                 └────────►   → operator_role_arn        │
+│   aws_ce_anomaly_monitor            ← agent's anomaly-investigation     │
+│     (DIMENSIONAL / SERVICE)           feature reads from this           │
+│   aws_computeoptimizer_enrollment_status  ← rightsizing recs            │
+│     (Active, management only)                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The agentspace is the only piece with no CFN/tofu/awscc/CDK support, so it is the only manual step. The README carries a "migrate to a native resource when AWS ships support" note.
+
+## Components (files)
+
+| File | Contents |
+|---|---|
+| `config.tf` | `aws` provider (region/profile from vars); S3 backend key `management/finops-agent/terraform.tfstate`; `aws ~> 5.0`; `required_version ~> 1.6`; `data.aws_caller_identity` + `data.aws_region` |
+| `common-variables.tf` | symlink → `../../../config/common-variables.tf` |
+| `locals.tf` | standard `tags` (`Terraform`, `Environment`, `Layer`); `name_prefix`; `account_id`; `region`. **No `aws-apn-id` tag** — per CLAUDE.md that PRM tag is scoped to Bedrock Marketplace layers only |
+| `variables.tf` | `agent_role_name` (default `FinOpsAgentRole`), `operator_role_name` (default `FinOpsAgentOperatorRole`), `anomaly_monitor_name`, `enable_compute_optimizer` (bool, default `true`) |
+| `iam.tf` | two `aws_iam_role` (agent, operator) sharing the trust policy; two customer-managed `aws_iam_policy` built from the documented policy JSON; `aws_iam_role_policy_attachment` for each |
+| `cost-anomaly.tf` | `aws_ce_anomaly_monitor` — `DIMENSIONAL` monitor on `SERVICE` |
+| `compute-optimizer.tf` | `aws_computeoptimizer_enrollment_status` — `status = "Active"`, `include_member_accounts = false`, gated on `var.enable_compute_optimizer` |
+| `outputs.tf` | `agent_role_arn`, `operator_role_arn`, `anomaly_monitor_arn`, `compute_optimizer_status` |
+| `README.md` | architecture, OpenTofu-vs-manual split, console-wizard steps (selecting our role ARNs), migration note, and the PRM-tag rationale (why `aws-apn-id` is intentionally absent) |
+
+## Design decision: inline customer-managed policies (not AWS managed)
+
+The two permission policies are implemented as **customer-managed `aws_iam_policy` built from the documented policy JSON**, rather than attaching AWS's managed `FinOpsAgentAgentPolicy` / `FinOpsAgentOperatorPolicy`.
+
+Rationale:
+- **Preview service** — managed-policy ARNs may not be reliably attachable yet and may change during preview.
+- **Git-visible / versioned** — the exact permission set lives in the repo and is reviewable in PRs.
+- **Consistency** — matches the existing inline-`jsonencode` IAM style in `data-science/us-east-1/bedrock-agentcore` and `bedrock-agent-kyb`.
+
+Trade-off: we track AWS's policy revisions manually. The README documents the managed-policy alternative so a future switch is a one-line change.
+
+## Trust policy (verified from AWS docs)
+
+Both roles share this trust policy:
+
+- **Principal:** service `finops-agent.amazonaws.com`
+- **Actions:** `sts:AssumeRole`, `sts:SetSourceIdentity` (the latter stamps the calling user's identity onto the session so agent-driven CloudTrail events are attributable per user)
+- **Conditions:**
+  - `StringEquals` `aws:SourceAccount = <management account id>`
+  - `ArnLike` `aws:SourceArn = arn:aws:finops-agent:*:<management account id>:agentspace/*`
+
+The `agentspace/*` wildcard allows any agent in the account to assume the role; after the agentspace is created it can optionally be tightened to the specific agent ID.
+
+## Permission policies (source of truth: AWS docs)
+
+- **Agent permissions policy** (attached to agent role): read access to Cost Explorer (`ce:Get*`/`ce:List*`/`ce:Describe*`), Budgets, Cost Optimization Hub, Compute Optimizer, `ec2/ecs/autoscaling/lambda/rds` describe/list, `organizations` read, `pricing`, `freetier`, `bcm-pricing-calculator`, `cloudtrail` lookup/describe, `cloudwatch` metrics, `logs` query; plus scoped EventBridge management (`events:*` on `rule/*` with `events:ManagedBy = finops-agent.amazonaws.com` and `aws:ResourceAccount` conditions).
+- **Operator permissions policy** (attached to operator role): `finops-agent:*` web-application actions (conversations, turns, tasks, automations, documents, artifacts, records, feedback).
+
+Both are reproduced verbatim from the [AWS FinOps Agent IAM setup guide](https://docs.aws.amazon.com/finops-agent/latest/userguide/setting-up.html) in `iam.tf`.
+
+## Manual step (post-apply, one-time)
+
+1. Open the AWS FinOps Agent console in the management account (us-east-1).
+2. **Create agent** → name it (e.g. `binbash-finops-agent`).
+3. **Step 2 (AWS resources access):** choose **Use an existing role** → select the `agent_role_arn` output.
+4. **Step 3 (web app access):** choose **Use an existing role** → select the `operator_role_arn` output.
+5. **Step 4 (integrations):** optional Jira/Slack — out of scope for this layer; can be added later.
+6. **Create.** Verify both roles appear under **Permissions** on the agent detail page.
+
+## Validation & rollout
+
+1. `leverage tofu fmt -recursive`
+2. `leverage tofu validate`
+3. `leverage tofu plan` from the layer directory
+4. Post the **redacted** plan to the PR per the CLAUDE.md procedure (action section only; 12-digit account IDs → `<MANAGEMENT_ACCOUNT_ID>`; scan clean).
+5. **Human applies** after approval — never from automation.
+6. Run the manual console wizard (above) selecting the role ARNs.
+7. Optional: add an `infracost.yml` entry for completeness (all resources here are $0).
+
+## Out of scope
+
+- The DevOps and Security frontier agents from #1003 (separate specs).
+- Jira/Slack integrations (Step 4 of the wizard).
+- Org-wide Compute Optimizer enrollment (management-account-only for now; easy future flip via `include_member_accounts`).
+- A native IaC resource for the agentspace itself — blocked on AWS shipping CFN/`awscc`/tofu support; tracked in the README migration note.
+
+## Migration note (for the README)
+
+When AWS ships a CloudFormation resource type for the FinOps agentspace (which would also unlock `awscc` and CDK), replace the manual `CreateAgentSpace` step with the native resource, wire it to the existing role ARNs, and import the already-created agentspace into state. Until then, the roles + prerequisites remain fully managed by this layer and only the agentspace is manual.

--- a/security/us-east-1/security-monitoring-agent --/README.md
+++ b/security/us-east-1/security-monitoring-agent --/README.md
@@ -1,7 +1,7 @@
 # Security Monitoring & the AWS Security Agent — Reference Layer
 
 > **Status: Documentation-only reference layer.** This directory intentionally
-> contains **no `.tf` files**. The trailing ` --` suffix marks it as a disabled
+> contains **no `.tf` files**. The trailing space-plus-`--` suffix marks it as a disabled
 > layer, so Atlantis autodiscover and `leverage tofu` never try to plan or apply
 > it. It exists to document a posture decision and to answer
 > [issue #541 — *Review our implementation of the AWS security monitoring
@@ -19,7 +19,7 @@ This layer reviews our AWS **security monitoring** posture against the model in
 
 1. **The classic detective stack is the foundation and it is only half-on.**
    CloudTrail and IAM Access Analyzer are live; **AWS Config, Security Hub,
-   GuardDuty, and Inspector are written but sitting in disabled ` --` layers.**
+   GuardDuty, and Inspector are written but sitting in disabled `--`-suffixed layers.**
    The article's core recommendation (Config + Security Hub as the central pane,
    GuardDuty/Inspector feeding it) is therefore **not** currently realized in the
    `security` account. Re-enabling those layers is step one — see
@@ -34,7 +34,7 @@ This layer reviews our AWS **security monitoring** posture against the model in
    | AWS AI offering | Axis | Verdict |
    |---|---|---|
    | **AWS Security Agent** (threat modeling, code review, on-demand pentest) | Build-time / shift-left | **Complementary** — new phase, no overlap |
-   | **AI Investigative Agent** (in Security Incident Response) | Response-time / triage | **Complementary**, and **replaces** custom alert-triage glue |
+   | **AI Investigative Agent** (in Security Incident Response) | Response-time / investigation | **Complementary** — replaces the manual **investigation** runbook (AWS-supported cases); not alert routing |
    | **Unified Security Hub** (exposure findings, attack-path correlation) | Aggregation evolution | **Replaces** our custom GuardDuty→Lambda→EventBridge routing |
 
    > **Bottom line:** keep the detectors, drop the bespoke glue. Re-enable the
@@ -49,7 +49,7 @@ This layer reviews our AWS **security monitoring** posture against the model in
 The article organizes AWS security telemetry into three layers. This is the lens
 we use for the gap analysis below.
 
-```
+```text
    ┌──────────────────────────────────────────────────────────────────┐
    │  3. AGGREGATION      Security Hub  ── single pane, ASFF, scoring   │
    │        ▲                                                           │
@@ -81,14 +81,14 @@ Article guidance we hold ourselves to:
 ## Current posture in this repository
 
 What the article recommends vs. **what is actually deployed today**. "Disabled"
-means the layer exists and is written, but its directory carries the ` --` suffix
+means the layer exists and is written, but its directory carries the space-plus-`--` suffix
 (or is an empty stub), so it is not applied.
 
 | Service | cloudonaut stance | Where it lives in this repo | State | Gap |
 |---|---|---|---|---|
 | **CloudTrail** (org, multi-region, log validation, KMS) | Required source | `security/us-east-1/security-audit` (`terraform-aws-cloudtrail` `0.24.0`) | ✅ **Active** | none |
 | **IAM Access Analyzer** | Recommended | `security/us-east-1/security-base` | ✅ **Active** | none |
-| **AWS Config** (FSBP checks, 1-yr retention) | **Core / required** | `management/us-east-1/security-compliance` (active) · `security/us-east-1/security-compliance --` (**disabled**) (`terraform-aws-config` `v8.1.0`) | ⚠️ **Partial** | Enable + delegate to the `security` account |
+| **AWS Config** (selected managed rules, 1-yr retention) | **Core / required** | `management/us-east-1/security-compliance` (active) · `security/us-east-1/security-compliance --` (**disabled**) (`terraform-aws-config` `v8.1.0`) | ⚠️ **Partial** | Enable + delegate to `security`; note this configures a **curated rule subset** (root-MFA, CloudTrail, GuardDuty, RDS/EC2 checks), **not** the full FSBP standard — that gap is closed by Security Hub |
 | **Security Hub** (FSBP + CIS) | **Core / central pane** | `security/us-east-1/security-hub --` & `management/us-east-1/security-hub --` (**disabled**; `auto_enable_standards = "NONE"`) | ❌ **Disabled** | Delegate admin, enable standards org-wide |
 | **GuardDuty** (all regions) | Recommended | `management/us-east-1/security-monitoring --` (**disabled**; `delegated-admin`) · `security/us-east-1/security-monitoring --` (**disabled**; `terraform-aws-guardduty-multiaccount` `v0.2.1` + custom `terraform-aws-guardduty-monitor` `v1.2.1`) | ❌ **Disabled** | Delegate admin from management, then re-enable in security |
 | **Amazon Inspector** (EC2/ECR) | Recommended | `management/us-east-1/security-compliance` (delegation, gated on `enable_inspector`) · `security/us-east-1/security-compliance --` (**disabled**; `inspector2` via `null_resource`) | ❌ **Disabled** | Set `enable_inspector = true` in management, then enable in security |
@@ -101,10 +101,15 @@ means the layer exists and is written, but its directory carries the ` --` suffi
 > `security-monitoring --` sibling. Re-activation means promoting that code, not
 > writing it from scratch.
 
-**Reading of the gap:** the *sources* layer is healthy (CloudTrail + Config-in-management),
-but the **analysis** and **aggregation** layers the article calls "core" are
-switched off in the `security` account. The good news: the code already exists —
-this is a **re-enablement and delegation** exercise, not new development.
+**Reading of the gap:** the *sources* layer is **partially** covered — CloudTrail
+(org-wide) and Config-in-management are confirmed active, but the other sources the
+diagram lists are **not verified enabled for the `security` account**: VPC Flow
+Logs exist only in the `base-network` layers of other accounts (`shared`,
+`apps-prd`, `apps-devstg`), and **Route 53 DNS query logging is absent repo-wide**.
+The **analysis** and **aggregation** layers the article calls "core" are switched
+off in the `security` account. The good news: most of the code already exists — so
+the bulk of this is a **re-enablement and delegation** exercise, with VPC
+Flow/DNS-logging coverage to confirm (or add) separately.
 
 ---
 
@@ -161,12 +166,16 @@ AWS responders:
 Enablement is org-level (AWS Organizations management account); AI investigation
 applies to **AWS-supported** cases (not self-managed).
 
-**Verdict: Complementary, and a partial replacement of glue.** It **consumes the
-same CloudTrail** our `security-audit` layer already produces — reinforcing that
-the source layer must stay on. It does **not** replace the detectors, but it
-**does replace the manual triage runbook** and much of the bespoke
-severity-filtering/notification logic the article hand-rolls. It answers *"what
-happened and what do I do?"* — the step after a finding fires.
+**Verdict: Complementary — replaces manual *investigation*, not alert routing.**
+It **consumes the same CloudTrail** our `security-audit` layer already produces —
+reinforcing that the source layer must stay on. It does **not** replace the
+detectors, and it does **not** handle severity-filtering/notification routing
+(that's finding C, unified Security Hub) — it answers *"what happened here?"* by
+**replacing the manual investigation runbook** for a case, the step after a
+finding is escalated. Scope limits to keep in mind: it applies to **AWS-supported
+cases only** (not self-managed), is oriented to **threat-detection**
+investigations rather than posture/compliance findings, and is invoked per-case
+rather than as a standing notification path.
 Docs: <https://docs.aws.amazon.com/security-ir/latest/userguide/ai-investigative-agent.html>
 
 ### C. Unified Security Hub — *aggregation-layer evolution*
@@ -196,7 +205,7 @@ Docs: <https://docs.aws.amazon.com/securityhub/latest/userguide/exposure-finding
 Detective foundation (re-enabled) feeding a native aggregation/correlation layer,
 wrapped by the two agents at the ends of the lifecycle.
 
-```
+```text
    BUILD-TIME                     RUN-TIME (detect → aggregate)                 RESPONSE-TIME
    ─────────                      ─────────────────────────────                ─────────────
 
@@ -217,7 +226,7 @@ wrapped by the two agents at the ends of the lifecycle.
    └──────────────────┘        │  · attack-path graphs                │      automation rules
                                 │  delegated-admin: security account   │      / notifications
                                 └──────────────────────────────────────┘
-   ✅ active today   ⚠️ partial (management only)   ❌ written but disabled (` --`)
+   ✅ active today   ⚠️ partial (management only)   ❌ written but disabled (-- suffix)
 ```
 
 ### Phased adoption path
@@ -226,7 +235,7 @@ wrapped by the two agents at the ends of the lifecycle.
 |---|---|---|
 | **1 — Restore the foundation** | Turn the article's "core" back on | Re-enable Config + Security Hub + GuardDuty + Inspector layers (see checklist); delegate admin to the `security` account |
 | **2 — Modernize aggregation** | Replace custom glue with native | Enable **unified Security Hub** exposure findings; migrate the `guardduty_monitor` Lambda logic to **EventBridge automation rules**; retire the custom module |
-| **3 — Add response-time AI** | Cut triage from days to hours | Enable **AWS Security Incident Response** at the org level so the **Investigative Agent** activates on cases |
+| **3 — Add response-time AI** | Cut investigation from days to hours | Enable **AWS Security Incident Response** from the Organizations **management account**; onboard the **membership** (select OUs/accounts for coverage), confirm the service is available in the **regions** in use, configure **incident-response contacts** and permissions, then verify the **Investigative Agent** activates on AWS-supported cases |
 | **4 — Add build-time AI** | Shift security left | Onboard **AWS Security Agent**; wire code review to repos and add threat modeling to the design workflow |
 
 ---
@@ -237,9 +246,9 @@ The detective layers already exist — this is **re-enablement + delegation**, n
 new code. Order matters: delegate from `management`, then enable in `security`.
 
 - [ ] **AWS Config** — apply `management/us-east-1/security-compliance` (delegation),
-      then rename `security/us-east-1/security-compliance --` → drop the ` --`
-      suffix and apply in the `security` account. Confirm ~1-year retention per
-      region in use.
+      then rename `security/us-east-1/security-compliance --` → drop the
+      space-plus-`--` suffix and apply in the `security` account. Confirm ~1-year
+      retention per region in use.
 - [ ] **Security Hub** — apply `management/us-east-1/security-hub --` (delegate
       admin), then enable `security/us-east-1/security-hub --`; flip
       `auto_enable_standards` from `NONE` and confirm **FSBP + CIS** are active
@@ -260,7 +269,10 @@ new code. Order matters: delegate from `management`, then enable in `security`.
       discovery and investigation graphs.
 - [ ] **Aggregation cleanup** — once exposure findings are on, migrate alert
       routing to EventBridge automation rules and **retire** the custom Lambda.
-- [ ] **Response-time** — enable **AWS Security Incident Response** (org level).
+- [ ] **Response-time** — enable **AWS Security Incident Response** from the
+      management account; onboard membership (OU/account coverage), confirm
+      supported regions, and set incident-response contacts so the Investigative
+      Agent activates on AWS-supported cases.
 - [ ] **Build-time** — onboard **AWS Security Agent**; connect repos + design flow.
 
 > Follow the repo standard workflow for every layer you re-enable: generate a

--- a/security/us-east-1/security-monitoring-agent --/README.md
+++ b/security/us-east-1/security-monitoring-agent --/README.md
@@ -90,8 +90,8 @@ means the layer exists and is written, but its directory carries the ` --` suffi
 | **IAM Access Analyzer** | Recommended | `security/us-east-1/security-base` | ✅ **Active** | none |
 | **AWS Config** (FSBP checks, 1-yr retention) | **Core / required** | `management/us-east-1/security-compliance` (active) · `security/us-east-1/security-compliance --` (**disabled**) (`terraform-aws-config` `v8.1.0`) | ⚠️ **Partial** | Enable + delegate to the `security` account |
 | **Security Hub** (FSBP + CIS) | **Core / central pane** | `security/us-east-1/security-hub --` & `management/us-east-1/security-hub --` (**disabled**; `auto_enable_standards = "NONE"`) | ❌ **Disabled** | Delegate admin, enable standards org-wide |
-| **GuardDuty** (all regions) | Recommended | `security/us-east-1/security-monitoring --` (**disabled**; `terraform-aws-guardduty-multiaccount` `v0.2.1` + custom `terraform-aws-guardduty-monitor` `v1.2.1`) | ❌ **Disabled** | Re-enable delegated-admin setup |
-| **Amazon Inspector** (EC2/ECR) | Recommended | `security/us-east-1/security-compliance --` (**disabled**; `inspector2` via `null_resource`) | ❌ **Disabled** | Enable via delegation |
+| **GuardDuty** (all regions) | Recommended | `management/us-east-1/security-monitoring --` (**disabled**; `delegated-admin`) · `security/us-east-1/security-monitoring --` (**disabled**; `terraform-aws-guardduty-multiaccount` `v0.2.1` + custom `terraform-aws-guardduty-monitor` `v1.2.1`) | ❌ **Disabled** | Delegate admin from management, then re-enable in security |
+| **Amazon Inspector** (EC2/ECR) | Recommended | `management/us-east-1/security-compliance` (delegation, gated on `enable_inspector`) · `security/us-east-1/security-compliance --` (**disabled**; `inspector2` via `null_resource`) | ❌ **Disabled** | Set `enable_inspector = true` in management, then enable in security |
 | **Amazon Macie** | Mentioned | — | ❌ **Absent** | Net-new (optional; sensitive-data discovery) |
 | **Amazon Detective** | Mentioned | — | ❌ **Absent** | Net-new (optional; investigation graphs) |
 
@@ -244,13 +244,18 @@ new code. Order matters: delegate from `management`, then enable in `security`.
       admin), then enable `security/us-east-1/security-hub --`; flip
       `auto_enable_standards` from `NONE` and confirm **FSBP + CIS** are active
       org-wide.
-- [ ] **GuardDuty** — enable `security/us-east-1/security-monitoring --`
-      (delegated-admin + multi-account); promote it over the empty active
-      `security-monitoring/` stub. **Defer/skip** the custom
-      `terraform-aws-guardduty-monitor` Lambda — prefer native exposure findings +
-      EventBridge (Phase 2).
-- [ ] **Inspector** — enable via `security/us-east-1/security-compliance --`
-      (`enable_inspector = true`); confirm EC2 + ECR coverage across members.
+- [ ] **GuardDuty** — apply `management/us-east-1/security-monitoring --` first
+      (the `delegated-admin` module designates the `security` account as GuardDuty
+      delegated administrator), then enable `security/us-east-1/security-monitoring --`
+      (multi-account setup); promote it over the empty active `security-monitoring/`
+      stub. **Defer/skip** the custom `terraform-aws-guardduty-monitor` Lambda —
+      prefer native exposure findings + EventBridge (Phase 2).
+- [ ] **Inspector** — set `enable_inspector = true` and apply
+      `management/us-east-1/security-compliance` first (its
+      `awsinspector_delegation.tf` runs `inspector2 enable-delegated-admin-account`
+      for the `security` account, gated on that variable), then enable
+      `security/us-east-1/security-compliance --`; confirm EC2 + ECR coverage across
+      members.
 - [ ] **Macie / Detective** *(optional)* — evaluate net-new for sensitive-data
       discovery and investigation graphs.
 - [ ] **Aggregation cleanup** — once exposure findings are on, migrate alert
@@ -288,6 +293,5 @@ new code. Order matters: delegate from `management`, then enable in `security`.
 - Security Hub CSPM — <https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html>
 - Security Hub exposure findings — <https://docs.aws.amazon.com/securityhub/latest/userguide/exposure-findings.html>
 - Related detective layers in this repo:
-  - `security/us-east-1/security-audit` (CloudTrail) · `security/us-east-1/security-base` (Access Analyzer)
-  - `security/us-east-1/security-compliance --` (Config + Inspector) · `security/us-east-1/security-hub --`
-  - `security/us-east-1/security-monitoring --` (GuardDuty) · `management/us-east-1/security-compliance` (Config delegation)
+  - **security account:** `security/us-east-1/security-audit` (CloudTrail) · `security/us-east-1/security-base` (Access Analyzer) · `security/us-east-1/security-compliance --` (Config + Inspector) · `security/us-east-1/security-hub --` · `security/us-east-1/security-monitoring --` (GuardDuty)
+  - **management account (delegation):** `management/us-east-1/security-compliance` (Config + Inspector delegation) · `management/us-east-1/security-hub --` · `management/us-east-1/security-monitoring --` (GuardDuty delegated-admin)

--- a/security/us-east-1/security-monitoring-agent --/README.md
+++ b/security/us-east-1/security-monitoring-agent --/README.md
@@ -1,0 +1,293 @@
+# Security Monitoring & the AWS Security Agent — Reference Layer
+
+> **Status: Documentation-only reference layer.** This directory intentionally
+> contains **no `.tf` files**. The trailing ` --` suffix marks it as a disabled
+> layer, so Atlantis autodiscover and `leverage tofu` never try to plan or apply
+> it. It exists to document a posture decision and to answer
+> [issue #541 — *Review our implementation of the AWS security monitoring
+> services*](https://github.com/binbashar/le-tf-infra-aws/issues/541).
+
+This layer reviews our AWS **security monitoring** posture against the model in
+[cloudonaut — *AWS Security Monitoring*](https://cloudonaut.io/2023-08-04-aws-security-monitoring/)
+(referenced by the issue) and then updates that 2023-era recommendation with the
+**AI security agents AWS has since shipped** — evaluating, for each, whether it
+**complements** or **replaces** parts of the classic detective stack.
+
+---
+
+## TL;DR — the verdict
+
+1. **The classic detective stack is the foundation and it is only half-on.**
+   CloudTrail and IAM Access Analyzer are live; **AWS Config, Security Hub,
+   GuardDuty, and Inspector are written but sitting in disabled ` --` layers.**
+   The article's core recommendation (Config + Security Hub as the central pane,
+   GuardDuty/Inspector feeding it) is therefore **not** currently realized in the
+   `security` account. Re-enabling those layers is step one — see
+   [Remediation checklist](#remediation-checklist).
+
+2. **The "AWS Security Agent" is not one thing — it's three, on three different
+   axes.** They do **not** replace the detective *sources* (you still must turn
+   Config/GuardDuty/CloudTrail **on** to feed them). They replace the **human
+   glue and aggregation layers** the 2023 article had to hand-roll, and they add
+   a **build-time** axis that did not previously exist:
+
+   | AWS AI offering | Axis | Verdict |
+   |---|---|---|
+   | **AWS Security Agent** (threat modeling, code review, on-demand pentest) | Build-time / shift-left | **Complementary** — new phase, no overlap |
+   | **AI Investigative Agent** (in Security Incident Response) | Response-time / triage | **Complementary**, and **replaces** custom alert-triage glue |
+   | **Unified Security Hub** (exposure findings, attack-path correlation) | Aggregation evolution | **Replaces** our custom GuardDuty→Lambda→EventBridge routing |
+
+   > **Bottom line:** keep the detectors, drop the bespoke glue. Re-enable the
+   > foundation, then adopt **unified Security Hub + the Investigative Agent**
+   > instead of rebuilding the custom Lambda/EventBridge alerting the article
+   > describes, and add **AWS Security Agent** to cover pre-deployment.
+
+---
+
+## Background — the cloudonaut monitoring model
+
+The article organizes AWS security telemetry into three layers. This is the lens
+we use for the gap analysis below.
+
+```
+   ┌──────────────────────────────────────────────────────────────────┐
+   │  3. AGGREGATION      Security Hub  ── single pane, ASFF, scoring   │
+   │        ▲                                                           │
+   │        │  findings (deduplicated, correlated, prioritized)         │
+   │  ──────┼───────────────────────────────────────────────────────   │
+   │  2. ANALYSIS         Config Rules · GuardDuty · Inspector · Macie  │
+   │        ▲                                                           │
+   │        │  raw events                                               │
+   │  ──────┼───────────────────────────────────────────────────────   │
+   │  1. SOURCES          CloudTrail · VPC Flow Logs · Route 53 DNS ·   │
+   │                      Config configuration items                    │
+   └──────────────────────────────────────────────────────────────────┘
+```
+
+Article guidance we hold ourselves to:
+
+- **AWS Config** enabled in every region in use, with ~**1-year** retention.
+- **Security Hub** as the central pane, with the **AWS Foundational Security Best
+  Practices (FSBP)** standard enabled across all regions.
+- **GuardDuty** and **Inspector** as recommended analysis feeders.
+- Findings routed by **severity/status** (the article filters severity ≥ 70,
+  status = `NEW`) to avoid alert fatigue — either via a Lambda that sets findings
+  to `NOTIFIED`, or a third-party tool.
+- **Avoid duplicate findings**: Trusted Advisor, Config Rules, and Security Hub
+  overlap — pick deliberately.
+
+---
+
+## Current posture in this repository
+
+What the article recommends vs. **what is actually deployed today**. "Disabled"
+means the layer exists and is written, but its directory carries the ` --` suffix
+(or is an empty stub), so it is not applied.
+
+| Service | cloudonaut stance | Where it lives in this repo | State | Gap |
+|---|---|---|---|---|
+| **CloudTrail** (org, multi-region, log validation, KMS) | Required source | `security/us-east-1/security-audit` (`terraform-aws-cloudtrail` `0.24.0`) | ✅ **Active** | none |
+| **IAM Access Analyzer** | Recommended | `security/us-east-1/security-base` | ✅ **Active** | none |
+| **AWS Config** (FSBP checks, 1-yr retention) | **Core / required** | `management/us-east-1/security-compliance` (active) · `security/us-east-1/security-compliance --` (**disabled**) (`terraform-aws-config` `v8.1.0`) | ⚠️ **Partial** | Enable + delegate to the `security` account |
+| **Security Hub** (FSBP + CIS) | **Core / central pane** | `security/us-east-1/security-hub --` & `management/us-east-1/security-hub --` (**disabled**; `auto_enable_standards = "NONE"`) | ❌ **Disabled** | Delegate admin, enable standards org-wide |
+| **GuardDuty** (all regions) | Recommended | `security/us-east-1/security-monitoring --` (**disabled**; `terraform-aws-guardduty-multiaccount` `v0.2.1` + custom `terraform-aws-guardduty-monitor` `v1.2.1`) | ❌ **Disabled** | Re-enable delegated-admin setup |
+| **Amazon Inspector** (EC2/ECR) | Recommended | `security/us-east-1/security-compliance --` (**disabled**; `inspector2` via `null_resource`) | ❌ **Disabled** | Enable via delegation |
+| **Amazon Macie** | Mentioned | — | ❌ **Absent** | Net-new (optional; sensitive-data discovery) |
+| **Amazon Detective** | Mentioned | — | ❌ **Absent** | Net-new (optional; investigation graphs) |
+
+> **Note on the active `security-monitoring/` directory:** the non-suffixed
+> `security/us-east-1/security-monitoring/` is currently an **empty stub** (only a
+> stale `.infracost/` cache, no `.tf`). The real GuardDuty code is in the disabled
+> `security-monitoring --` sibling. Re-activation means promoting that code, not
+> writing it from scratch.
+
+**Reading of the gap:** the *sources* layer is healthy (CloudTrail + Config-in-management),
+but the **analysis** and **aggregation** layers the article calls "core" are
+switched off in the `security` account. The good news: the code already exists —
+this is a **re-enablement and delegation** exercise, not new development.
+
+---
+
+## The AWS Security Agent landscape (2025+)
+
+When the issue says *"the latest AWS Security Agent that most probably can be
+complementary or even replace this possible solution,"* the important discovery
+is that **three distinct agentic offerings** now exist, each on a different axis of
+the security lifecycle. Conflating them leads to the wrong conclusion, so we treat
+them separately.
+
+### A. AWS Security Agent — *build-time / shift-left*
+
+A frontier agent that secures applications **before deployment**. Security teams
+define organizational requirements once in the console (approved auth libraries,
+logging standards, data-access policies); the agent then enforces them across
+teams. Capabilities:
+
+- **Design security review** — real-time feedback on architecture/design docs
+  against your standards, before any code is written.
+- **Threat modeling** — generates a system overview (components, trust
+  boundaries, data flows) and a **STRIDE**-classified threat list (Spoofing,
+  Tampering, Repudiation, Information Disclosure, DoS, Elevation of Privilege)
+  with severities and recommendations; re-runnable as code evolves.
+- **Code security review** — full-repo scans from GitHub / GitLab / Bitbucket /
+  GitHub Enterprise / S3, plus automated **pull-request analysis** posting
+  findings (and fix PRs) inline.
+- **On-demand penetration testing** — deploys specialized agents that build deep
+  application understanding and execute multi-step attack chains, documenting
+  reproducible attack paths and generating fix PRs.
+
+**Verdict: Complementary — a new axis.** The detective stack (Config/GuardDuty/
+Security Hub) only observes **running** infrastructure. Nothing in our current
+posture addresses design-time or code-time risk. AWS Security Agent fills a phase
+the cloudonaut model never covered; there is **no overlap** to replace.
+Docs: <https://docs.aws.amazon.com/securityagent/latest/userguide/what-is.html>
+
+### B. AI Investigative Agent (AWS Security Incident Response) — *response-time*
+
+An AI agent embedded in **AWS Security Incident Response** that activates
+automatically when an AWS-supported case is opened and runs **in parallel** with
+AWS responders:
+
+- **Automated evidence gathering** — queries **CloudTrail, IAM, EC2, and Cost
+  Explorer** without manual log analysis.
+- **Analysis & correlation** — correlates evidence across services, builds an
+  event timeline.
+- **Investigation summary in minutes** — findings, timeline, and recommendations
+  posted to the case Investigation tab and Communication section.
+- **Auditable & private** — acts via the `AWSServiceRoleForSupport`
+  service-linked role (read-only); actions logged in CloudTrail; customer data is
+  **not** used for training.
+
+Enablement is org-level (AWS Organizations management account); AI investigation
+applies to **AWS-supported** cases (not self-managed).
+
+**Verdict: Complementary, and a partial replacement of glue.** It **consumes the
+same CloudTrail** our `security-audit` layer already produces — reinforcing that
+the source layer must stay on. It does **not** replace the detectors, but it
+**does replace the manual triage runbook** and much of the bespoke
+severity-filtering/notification logic the article hand-rolls. It answers *"what
+happened and what do I do?"* — the step after a finding fires.
+Docs: <https://docs.aws.amazon.com/security-ir/latest/userguide/ai-investigative-agent.html>
+
+### C. Unified Security Hub — *aggregation-layer evolution*
+
+The aggregation layer itself has evolved. Alongside the classic **Security Hub
+CSPM** (posture management — FSBP/CIS/PCI/NIST control checks and security
+scores), AWS now offers **exposure findings**: signals from **Security Hub CSPM,
+GuardDuty, Inspector, and Macie** are **correlated** into prioritized exposures,
+with **potential attack-path graphs** and severity based on exploit likelihood +
+impact — surfaced on a new summary dashboard.
+
+**Verdict: Replaces our custom glue.** Our disabled GuardDuty layer ships a custom
+**`terraform-aws-guardduty-monitor`** Lambda that reacts to findings and routes
+alerts — exactly the hand-rolled "severity ≥ 70 → notify" logic the article
+describes. Native **exposure-finding correlation** subsumes most of that: instead
+of writing Lambda to dedupe and prioritize across GuardDuty/Inspector/Macie, the
+service does it and draws the attack path. Keep the **detectors**; retire the
+**custom correlation/notification code** in favor of native Security Hub +
+EventBridge automation rules.
+Docs: <https://docs.aws.amazon.com/securityhub/latest/userguide/exposure-findings.html>
+· <https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html>
+
+---
+
+## Target reference architecture
+
+Detective foundation (re-enabled) feeding a native aggregation/correlation layer,
+wrapped by the two agents at the ends of the lifecycle.
+
+```
+   BUILD-TIME                     RUN-TIME (detect → aggregate)                 RESPONSE-TIME
+   ─────────                      ─────────────────────────────                ─────────────
+
+  ┌───────────────────┐        ┌──────────────────────────────────────┐     ┌────────────────────┐
+  │ AWS Security Agent │        │ SOURCES                              │     │ AI Investigative   │
+  │  · design review   │        │  CloudTrail (org) ✅  · Config ⚠️     │     │ Agent (Security    │
+  │  · threat model    │        │  VPC Flow · Route 53 DNS             │     │ Incident Response) │
+  │    (STRIDE)        │        │            │                         │     │                    │
+  │  · code review     │        │            ▼                         │     │  reads CloudTrail, │
+  │  · on-demand pentest│       │ ANALYSIS                             │     │  IAM, EC2, Cost    │
+  └─────────┬─────────┘        │  GuardDuty ❌ · Inspector ❌          │     │  Explorer → builds │
+            │                   │  Macie (opt) · Config Rules          │     │  timeline + summary│
+            │ fix PRs           │            │                         │     └─────────▲──────────┘
+            ▼                   │            ▼                         │               │
+   ┌──────────────────┐        │ AGGREGATION — Unified Security Hub    │     case ─────┘
+   │  Git repos /      │        │  · FSBP + CIS controls (CSPM)        │
+   │  CI-CD pipeline   │        │  · exposure findings (correlation)   │────► EventBridge
+   └──────────────────┘        │  · attack-path graphs                │      automation rules
+                                │  delegated-admin: security account   │      / notifications
+                                └──────────────────────────────────────┘
+   ✅ active today   ⚠️ partial (management only)   ❌ written but disabled (` --`)
+```
+
+### Phased adoption path
+
+| Phase | Goal | Actions |
+|---|---|---|
+| **1 — Restore the foundation** | Turn the article's "core" back on | Re-enable Config + Security Hub + GuardDuty + Inspector layers (see checklist); delegate admin to the `security` account |
+| **2 — Modernize aggregation** | Replace custom glue with native | Enable **unified Security Hub** exposure findings; migrate the `guardduty_monitor` Lambda logic to **EventBridge automation rules**; retire the custom module |
+| **3 — Add response-time AI** | Cut triage from days to hours | Enable **AWS Security Incident Response** at the org level so the **Investigative Agent** activates on cases |
+| **4 — Add build-time AI** | Shift security left | Onboard **AWS Security Agent**; wire code review to repos and add threat modeling to the design workflow |
+
+---
+
+## Remediation checklist
+
+The detective layers already exist — this is **re-enablement + delegation**, not
+new code. Order matters: delegate from `management`, then enable in `security`.
+
+- [ ] **AWS Config** — apply `management/us-east-1/security-compliance` (delegation),
+      then rename `security/us-east-1/security-compliance --` → drop the ` --`
+      suffix and apply in the `security` account. Confirm ~1-year retention per
+      region in use.
+- [ ] **Security Hub** — apply `management/us-east-1/security-hub --` (delegate
+      admin), then enable `security/us-east-1/security-hub --`; flip
+      `auto_enable_standards` from `NONE` and confirm **FSBP + CIS** are active
+      org-wide.
+- [ ] **GuardDuty** — enable `security/us-east-1/security-monitoring --`
+      (delegated-admin + multi-account); promote it over the empty active
+      `security-monitoring/` stub. **Defer/skip** the custom
+      `terraform-aws-guardduty-monitor` Lambda — prefer native exposure findings +
+      EventBridge (Phase 2).
+- [ ] **Inspector** — enable via `security/us-east-1/security-compliance --`
+      (`enable_inspector = true`); confirm EC2 + ECR coverage across members.
+- [ ] **Macie / Detective** *(optional)* — evaluate net-new for sensitive-data
+      discovery and investigation graphs.
+- [ ] **Aggregation cleanup** — once exposure findings are on, migrate alert
+      routing to EventBridge automation rules and **retire** the custom Lambda.
+- [ ] **Response-time** — enable **AWS Security Incident Response** (org level).
+- [ ] **Build-time** — onboard **AWS Security Agent**; connect repos + design flow.
+
+> Follow the repo standard workflow for every layer you re-enable: generate a
+> `leverage tofu plan`, **redact** account IDs/ARNs, attach the redacted excerpt to
+> the PR in a `<details>` block, and **let a human apply after approval** — never
+> apply from automation. See the root `CLAUDE.md` for the exact redaction procedure.
+
+---
+
+## Cost & tagging notes
+
+- These are mostly **usage-priced** services (Config per configuration item +
+  rule evaluation; GuardDuty per event/GB analyzed; Inspector per instance/image;
+  Security Hub per check/finding-ingestion). Re-enabling them org-wide has a real
+  monthly cost — run `make infracost-breakdown` on each layer before applying, and
+  scope regions to those actually in use (the article's advice, and a cost lever).
+- **Do not** add the `aws-apn-id` PRM tag to these layers. That tag is scoped to
+  specific Bedrock/Marketplace layers under `data-science/` and requires Partner
+  Development Manager approval (see root `CLAUDE.md`). Security monitoring layers
+  are out of scope for Marketplace attribution.
+
+---
+
+## References
+
+- Issue #541 — <https://github.com/binbashar/le-tf-infra-aws/issues/541>
+- cloudonaut, *AWS Security Monitoring* — <https://cloudonaut.io/2023-08-04-aws-security-monitoring/>
+- AWS Security Agent (build-time) — <https://docs.aws.amazon.com/securityagent/latest/userguide/what-is.html>
+- AI Investigative Agent (Security Incident Response) — <https://docs.aws.amazon.com/security-ir/latest/userguide/ai-investigative-agent.html>
+- Security Hub CSPM — <https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html>
+- Security Hub exposure findings — <https://docs.aws.amazon.com/securityhub/latest/userguide/exposure-findings.html>
+- Related detective layers in this repo:
+  - `security/us-east-1/security-audit` (CloudTrail) · `security/us-east-1/security-base` (Access Analyzer)
+  - `security/us-east-1/security-compliance --` (Config + Inspector) · `security/us-east-1/security-hub --`
+  - `security/us-east-1/security-monitoring --` (GuardDuty) · `management/us-east-1/security-compliance` (Config delegation)


### PR DESCRIPTION
## What?
* Adds a **documentation-only reference layer** at `security/us-east-1/security-monitoring-agent --/README.md` (no `.tf`; the ` --` suffix keeps it out of Atlantis autodiscover).
* **Reviews our AWS security monitoring posture** against the [cloudonaut *AWS Security Monitoring*](https://cloudonaut.io/2023-08-04-aws-security-monitoring/) model referenced in #541, with a gap table of what's active vs. disabled.
* **Updates that 2023-era recommendation** with the AI security agents AWS has since shipped, disambiguating the three distinct "AWS Security Agent" offerings onto three axes, each with a **complementary-vs-replace** verdict.
* Provides a **target architecture**, a **phased adoption path**, and a **re-enablement remediation checklist** for the existing disabled detective layers.

## Why?
* Issue #541 asked us to review our security-monitoring services against the cloudonaut article and list the changes we should make. The honest finding: the article's "core" stack (Config, Security Hub, GuardDuty, Inspector) is **written but sitting in disabled ` --` layers** in the `security` account — only CloudTrail and IAM Access Analyzer are live. So the recommended posture is **not currently realized**, and closing the gap is a re-enablement/delegation exercise (the code already exists).
* The issue also asked us to weigh "the latest AWS Security Agent" as complementary or a replacement. The key clarification captured here: it's **not one thing** —
  * **AWS Security Agent** (threat modeling / code review / on-demand pentest) → **build-time**, purely **complementary** (a phase the detective stack never covered).
  * **AI Investigative Agent** (Security Incident Response) → **response-time**, complementary and **replaces manual triage glue**; it consumes the same CloudTrail we already emit.
  * **Unified Security Hub** exposure findings (attack-path correlation across CSPM/GuardDuty/Inspector/Macie) → **replaces** our custom `guardduty_monitor` Lambda/EventBridge routing.
* **Thesis: keep the detectors, drop the bespoke glue.** Re-enable the foundation, then adopt native unified Security Hub + the Investigative Agent instead of rebuilding custom alerting, and add AWS Security Agent to cover pre-deployment.
* This ref-arch doc resolves #541 and gives the team a decision record + actionable checklist for planning.

## References
* closes #541
* [cloudonaut — AWS Security Monitoring](https://cloudonaut.io/2023-08-04-aws-security-monitoring/)
* [AWS Security Agent](https://docs.aws.amazon.com/securityagent/latest/userguide/what-is.html) · [AI Investigative Agent](https://docs.aws.amazon.com/security-ir/latest/userguide/ai-investigative-agent.html) · [Security Hub CSPM](https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html) · [exposure findings](https://docs.aws.amazon.com/securityhub/latest/userguide/exposure-findings.html)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference guide describing the current AWS security monitoring posture and target architecture.
  * Documented available security monitoring and agentic security capabilities, including phased adoption guidance.
  * Clarified disabled and partial monitoring components, remediation workflows, operational considerations, and cost guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->