### PR TITLE
fix(ci): scope static-code lint to the files a branch actually changed

### DIFF
--- a/.github/workflows/test-static-code-and-linting.yml
+++ b/.github/workflows/test-static-code-and-linting.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches-ignore:
       - master
+  # Branch pushes only check the files they changed (see #929), so a weekly
+  # repo-wide sweep still catches formatting drift in layers nobody has touched.
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
 env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
@@ -18,6 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+          # Full history so the lint step can diff this branch against origin/master.
+          fetch-depth: 0
 
       - name: Context Info
         run: |
@@ -53,7 +60,37 @@ jobs:
           terraform-docs --version
 
       - name: Test terraform format and docs
-        run: make pre-commit
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Scheduled and manual runs sweep the whole repo.
+          if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
+            echo "[INFO] ${GITHUB_EVENT_NAME} run - checking all files"
+            make pre-commit
+            exit 0
+          fi
+
+          # Push runs check only what this branch changed against master, so a
+          # pre-existing violation in a layer outside the PR scope cannot fail it.
+          git fetch --no-tags --quiet origin master || true
+          BASE="$(git merge-base origin/master HEAD 2>/dev/null || true)"
+
+          if [[ -z "${BASE}" ]]; then
+            echo "[WARN] no merge-base with origin/master - falling back to all files"
+            make pre-commit
+            exit 0
+          fi
+
+          COUNT="$(git diff --name-only "${BASE}" HEAD | wc -l | tr -d '[:space:]')"
+          if [[ "${COUNT}" -eq 0 ]]; then
+            echo "[INFO] no files changed since ${BASE::8} - nothing to check"
+            exit 0
+          fi
+
+          echo "[INFO] checking ${COUNT} file(s) changed since ${BASE::8}:"
+          git diff --name-only "${BASE}" HEAD | sed 's/^/  /'
+          pre-commit run --from-ref "${BASE}" --to-ref HEAD --show-diff-on-failure
 
       - name: Notify slack failure workflow run
         uses: slackapi/slack-github-action@v2.0.0

--- a/docs/ai-sdlc/README.md
+++ b/docs/ai-sdlc/README.md
@@ -45,7 +45,7 @@ These run on every PR with no human action required.
 
 | Workflow | File | Purpose |
 | --- | --- | --- |
-| **Test and Lint** | [`.github/workflows/test-static-code-and-linting.yml`](../../.github/workflows/test-static-code-and-linting.yml) | Runs `make pre-commit` → `pre-commit run --all-files` (terraform_fmt, pretty-format-json, trailing-whitespace, private-key detection). |
+| **Test and Lint** | [`.github/workflows/test-static-code-and-linting.yml`](../../.github/workflows/test-static-code-and-linting.yml) | Runs the pre-commit hooks (terraform_fmt, pretty-format-json, trailing-whitespace, private-key detection). On a branch push it checks **only the files changed since the merge-base with `master`**, so an unrelated violation elsewhere can't fail your PR; a weekly schedule and `workflow_dispatch` still run the full `make pre-commit` → `pre-commit run --all-files` sweep to catch drift in untouched layers. |
 | **Infracost** | [`.github/workflows/infracost.yml`](../../.github/workflows/infracost.yml) | Posts a monthly cost-diff comment per layer ([`infracost.yml`](../../infracost.yml)). |
 | **GitGuardian** | GitHub App | Secret scanning across the diff. |
 


### PR DESCRIPTION
## What?
* The `Test and Lint` job no longer re-lints the whole repository on every branch push. Push runs now diff against the merge-base with `origin/master` and pass only those paths to `pre-commit` via `--from-ref/--to-ref`.
* Adds `--show-diff-on-failure`, so a `terraform_fmt` failure prints the exact diff that would fix it instead of just reporting non-zero.
* Adds `fetch-depth: 0` to the checkout, required for the merge-base to resolve.
* Adds a weekly `schedule` (Mondays 06:17 UTC) and `workflow_dispatch`, which still run the full `make pre-commit` sweep.

## Why?
* `make pre-commit` is `pre-commit run --all-files`, defined in `le-dev-makefiles` at `terraform1/terraform1-root-context.mk` (pinned `v0.1.37`). Because that target lives in an external repo it cannot be narrowed from here — the fix has to be at the workflow step, which is what this does.
* Repo-wide linting on every push means a pre-existing formatting violation in a layer **outside** the change set fails an unrelated PR, and every author pays the full-repo cost for a one-line change.
* **Repo-wide coverage is kept, not dropped.** Scoping alone would let drift accumulate silently in layers nobody touches, so the weekly sweep and manual dispatch retain the `--all-files` behaviour — it is just off every PR's critical path. If the merge-base cannot be resolved (e.g. an orphan branch), the step falls back to the full sweep rather than silently checking nothing.
* Verified locally against this branch: merge-base resolved to `13032247`, one changed file detected, and `terraform_fmt` correctly **skipped** because no `.tf` files changed — the exact behaviour the issue asks for. The whitespace/merge-conflict/private-key hooks still ran on the changed file.
* No `${{ }}` interpolation is used inside any `run:` block; the script reads `${GITHUB_EVENT_NAME}` as an environment variable, avoiding workflow script injection.

## References
* Refs #929 (item 3: "Format check shouldn't run on the whole repo but only for the layers that are in the PR scope").
* On the other two items in #929, for whoever triages it:
  * **Item 2** (`allowed_regions` missing defaults) is **already fixed** — the variable is `regions_allowed`, and #1043 (`212ce50c`, 2026-03-23) added `default = ["us-east-1", "us-east-2", "us-west-2"]` plus a validation block. `test_leverage` passes.
  * **Item 1** ("Pre-commit fails due to unknown reasons") **does not currently reproduce** — `Test and Lint` passes on master and on #1123. Left untouched rather than guessed at; suggest closing it unless someone has a failing run to point at.