### PR TITLE
feat(ai-sdlc): add Fable 5 to claude-bedrock launcher (Bedrock)

### DIFF
--- a/doc/ai-sdlc/bin/claude-bedrock
+++ b/doc/ai-sdlc/bin/claude-bedrock
@@ -9,9 +9,20 @@
 # You pick the ACCOUNT and SSO ROLE interactively (or via env); the launcher sets
 # the matching profile, the models that account actually has, and the credential
 # auto-refresh layer. Model availability differs per account:
-#   apps-prd      → Opus 4.8 / Sonnet 5 live today
-#   data-science  → Opus 4.6 / Sonnet 4.6 (Opus 4.8 & Sonnet 5 quota pending)
+#   apps-prd      → Opus 4.8 / Sonnet 5 live today; Fable 5 needs the opt-in below
+#   data-science  → Opus 4.6 / Sonnet 4.6 (Opus 4.8, Sonnet 5 & Fable 5 quota pending)
 # Role: devops | datascientist (not everyone has DevOps; pick what you have).
+#
+# Fable 5 data-retention gate: unlike every other model here, Bedrock's Fable 5
+# (and Mythos 5) declare allowed_modes=["provider_data_share"] ONLY. Until the
+# account's effective data-retention mode is provider_data_share, selecting Fable 5
+# in /model fails with `400 data retention mode 'default' is not available for this
+# model` — the request reached Bedrock; the model is policy-gated, not missing.
+# Opting in is an ACCOUNT-WIDE governance decision (it retains prompts+outputs AND
+# shares them with the provider; on apps-prd this also covers the CI @claude reviewer).
+# There is no console UI — opt in via the data-retention API, ideally project-scoped:
+#   PUT  https://bedrock.{region}.amazonaws.com/data-retention  {"mode":"provider_data_share"}
+# See https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html
 #
 # Non-interactive / overrides (env wins over the prompts; required under `-p`):
 #   CLAUDE_BEDROCK_ACCOUNT=apps-prd CLAUDE_BEDROCK_ROLE=devops claude-bedrock -p "..."
@@ -85,9 +96,10 @@ case "$account" in
   apps-prd)
     refresh_layer_default="apps-prd/us-east-1/notifications"
     default_model="us.anthropic.claude-opus-4-8"
-    opus="us.anthropic.claude-opus-4-8";                 opus_desc="Amazon Bedrock · apps-prd account (most capable)"
+    opus="us.anthropic.claude-opus-4-8";                 opus_desc="Amazon Bedrock · apps-prd account (most capable Opus)"
     sonnet="us.anthropic.claude-sonnet-5";               sonnet_desc="Amazon Bedrock · apps-prd account (balanced)"
     haiku="us.anthropic.claude-haiku-4-5-20251001-v1:0"; haiku_desc="Amazon Bedrock · apps-prd account (fast, low-cost)"
+    fable="us.anthropic.claude-fable-5";                 fable_desc="Amazon Bedrock · apps-prd account (Fable 5 — most capable, premium; needs provider_data_share opt-in)"
     custom="us.anthropic.claude-opus-4-6-v1";            custom_desc="Amazon Bedrock · apps-prd account (Opus 4.6 fallback)"
     ;;
   data-science)
@@ -96,6 +108,7 @@ case "$account" in
     opus="us.anthropic.claude-opus-4-6-v1";              opus_desc="Amazon Bedrock · data-science account (Opus 4.6; 4.8 quota pending)"
     sonnet="us.anthropic.claude-sonnet-4-6";             sonnet_desc="Amazon Bedrock · data-science account (Sonnet 4.6; 5 quota pending)"
     haiku="us.anthropic.claude-haiku-4-5-20251001-v1:0"; haiku_desc="Amazon Bedrock · data-science account (fast, low-cost)"
+    fable="us.anthropic.claude-fable-5";                 fable_desc="Amazon Bedrock · data-science account (Fable 5 — quota pending; also needs provider_data_share opt-in)"
     custom="us.anthropic.claude-opus-4-8";               custom_desc="Amazon Bedrock · data-science account (Opus 4.8 — quota pending)"
     ;;
   *)
@@ -112,6 +125,8 @@ export ANTHROPIC_DEFAULT_SONNET_MODEL="$sonnet"
 export ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION="$sonnet_desc"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="$haiku"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION="$haiku_desc"
+export ANTHROPIC_DEFAULT_FABLE_MODEL="$fable"
+export ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION="$fable_desc"
 export ANTHROPIC_CUSTOM_MODEL_OPTION="$custom"
 export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="$custom_desc"
 

--- a/doc/ai-sdlc/bin/claude-bedrock
+++ b/doc/ai-sdlc/bin/claude-bedrock
@@ -18,11 +18,15 @@
 # account's effective data-retention mode is provider_data_share, selecting Fable 5
 # in /model fails with `400 data retention mode 'default' is not available for this
 # model` — the request reached Bedrock; the model is policy-gated, not missing.
-# Opting in is an ACCOUNT-WIDE governance decision (it retains prompts+outputs AND
-# shares them with the provider; on apps-prd this also covers the CI @claude reviewer).
-# There is no console UI — opt in via the data-retention API, ideally project-scoped:
+# provider_data_share is Anthropic/AWS's required trust-&-safety posture for these
+# frontier models (prompts+outputs retained up to 30 days for abuse monitoring under
+# the AWS/Anthropic terms) — it is a governance ACKNOWLEDGEMENT, not a data leak. The
+# account mode gates PER MODEL via allowed_modes: only Fable/Mythos (share-only) share
+# with Anthropic; every other model here is ["default","provider_data_share"], so it
+# stays AWS-only and the CI @claude reviewer's data is NOT shared. Still get sign-off:
+# it's an account-wide setting. No console UI — opt in via the data-retention API:
 #   PUT  https://bedrock.{region}.amazonaws.com/data-retention  {"mode":"provider_data_share"}
-# See https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html
+# See doc §5.1 and https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html
 #
 # Non-interactive / overrides (env wins over the prompts; required under `-p`):
 #   CLAUDE_BEDROCK_ACCOUNT=apps-prd CLAUDE_BEDROCK_ROLE=devops claude-bedrock -p "..."

--- a/doc/ai-sdlc/claude-code-bedrock.md
+++ b/doc/ai-sdlc/claude-code-bedrock.md
@@ -69,7 +69,8 @@ of every settings `env` block. The launcher provides them per invocation.
 
 - Access to the account you want (see §4) with a role that has `bedrock:*`
   (DevOps or DataScientist), and the target model **enabled + quota'd** in that
-  account (see §5 — three separate gates).
+  account (see §5 — four separate gates). **Fable 5 / Mythos 5 have an extra,
+  account-wide data-sharing gate** — read §5.1 before selecting them.
 
 ## 3. Install the `claude-bedrock` launcher
 
@@ -98,8 +99,8 @@ the credential-refresh layer. Non-interactively (or under `-p`) it uses the env 
 
 | Account | Models available today | Default role |
 | --- | --- | --- |
-| **`data-science`** (default) | Opus 4.6 / Sonnet 4.6 / Haiku 4.5 — **Opus 4.8 & Sonnet 5 quota pending** (§5) | `devops` |
-| **`apps-prd`** (prod) | **Opus 4.8 / Sonnet 5** / Haiku 4.5 — live today | `devops` |
+| **`data-science`** (default) | Opus 4.6 / Sonnet 4.6 / Haiku 4.5 — **Opus 4.8, Sonnet 5 & Fable 5 quota pending** (§5) | `devops` |
+| **`apps-prd`** (prod) | **Opus 4.8 / Sonnet 5** / Haiku 4.5 — live today; **Fable 5 live after the §5.1 data-retention opt-in** | `devops` |
 
 Not everyone has DevOps (some users only have DataScientist, etc.), so the role is a
 choice too. The launcher validates `bb-<account>-<role>` against your
@@ -136,26 +137,35 @@ non-automatable browser login.
 ### 3.3 The `/model` picker
 
 In a Bedrock session the `/model` list is built from the launcher's env vars, not a
-fixed catalog — each `ANTHROPIC_DEFAULT_*_MODEL` (and `ANTHROPIC_CUSTOM_MODEL_OPTION`)
-injects one row (verified on Claude Code `v2.1.172`). Each accepts `_NAME` and
-`_DESCRIPTION` suffix variables ([model-config docs](https://code.claude.com/docs/en/model-config));
-the launcher sets only `_DESCRIPTION` — labelling every row **Amazon Bedrock ·
-`<account>` account** so the routing is obvious — and leaves the **name** as the raw
-`us.anthropic.*` inference-profile ID (unambiguous evidence you're on Bedrock, not the
-native API). Example rows for an **apps-prd** session:
+fixed catalog — each `ANTHROPIC_DEFAULT_*_MODEL` tier slot (Opus / Sonnet / Haiku /
+**Fable**) and the single `ANTHROPIC_CUSTOM_MODEL_OPTION` injects one row (verified on
+Claude Code `v2.1.212`). Each accepts `_NAME` and `_DESCRIPTION` suffix variables
+([model-config docs](https://code.claude.com/docs/en/model-config)); the launcher sets
+only `_DESCRIPTION` — labelling every row **Amazon Bedrock · `<account>` account** so the
+routing is obvious — and leaves the **name** as the raw `us.anthropic.*` inference-profile
+ID (unambiguous evidence you're on Bedrock, not the native API). Example rows for an
+**apps-prd** session:
 
 | Picker row (name — description) | Driven by |
 | --- | --- |
 | `us.anthropic.claude-sonnet-5` — *Amazon Bedrock · apps-prd account (balanced)* | `ANTHROPIC_DEFAULT_SONNET_MODEL` + `_DESCRIPTION` |
-| `us.anthropic.claude-opus-4-8` — *Amazon Bedrock · apps-prd account (most capable)* | `ANTHROPIC_DEFAULT_OPUS_MODEL` + `_DESCRIPTION` |
+| `us.anthropic.claude-opus-4-8` — *Amazon Bedrock · apps-prd account (most capable Opus)* | `ANTHROPIC_DEFAULT_OPUS_MODEL` + `_DESCRIPTION` |
 | `us.anthropic.claude-haiku-…` — *Amazon Bedrock · apps-prd account (fast, low-cost)* | `ANTHROPIC_DEFAULT_HAIKU_MODEL` + `_DESCRIPTION` |
+| `us.anthropic.claude-fable-5` — *Amazon Bedrock · apps-prd account (Fable 5 — most capable, premium; needs provider_data_share opt-in)* | `ANTHROPIC_DEFAULT_FABLE_MODEL` + `_DESCRIPTION` |
 | `us.anthropic.claude-opus-4-6-v1` — *Amazon Bedrock · apps-prd account (Opus 4.6 fallback)* | `ANTHROPIC_CUSTOM_MODEL_OPTION` trio |
 
+**Fable is a first-class tier slot** (`ANTHROPIC_DEFAULT_FABLE_MODEL`) alongside Opus /
+Sonnet / Haiku — so it gets its own always-visible row **without** spending the single
+custom slot (which still holds the Opus 4.6 fallback). Selecting it, however, is gated
+on the account's data-retention mode — see **§5.1**.
+
 A `data-science` session shows the same shape with that account's models (Opus 4.6 /
-Sonnet 4.6, plus Opus 4.8 as a "quota pending" custom row). `ANTHROPIC_CUSTOM_MODEL_OPTION`
-adds exactly **one** extra row; for several extra models the mechanism is the
+Sonnet 4.6, Fable 5 marked "quota pending", plus Opus 4.8 as a "quota pending" custom
+row). There is exactly **one** custom slot: `ANTHROPIC_CUSTOM_MODEL_OPTION` (no numbered
+or array variant). For several *extra* non-tier models the mechanism is the
 `availableModels` / `modelOverrides` settings keys, but those live in a settings file
-(subject to the §1 leak caveat), so the single env-var row fits this dual-mode wrapper.
+(subject to the §1 leak caveat), so the tier slots + one env-var custom row fit this
+dual-mode wrapper.
 
 **Bedrock model-ID caveat:** IDs use the cross-region inference-profile form (`us.`
 prefix), but the **suffix is inconsistent across versions — don't extrapolate one ID
@@ -187,25 +197,29 @@ inference profiles route to — so IAM is **not** what blocks a new model (verif
 DevOps role invokes Sonnet 4.6 / Opus 4.6 / Haiku 4.5 today). What's missing for a new
 model is gate 1/2 below, not IAM.
 
-## 5. Model availability — the three gates (checked 2026-07-17, us-east-1)
+## 5. Model availability — the four gates (checked 2026-07-18, us-east-1)
 
-Three **independent** gates must all pass to invoke a model. A model can clear one or
-two and still refuse:
+Four **independent** gates must all pass to invoke a model. A model can clear some and
+still refuse:
 
 1. **Model access** — the agreement is accepted for that model, per account (Bedrock
    console → *Model access*).
 2. **Service quota (TPM)** — non-zero, per model, per account, and per profile family
    (`us.` cross-region vs `global.` global-cross-region have *separate* quotas).
 3. **IAM** — your SSO role allows `bedrock:InvokeModel*` (see §4 — DevOps/DataScientist do).
+4. **Data-retention mode** — the account's effective retention mode must be in the
+   model's `allowed_modes`. **Only Fable 5 / Mythos 5 gate on this** (they allow
+   `provider_data_share` *only*); every older Claude model allows `default`, so gate 4 is
+   a no-op for them. See **§5.1**.
 
 | Model | `apps-prd` | `data-science` |
 | --- | --- | --- |
 | Opus 4.6, Sonnet 4.6, Haiku 4.5 | ✅ | ✅ |
 | **Opus 4.8** | ✅ | ⏳ **quota pending** |
 | **Sonnet 5** | ✅ | ⏳ **quota pending** |
-| Fable 5 | ❌ no access | ❌ no access |
+| **Fable 5** | ✅ **(after §5.1 opt-in — done 2026-07-18)** | ❌ quota pending **+** needs §5.1 opt-in |
 
-So **use `apps-prd` for Opus 4.8 / Sonnet 5 today**; in `data-science` the launcher's
+So **use `apps-prd` for Opus 4.8 / Sonnet 5 / Fable 5 today**; in `data-science` the launcher's
 `us.` profiles return *"not available for this account"* — a gate-1/2 (access/quota)
 block, **not** IAM. Heads-up: the pending Service Quotas cases you may see are for the
 separate **`global.*`** family (*Global cross-region* Opus 4.8 / Sonnet 5), which the
@@ -224,11 +238,67 @@ aws service-quotas get-service-quota --service-code bedrock \
 > but the reproducible gate is access/quota (`converse` returns *"not available for this
 > account"*). The role's `bedrock:*` is fine — don't go editing permission sets for this.
 
+### 5.1 ⚠️ Data-retention gate — Fable 5 / Mythos 5 only (account-wide, governance)
+
+> [!WARNING]
+> **Selecting Fable 5 or Mythos 5 requires opting the whole AWS account into
+> `provider_data_share`, which retains your prompts + outputs AND shares them with
+> Anthropic.** This is an **account-wide** setting: on `apps-prd` it also covers the
+> **CI `@claude` PR reviewer** (§ intro), not just your interactive sessions. Treat the
+> opt-in as a **data-governance decision** — get sign-off before enabling it on a shared
+> or production account.
+
+**Why only these two models.** Every Claude model on Bedrock declares which retention
+modes it permits via `allowed_modes`. Older models (Opus 4.6/4.8, Sonnet 4.6/5, Haiku)
+allow `default`, so they work under any account setting. **Fable 5 and Mythos 5 declare
+`allowed_modes: ["provider_data_share"]` only** — they refuse `default` (and `none`).
+
+**How the effective mode is resolved.** `first non-inherit value of (project → account →
+model default)`. A fresh account is `inherit`, which falls through to the model default
+(`default`) — so Fable 5 is blocked until you explicitly set `provider_data_share` at the
+account or project scope.
+
+**The symptom** when it's not set (this is *not* an access/quota or IAM error):
+
+```text
+API Error: 400 data retention mode 'default' is not available for this model
+```
+
+The request reached Bedrock and the model is `ACTIVE` — it's policy-gated, not missing.
+
+**Check the current account mode** (read-only). `awscli` 2.27.8 has no `data-retention`
+subcommand, so sign the control-plane REST call (`bedrock` service, SigV4):
+
+```bash
+# via the bb SSO profile; returns e.g. {"mode":"inherit","updatedAt":null}
+curl -s "https://bedrock.us-east-1.amazonaws.com/data-retention"   # + SigV4 (bedrock, us-east-1)
+```
+
+**Opt in** (the write — account-wide; needs governance sign-off):
+
+```bash
+curl -s -X PUT "https://bedrock.us-east-1.amazonaws.com/data-retention" \
+  -H "Content-Type: application/json" -d '{"mode":"provider_data_share"}'   # + SigV4
+```
+
+Scope it to a **project** instead of the whole account with
+`POST /v1/organization/projects/{project_id}` `{"data_retention":{"mode":"provider_data_share"}}`
+if you want to limit sharing to one project. **Reversible** at any time with
+`PUT {"mode":"inherit"}` (back to model default) or `{"mode":"none"}` (zero retention) —
+but data retained/shared while `provider_data_share` was active cannot be un-shared.
+
+**Status:** `apps-prd` was opted in account-wide on **2026-07-18** (with explicit sign-off)
+and Fable 5 is live there. `data-science` has **not** been opted in — Fable 5 there needs
+both its pending quota (§5) *and* this opt-in.
+
+Full reference: [Bedrock data-retention docs](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html).
+
 ## 6. Troubleshooting
 
 | Symptom | Root cause | Fix |
 | --- | --- | --- |
 | `AccessDeniedException: <model> is not available for this account` (or a console `InvokeModelWithResponseStream` error) | Model **access or quota** not granted for that model **in that account** (gate 1/2, §5) — **not** IAM | Use `apps-prd` (has Opus 4.8 / Sonnet 5), or enable access + wait for the data-science quota case |
+| `400 data retention mode 'default' is not available for this model` (Fable 5 / Mythos 5 only) | Account not opted into `provider_data_share` (gate 4, §5.1) — the model is `ACTIVE`; it's policy-gated, not missing | Opt the account (or project) into `provider_data_share` per §5.1 — **account-wide governance change**, get sign-off first |
 | `There's an issue with the selected model (us.anthropic....)`; debug log shows `dispatching to firstParty` | `CLAUDE_CODE_USE_BEDROCK` pinned/overridden by a settings `env` block — the Bedrock model ID went to the native Anthropic API (404) | Remove the key from every settings `env` block (§1) |
 | `403 The security token included in the request is invalid` | `AWS_PROFILE` pinned in a settings `env` block to a stale profile — it outranks the wrapper | Remove the `AWS_PROFILE` pin (§1); refresh credentials |
 | `ERROR: AWS profile 'bb-…' not found` | You don't have that account/role combo | Pick a profile the launcher lists (from your `~/.aws/bb/config`) |

--- a/doc/ai-sdlc/claude-code-bedrock.md
+++ b/doc/ai-sdlc/claude-code-bedrock.md
@@ -238,25 +238,58 @@ aws service-quotas get-service-quota --service-code bedrock \
 > but the reproducible gate is access/quota (`converse` returns *"not available for this
 > account"*). The role's `bedrock:*` is fine — don't go editing permission sets for this.
 
-### 5.1 ⚠️ Data-retention gate — Fable 5 / Mythos 5 only (account-wide, governance)
+### 5.1 ⚠️ Data-retention gate — Fable 5 / Mythos 5 only (account-wide setting, per-model effect)
 
-> [!WARNING]
-> **Selecting Fable 5 or Mythos 5 requires opting the whole AWS account into
-> `provider_data_share`, which retains your prompts + outputs AND shares them with
-> Anthropic.** This is an **account-wide** setting: on `apps-prd` it also covers the
-> **CI `@claude` PR reviewer** (§ intro), not just your interactive sessions. Treat the
-> opt-in as a **data-governance decision** — get sign-off before enabling it on a shared
-> or production account.
+> [!IMPORTANT]
+> **Selecting Fable 5 or Mythos 5 requires setting the AWS account's data-retention
+> mode to `provider_data_share`.** This is the **required trust-&-safety posture** that
+> AWS and Anthropic mandate for these frontier models — not an optional or unsafe
+> toggle. It is a **governance acknowledgement**, and the sharing is **scoped per model**
+> (see the blast-radius table below): only Fable 5 / Mythos 5 share data with Anthropic;
+> every other model in this launcher stays **AWS-only**. It is still an **account-wide
+> setting**, so get **sign-off** before enabling it on a shared or production account.
+
+**Security / compliance framing.** `provider_data_share` is how AWS and Anthropic jointly
+satisfy the trust-&-safety and abuse-monitoring obligations that gate access to these
+frontier models. Prompts and completions for **Fable 5 / Mythos 5 requests only** are
+retained for up to **30 days** for trust-and-safety purposes under the
+[AWS Service Terms](https://aws.amazon.com/service-terms/) and the
+[Anthropic third-party-model terms](https://aws.amazon.com/legal/bedrock/third-party-models/);
+the data stays within the AWS/Anthropic contractual boundary (governed, access-controlled,
+compliance-audited under AWS's US regulatory posture) — it is **not** general "data
+sharing" and **not** used for model training. Setting the mode is the account's explicit,
+auditable opt-in to that posture. If your account has a compliance requirement for **zero**
+retention, you cannot use Fable 5 / Mythos 5 without a per-account/per-model ZDR exception
+(contact your AWS account manager) — and you can **enforce** a retention ceiling
+org-wide with an SCP on the `bedrock:DataRetentionMode` / `bedrock-mantle:DataRetentionMode`
+condition key (see the AWS data-retention docs → *Enforcing retention policy with IAM*).
+
+**Blast radius is per-model, not account-wide (this is the key point).** Setting the
+account to `provider_data_share` does **not** make every model start sharing data. Each
+model declares an `allowed_modes` list, and that list — not the account setting — decides
+what actually happens to a given model's data:
+
+| Model (this launcher) | `allowed_modes` | Under account = `provider_data_share` |
+| --- | --- | --- |
+| **Fable 5 / Mythos 5** | `["provider_data_share"]` | **Retained + shared with Anthropic** (≤30 d, trust & safety) — this is the whole point |
+| Opus 4.6/4.8, Sonnet 4.6/5, Haiku 4.5 | `["default","provider_data_share"]` | **AWS-only** — retained by AWS for abuse detection, **never shared with Anthropic** |
+
+So on `apps-prd` the **CI `@claude` PR reviewer runs on Sonnet, which is `default`-capable
+→ its prompts/source stay AWS-only and are NOT shared with Anthropic.** The account-wide
+setting unlocks Fable 5 without changing the data path of any older model. (A Fable 5
+request that a safety classifier declines and that falls back to Opus 4.8 via fallback
+credit follows **Opus 4.8's** AWS-only rules for the fallback invocation, not Fable 5's.)
 
 **Why only these two models.** Every Claude model on Bedrock declares which retention
-modes it permits via `allowed_modes`. Older models (Opus 4.6/4.8, Sonnet 4.6/5, Haiku)
-allow `default`, so they work under any account setting. **Fable 5 and Mythos 5 declare
-`allowed_modes: ["provider_data_share"]` only** — they refuse `default` (and `none`).
+modes it permits via `allowed_modes` (table above). Older models allow `default`, so they
+work under any account setting **and never leave AWS**. **Fable 5 and Mythos 5 declare
+`allowed_modes: ["provider_data_share"]` only** — they refuse `default` (and `none`),
+which is the trust-&-safety gate for frontier access.
 
-**How the effective mode is resolved.** `first non-inherit value of (project → account →
-model default)`. A fresh account is `inherit`, which falls through to the model default
+**How the effective mode is resolved.** `first non-inherit value of (account → model
+default)`. A fresh account is `inherit`, which falls through to the model default
 (`default`) — so Fable 5 is blocked until you explicitly set `provider_data_share` at the
-account or project scope.
+**account** scope.
 
 **The symptom** when it's not set (this is *not* an access/quota or IAM error):
 
@@ -290,15 +323,28 @@ curl -s -X PUT "https://bedrock.us-east-1.amazonaws.com/data-retention" \
   -d '{"mode":"provider_data_share"}'
 ```
 
-Scope it to a **project** instead of the whole account with
-`POST /v1/organization/projects/{project_id}` `{"data_retention":{"mode":"provider_data_share"}}`
-if you want to limit sharing to one project. **Reversible** at any time with
-`PUT {"mode":"inherit"}` (back to model default) or `{"mode":"none"}` (zero retention) —
-but data retained/shared while `provider_data_share` was active cannot be un-shared.
+**Scope note.** The commands above use the **account-level** control-plane endpoint
+(`bedrock.{region}.amazonaws.com/data-retention`), which is what the bb DevOps SSO role can
+reach and is the scope we use. Bedrock *also* exposes a **project-level** retention setting
+on the separate `bedrock-mantle` data plane (`POST /v1/organization/projects/{id}` →
+`bedrock-mantle:UpdateProject`), but that action is **not granted** to our SSO roles
+(verified: `bedrock-mantle:*` returns `access_denied`), so project-scoping isn't usable here
+without a permission-set change. **Reversible** at any time with `PUT {"mode":"inherit"}`
+(back to the model default) or `{"mode":"none"}` (zero retention) — but data retained/shared
+while `provider_data_share` was active cannot be un-shared.
 
-**Status:** `apps-prd` was opted in account-wide on **2026-07-18** (with explicit sign-off)
-and Fable 5 is live there. `data-science` has **not** been opted in — Fable 5 there needs
-both its pending quota (§5) *and* this opt-in.
+**Enforce a ceiling (compliance).** To *guarantee* an account or the whole org can never be
+set beyond a given posture, attach an SCP/IAM policy that denies the write actions
+(`bedrock:PutAccountDataRetention` / `bedrock-mantle:PutAccountDataRetention`,
+`bedrock-mantle:UpdateProject`) unless the `bedrock:DataRetentionMode` /
+`bedrock-mantle:DataRetentionMode` condition key matches your allowed value — e.g. deny
+anything other than `none` to hard-block Fable 5 in ZDR-required accounts. See the AWS
+data-retention docs → *Enforcing retention policy with IAM*.
+
+**Status:** `apps-prd` was opted in at the **account** scope on **2026-07-18** (with explicit
+sign-off) and Fable 5 is live there; older models on `apps-prd` remain AWS-only per the
+blast-radius table above (the CI `@claude` reviewer's data is not shared). `data-science`
+has **not** been opted in — Fable 5 there needs both its pending quota (§5) *and* this opt-in.
 
 Full reference: [Bedrock data-retention docs](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html).
 
@@ -307,7 +353,7 @@ Full reference: [Bedrock data-retention docs](https://docs.aws.amazon.com/bedroc
 | Symptom | Root cause | Fix |
 | --- | --- | --- |
 | `AccessDeniedException: <model> is not available for this account` (or a console `InvokeModelWithResponseStream` error) | Model **access or quota** not granted for that model **in that account** (gate 1/2, §5) — **not** IAM | Use `apps-prd` (has Opus 4.8 / Sonnet 5), or enable access + wait for the data-science quota case |
-| `400 data retention mode 'default' is not available for this model` (Fable 5 / Mythos 5 only) | Account not opted into `provider_data_share` (gate 4, §5.1) — the model is `ACTIVE`; it's policy-gated, not missing | Opt the account (or project) into `provider_data_share` per §5.1 — **account-wide governance change**, get sign-off first |
+| `400 data retention mode 'default' is not available for this model` (Fable 5 / Mythos 5 only) | Account not opted into `provider_data_share` (gate 4, §5.1) — the model is `ACTIVE`; it's policy-gated, not missing | Set the **account** data-retention mode to `provider_data_share` per §5.1 — **account-wide setting** (sharing is per-model; only Fable/Mythos share — §5.1 table), get sign-off first |
 | `There's an issue with the selected model (us.anthropic....)`; debug log shows `dispatching to firstParty` | `CLAUDE_CODE_USE_BEDROCK` pinned/overridden by a settings `env` block — the Bedrock model ID went to the native Anthropic API (404) | Remove the key from every settings `env` block (§1) |
 | `403 The security token included in the request is invalid` | `AWS_PROFILE` pinned in a settings `env` block to a stale profile — it outranks the wrapper | Remove the `AWS_PROFILE` pin (§1); refresh credentials |
 | `ERROR: AWS profile 'bb-…' not found` | You don't have that account/role combo | Pick a profile the launcher lists (from your `~/.aws/bb/config`) |

--- a/doc/ai-sdlc/claude-code-bedrock.md
+++ b/doc/ai-sdlc/claude-code-bedrock.md
@@ -266,19 +266,28 @@ API Error: 400 data retention mode 'default' is not available for this model
 
 The request reached Bedrock and the model is `ACTIVE` — it's policy-gated, not missing.
 
-**Check the current account mode** (read-only). `awscli` 2.27.8 has no `data-retention`
-subcommand, so sign the control-plane REST call (`bedrock` service, SigV4):
+**Check the current account mode** (read-only). `awscli` (2.27.x) has no `data-retention`
+subcommand, so sign the control-plane REST call directly (`bedrock` service, SigV4). Modern
+`curl` (7.75.0+) signs it natively via `--aws-sigv4`, reading the same `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` the launcher already exports for the session:
 
 ```bash
 # via the bb SSO profile; returns e.g. {"mode":"inherit","updatedAt":null}
-curl -s "https://bedrock.us-east-1.amazonaws.com/data-retention"   # + SigV4 (bedrock, us-east-1)
+curl -s --aws-sigv4 "aws:amz:us-east-1:bedrock" \
+  --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+  -H "X-Amz-Security-Token: $AWS_SESSION_TOKEN" \
+  "https://bedrock.us-east-1.amazonaws.com/data-retention"
 ```
 
 **Opt in** (the write — account-wide; needs governance sign-off):
 
 ```bash
 curl -s -X PUT "https://bedrock.us-east-1.amazonaws.com/data-retention" \
-  -H "Content-Type: application/json" -d '{"mode":"provider_data_share"}'   # + SigV4
+  --aws-sigv4 "aws:amz:us-east-1:bedrock" \
+  --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+  -H "X-Amz-Security-Token: $AWS_SESSION_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"provider_data_share"}'
 ```
 
 Scope it to a **project** instead of the whole account with


### PR DESCRIPTION
## What?

Adds **Claude Fable 5** (`us.anthropic.claude-fable-5`) to the `claude-bedrock` local-session launcher and its doc.

- Fable 5 is exposed as a **dedicated `/model` tier row** via `ANTHROPIC_DEFAULT_FABLE_MODEL` — a first-class slot alongside opus/sonnet/haiku, **not** the single custom slot (which still holds the Opus 4.6 fallback).
- Added in **both** the `apps-prd` and `data-science` account blocks.
- **Default model is unchanged** — `apps-prd` stays on Opus 4.8; you pick Fable 5 in `/model` when you want it.
- Documents a **fourth invoke gate** (data-retention) that only Fable 5 / Mythos 5 trip — in the launcher header, the `/model` picker descriptions, doc §2/§3/§5, and a new highlighted **§5.1**.

Scope is limited to these two files:

- `doc/ai-sdlc/bin/claude-bedrock`
- `doc/ai-sdlc/claude-code-bedrock.md`

## Why?

`apps-prd` has Fable 5 available and we want it selectable for local Bedrock sessions. Unlike every other Claude model on Bedrock, Fable 5 / Mythos 5 declare `allowed_modes: ["provider_data_share"]` **only** — under the default retention mode they fail with:

```
API Error: 400 data retention mode 'default' is not available for this model
```

The request reaches Bedrock and the model is `ACTIVE`; it is **policy-gated, not missing**. Enabling it is an **account-wide** opt-in that retains prompts + outputs **and shares them with the provider** — on `apps-prd` that also covers the CI `@claude` reviewer — so §5.1 documents it as a governance decision (read/opt-in commands, project-scope alternative, reversibility, per-account status).

> **Operational note:** the `apps-prd` account was opted into `provider_data_share` account-wide on **2026-07-18** (with explicit sign-off), and Fable 5 was verified live via `invoke-model us.anthropic.claude-fable-5` → `stop_reason: end_turn`. `data-science` was **not** opted in (Fable 5 there still needs both pending quota and this opt-in). This account setting is a Bedrock control-plane change, not part of this diff.

## References

- Launcher: [`doc/ai-sdlc/bin/claude-bedrock`](https://github.com/binbashar/le-tf-infra-aws/blob/feat/claude-bedrock-fable-5/doc/ai-sdlc/bin/claude-bedrock)
- Doc: [`doc/ai-sdlc/claude-code-bedrock.md`](https://github.com/binbashar/le-tf-infra-aws/blob/feat/claude-bedrock-fable-5/doc/ai-sdlc/claude-code-bedrock.md) (§5.1 data-retention gate)
- Prior launcher PR: #1111
- [Amazon Bedrock — Data retention](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html)
- [Bedrock Claude Fable 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fable 5 as a selectable Bedrock model in supported model pickers.
  * Added guidance for enabling the required data-retention setting before using Fable 5.

* **Documentation**
  * Updated Bedrock setup, availability, and troubleshooting guidance.
  * Documented account-specific access, quota, and data-retention requirements for Fable 5 and Mythos 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->