### PR TITLE
docs(ecr): add container-registry README (consolidated vs per-env)

### DIFF
--- a/shared/us-east-1/container-registry/README.md
+++ b/shared/us-east-1/container-registry/README.md
@@ -9,8 +9,12 @@ across the organization. Images are built and pushed here once, and other accoun
 (e.g. `apps-devstg`) are granted cross-account **pull (read)** access through repository
 policies.
 
-The same layer is deployed in the primary region (`us-east-1`) and, for DR, in the
-secondary region (`us-east-2`).
+A corresponding container-registry layer is deployed in the secondary region
+(`us-east-2`) for DR. Note it is **not an exact mirror**: this primary-region layer uses
+the [`terraform-aws-ecr`](https://github.com/binbashar/terraform-aws-ecr) module
+(`local.repositories`), whereas `us-east-2` uses the
+[`terraform-aws-ecr-cross-account`](https://github.com/binbashar/terraform-aws-ecr-cross-account)
+module (`local.repository_list`) with a different variable structure.
 
 ### What this layer configures
 
@@ -39,10 +43,11 @@ approaches lives in the Leverage documentation, under the AWS Reference Architec
 
 - [Leverage Reference Architecture — Features](https://leverage.binbash.co/user-guide/ref-architecture-aws/features/)
 
-## Module
+## Modules
 
-- [`terraform-aws-ecr`](https://github.com/binbashar/terraform-aws-ecr) — `v2.4.0`
+- This layer (`us-east-1`): [`terraform-aws-ecr`](https://github.com/binbashar/terraform-aws-ecr) — `v2.4.0`
+- DR layer (`us-east-2`): [`terraform-aws-ecr-cross-account`](https://github.com/binbashar/terraform-aws-ecr-cross-account) — `v1.1.0`
 
 ---
 
-**Layer**: `shared/us-east-1/container-registry` (mirrored in `shared/us-east-2`)
+**Layer**: `shared/us-east-1/container-registry` (with a corresponding DR layer in `shared/us-east-2`)

--- a/shared/us-east-1/container-registry/README.md
+++ b/shared/us-east-1/container-registry/README.md
@@ -1,0 +1,48 @@
+# Container Registry (ECR)
+
+## Overview
+
+This layer manages the project's [Amazon ECR](https://aws.amazon.com/ecr/) container
+image repositories. It follows the Leverage Reference Architecture's current
+**consolidated** model: ECR repositories live in the **Shared** account and are shared
+across the organization. Images are built and pushed here once, and other accounts
+(e.g. `apps-devstg`) are granted cross-account **pull (read)** access through repository
+policies.
+
+The same layer is deployed in the primary region (`us-east-1`) and, for DR, in the
+secondary region (`us-east-2`).
+
+### What this layer configures
+
+- **Repositories** (`ecr_repositories.tf` + `locals.tf`) — one repository per image, each
+  with its own cross-account access ARNs (`read_access_arns` / `read_write_access_arns`).
+- **Registry scanning** (`ecr_repositories.tf`) — account-wide `SCAN_ON_PUSH` (BASIC) for
+  every repository.
+- **Lifecycle policy** (`lifecycle_policy.tf`) — default rules keep the last 20 tagged
+  images and expire images older than 90 days.
+
+## Consolidated vs. per-environment ECR
+
+The **consolidated** approach above centralizes all repositories in the Shared account.
+An alternative **per-environment (per-account)** approach is being evaluated: each account
+would own its own ECR repositories, images would be built/pushed to the dev registry, and
+cross-account/cross-region **replication** would propagate them downstream (e.g.
+DEV → STG → PRD, optionally conditional on tags or other logic). See
+[binbashar/le-tf-infra-aws#564](https://github.com/binbashar/le-tf-infra-aws/issues/564)
+for the rationale.
+
+## Documentation
+
+A detailed feature write-up comparing the **consolidated** and **per-environment** ECR
+approaches lives in the Leverage documentation, under the AWS Reference Architecture
+**Features** section:
+
+- [Leverage Reference Architecture — Features](https://leverage.binbash.co/user-guide/ref-architecture-aws/features/)
+
+## Module
+
+- [`terraform-aws-ecr`](https://github.com/binbashar/terraform-aws-ecr) — `v2.4.0`
+
+---
+
+**Layer**: `shared/us-east-1/container-registry` (mirrored in `shared/us-east-2`)


### PR DESCRIPTION
## What?
* Add a concise `README.md` to `shared/us-east-1/container-registry/`.
* Documents the **current consolidated ECR model**: repositories in the Shared account, cross-account **pull (read)** access for other accounts (e.g. `apps-devstg`), registry-wide `SCAN_ON_PUSH`, and the default lifecycle policy (keep last 20 tagged / expire > 90 days).
* Briefly contrasts it with the proposed **per-environment (per-account) ECR + replication** model, and links to the Leverage Reference Architecture **Features** docs.

## Why?
* Resolves the ask in #564: give the layer a simple README and point readers to the docs comparing the **consolidated** vs **per-environment** ECR approaches.
* Keeps the code-side README minimal while the detailed feature write-up is tracked as a documentation task in the docs repo: **binbashar/le-ref-architecture-doc#255**.

## References
* Closes #564
* Documentation follow-up: binbashar/le-ref-architecture-doc#255
* Module: [`terraform-aws-ecr`](https://github.com/binbashar/terraform-aws-ecr) `v2.4.0`
* [Leverage Reference Architecture — Features](https://leverage.binbash.co/user-guide/ref-architecture-aws/features/)
