### PR TITLE
docs(ai-sdlc): document GitHub token scopes for AI agent workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,18 @@ Please note we have a code of conduct, please follow it in all your interactions
    do not have permission to do that, you may request the second reviewer to merge it for you.
 
 
+### AI agent contributions
+
+If you are configuring an AI agent to open PRs against this repo — Claude Code, the
+`@claude` PR assistant, or the `release-management` plugin — it needs a GitHub token
+with the right scopes. `Contents: RW` is required for anything that pushes a branch,
+and GitHub's `403 Resource not accessible by personal access token` has three distinct
+causes that look identical from the outside.
+
+Scope tables, the resource-owner requirement, and how to discriminate those 403s:
+[`docs/ai-sdlc/github-token-scopes.md`](docs/ai-sdlc/github-token-scopes.md). The
+end-to-end review flow is in [`docs/ai-sdlc/README.md`](docs/ai-sdlc/README.md).
+
 ### Collaborate on fixes for security vulnerabilities in private forks
 
 Working in the open means that it is impossible to hide things. And yet, sometimes you will want

--- a/docs/ai-sdlc/README.md
+++ b/docs/ai-sdlc/README.md
@@ -8,6 +8,11 @@ runs at each step, and how the on-demand `@claude` assistant routes through
 > through Bedrock (data-science account) on demand — see
 > [`claude-code-bedrock.md`](claude-code-bedrock.md).
 
+> **Agent GitHub access:** which token and scopes an AI agent needs to open a PR
+> here, and how to tell apart the three causes of GitHub's ambiguous `403
+> Resource not accessible by personal access token` — see
+> [`github-token-scopes.md`](github-token-scopes.md).
+
 ![AI-Driven SDLC overview](../diagrams/ai-sdlc.png)
 
 > Source: [`docs/diagrams/ai-sdlc.py`](../diagrams/ai-sdlc.py) — re-render with
@@ -118,6 +123,7 @@ Maintainers read the AI + CI findings on the PR, then:
 ## Related references
 
 - Project conventions and commands: [`CLAUDE.md`](../../CLAUDE.md)
+- GitHub token scopes for AI agents: [`github-token-scopes.md`](github-token-scopes.md)
 - Workflows: [`.github/workflows/`](../../.github/workflows/)
 - Diagram sources & rendered PNGs: [`docs/diagrams/`](../diagrams/)
 - `@claude` action: [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)

--- a/docs/ai-sdlc/github-token-scopes.md
+++ b/docs/ai-sdlc/github-token-scopes.md
@@ -1,0 +1,126 @@
+# GitHub token scopes for AI agent workflows
+
+Which GitHub token an AI agent needs to drive the workflows in this repo, what each
+scope unlocks, and how to tell the three different causes of GitHub's ambiguous
+`403 Resource not accessible by personal access token` apart.
+
+Scope tables below were verified against this repo on **2026-07-25**.
+
+> See also: [`README.md`](README.md) for the end-to-end SDLC flow, and
+> [`claude-code-bedrock.md`](claude-code-bedrock.md) for routing local Claude Code
+> sessions through Bedrock.
+
+---
+
+## 1. Which token do you need?
+
+Two different paths, and they fail in different ways. Pick the row that matches what
+you are wiring up.
+
+| Use case | Token | Why |
+| --- | --- | --- |
+| **Local Claude Code + GitHub MCP server** | `gh` CLI OAuth token (`gho_…`) | Inherits your own OAuth scopes, so there is no fine-grained scope matrix to get wrong. See [§5](#5-local-claude-code-the-gh-cli-shortcut). |
+| **CI / unattended automation** (agent-driven PRs, `release-management`) | Fine-grained PAT | No interactive login available. Scopes must be granted explicitly — see [§2](#2-fine-grained-pat-required-scopes). |
+
+## 2. Fine-grained PAT: required scopes
+
+Split by what each one actually unlocks, so you can grant the minimum for the
+workflow you need rather than copying the whole set:
+
+| Scope | Enables |
+| --- | --- |
+| `Metadata: RO` | Mandatory baseline — GitHub requires it alongside any other scope. |
+| `Contents: RO` | Read files, list branches. |
+| `Contents: RW` | Create branches, commit files — **required for any PR-opening workflow**. |
+| `Issues: RW` | Create / comment / label / close issues. |
+| `Pull requests: RW` | Open, update, merge PRs. |
+
+**The `Contents` level is the one that catches people.** With `Contents: RO` an agent
+can read code, triage, and discuss, but `POST /git/refs` fails — so it can never push
+the branch a PR would be built from. Triage-only agents are fine at `RO`; anything
+that opens a PR needs `RW`.
+
+Verified behaviour at `Issues: RW`, `Pull requests: RW`, `Contents: RO`, `Metadata: RO`:
+
+| Operation | Result |
+| --- | --- |
+| Read files, list branches / issues / PRs | ✅ works |
+| Create an issue | ✅ works |
+| Comment on an issue or PR | ✅ works |
+| `POST /git/refs` (create a branch) | ❌ `403 Resource not accessible by personal access token` |
+
+## 3. Resource owner must be `binbashar`
+
+A fine-grained PAT is scoped to a **resource owner**. A token owned by your personal
+account cannot write to an org repo *no matter which scopes you tick* — the scopes
+apply to resources the owner controls.
+
+- Set the resource owner to **`binbashar`** when creating the token, not your personal account.
+- Org owners then approve it at
+  `https://github.com/organizations/binbashar/settings/personal-access-tokens-pending`.
+- Until it is approved, the token behaves like it has no permissions at all.
+
+## 4. Troubleshooting the ambiguous 403
+
+`403 Resource not accessible by personal access token` is returned for at least three
+distinct causes, and the fixes have nothing in common:
+
+| 403 on | Cause | Fix |
+| --- | --- | --- |
+| *Every* write, including issue comments | PAT resource owner is a personal account | Regenerate with owner `binbashar` ([§3](#3-resource-owner-must-be-binbashar)) |
+| Branch creation / commits only | `Contents` is `RO` | Raise `Contents` to `RW` ([§2](#2-fine-grained-pat-required-scopes)) |
+| `GET /orgs/{org}/issue-types` | Org-level endpoint, org permission absent | Grant org read, or omit `type` on issue creation |
+
+### The cheap discriminator
+
+**If an issue comment succeeds but branch creation fails with the same 403, it is a
+scope problem, not a resource-owner problem.**
+
+Worth stating explicitly because without that check the natural move is to regenerate
+the token — which returns the identical error, costs an org-approval round trip, and
+teaches you nothing.
+
+```bash
+# Succeeds but branch creation 403s  ->  raise Contents to RW.
+# Also 403s                          ->  fix the resource owner first.
+gh api "repos/binbashar/le-tf-infra-aws/issues/<N>/comments" -f body="scope probe"
+```
+
+## 5. Local Claude Code: the `gh` CLI shortcut
+
+For local sessions the GitHub MCP server authenticates with
+`Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`. Rather than minting a
+fine-grained PAT, export the `gh` CLI's own OAuth token — it carries the scopes you
+already have, so §2's matrix does not apply:
+
+```bash
+# ~/.zshrc  (or ~/.bashrc)
+export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+```
+
+Two gotchas, both verified on 2026-07-25:
+
+- **When the variable is unset the header ships empty**, and GitHub returns
+  `HTTP 400: Authorization header is badly formatted`. That surfaces in the client as a
+  *connection* failure rather than an auth one, which sends you debugging the wrong layer.
+- **A client restart is required** — the MCP server reads the variable from the
+  environment at spawn time. `claude mcp list` reporting *Connected* only means the
+  process started; it does not prove the token works. Confirm with one real read call.
+
+## 6. Compensating controls
+
+`Contents: RW` sounds broad, but it does **not** grant a direct push to the default
+branch here:
+
+- **`master` is protected**, so changes still have to arrive as a PR for human review.
+  This keeps the standing rule — plans go to a PR, a human runs `apply` — enforced at
+  the platform level rather than depending on agent behaviour.
+- **Scope the token to an explicit repository list** rather than all of `binbashar`.
+- **Confirm equivalent branch protection** on any repo you later add to that list —
+  otherwise `Contents: RW` there really does mean unreviewed pushes.
+
+## Related references
+
+- SDLC flow and CI checks: [`README.md`](README.md)
+- Project conventions and commands: [`CLAUDE.md`](../../CLAUDE.md)
+- GitHub docs: [Fine-grained PAT permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)


### PR DESCRIPTION
## What?
* Adds [`docs/ai-sdlc/github-token-scopes.md`](docs/ai-sdlc/github-token-scopes.md), covering the four things #1122 asked for:
  1. A fine-grained PAT **scope table split by what each scope unlocks**, with `Contents: RW` called out as the requirement for any PR-opening workflow.
  2. The **resource-owner requirement** (`binbashar`, not a personal account) and where org owners approve pending tokens.
  3. A **troubleshooting matrix for the ambiguous `403`**, plus the cheap discriminator.
  4. The **compensating control** — protected `master` means `Contents: RW` still can't push to the default branch unreviewed.
* Adds a fifth section not in the original ask: the `gh auth token` path for local Claude Code MCP sessions, which sidesteps the fine-grained scope matrix entirely.
* Links the new doc from `CONTRIBUTING.md` (new *AI agent contributions* subsection) and from `docs/ai-sdlc/README.md`.

## Why?
* `Contents: RO` lets an agent read, triage and discuss but not `POST /git/refs`, so it can never push the branch a PR would be built from. That blocks the agent-driven PR flow #1011 is aiming at and the `release-management` plugin, which must commit a version bump and CHANGELOG before opening its release PR.
* The `403 Resource not accessible by personal access token` message is returned for three different causes whose fixes have nothing in common. The discriminator is the part worth writing down: **if an issue comment succeeds but branch creation fails with the same 403, it's a scope problem, not a resource-owner problem.** Without it the natural move is to regenerate the token — which returns the identical error and costs an org-approval round trip.
* The `gh auth token` section documents two failure modes found while wiring the GitHub MCP server locally: an unset `GITHUB_PERSONAL_ACCESS_TOKEN` ships an empty `Bearer` header and surfaces as `HTTP 400` / a *connection* failure rather than an auth one, and `claude mcp list` reporting **Connected** only proves the process spawned — not that the token works. Both send you debugging the wrong layer.

## References
* Closes #1122.
* Related: #1011 (Claude Code GitHub workflows for AI-assisted infrastructure management).
* Scope behaviour tables were verified against this repo on 2026-07-25; internal links and heading anchors verified, and `pre-commit` passes on the changed files.