### PR TITLE
chore(ai-tooling): promote Opus 5 in the claude-bedrock launcher, retire Opus 4.6

### DIFF
--- a/docs/ai-sdlc/bin/claude-bedrock
+++ b/docs/ai-sdlc/bin/claude-bedrock
@@ -9,8 +9,8 @@
 # You pick the ACCOUNT and SSO ROLE interactively (or via env); the launcher sets
 # the matching profile, the models that account actually has, and the credential
 # auto-refresh layer. Model availability differs per account:
-#   apps-prd      → Opus 4.8 / Sonnet 5 live today; Fable 5 needs the opt-in below
-#   data-science  → Opus 4.6 / Sonnet 4.6 (Opus 4.8, Sonnet 5 & Fable 5 quota pending)
+#   apps-prd      → Opus 5 / Sonnet 5 live today; Fable 5 needs the opt-in below
+#   data-science  → Opus 4.6 / Sonnet 4.6 (Opus 5, Sonnet 5 & Fable 5 quota pending)
 # Role: devops | datascientist (not everyone has DevOps; pick what you have).
 #
 # Fable 5 data-retention gate: unlike every other model here, Bedrock's Fable 5
@@ -56,8 +56,8 @@ interactive() { [[ "$headless" == 0 && -t 0 && -t 1 ]]; }
 if [[ -z "${CLAUDE_BEDROCK_ACCOUNT:-}" ]]; then
   if interactive; then
     echo "AWS account for this Amazon Bedrock session:" >&2
-    echo "  1) data-science  [default]  — Opus 4.6 / Sonnet 4.6 (Opus 4.8 & Sonnet 5 quota pending)" >&2
-    echo "  2) apps-prd      (prod)     — Opus 4.8 / Sonnet 5 live" >&2
+    echo "  1) data-science  [default]  — Opus 4.6 / Sonnet 4.6 (Opus 5 & Sonnet 5 quota pending)" >&2
+    echo "  2) apps-prd      (prod)     — Opus 5 / Sonnet 5 live" >&2
     printf "Account [1]: " >&2; read -r _a || _a=""
     case "$_a" in 2 | apps-prd | prd | prod) CLAUDE_BEDROCK_ACCOUNT="apps-prd" ;; *) CLAUDE_BEDROCK_ACCOUNT="data-science" ;; esac
   else
@@ -94,26 +94,26 @@ fi
 # --- Account-aware model set + /model picker descriptions ------------------
 # The NAME shown in /model stays the raw us.anthropic.* inference-profile ID
 # (unambiguous evidence you're on Bedrock). _DESCRIPTION labels each row's origin.
-# Availability differs per account — see the header. When data-science's Opus 4.8 /
+# Availability differs per account — see the header. When data-science's Opus 5 /
 # Sonnet 5 quota lands, promote them to the defaults here (and drop the "pending").
 case "$account" in
   apps-prd)
     refresh_layer_default="apps-prd/us-east-1/notifications"
-    default_model="us.anthropic.claude-opus-4-8"
-    opus="us.anthropic.claude-opus-4-8";                 opus_desc="Amazon Bedrock · apps-prd account (most capable Opus)"
+    default_model="us.anthropic.claude-opus-5"
+    opus="us.anthropic.claude-opus-5";                   opus_desc="Amazon Bedrock · apps-prd account (most capable Opus)"
     sonnet="us.anthropic.claude-sonnet-5";               sonnet_desc="Amazon Bedrock · apps-prd account (balanced)"
     haiku="us.anthropic.claude-haiku-4-5-20251001-v1:0"; haiku_desc="Amazon Bedrock · apps-prd account (fast, low-cost)"
     fable="us.anthropic.claude-fable-5";                 fable_desc="Amazon Bedrock · apps-prd account (Fable 5 — most capable, premium; needs provider_data_share opt-in)"
-    custom="us.anthropic.claude-opus-4-6-v1";            custom_desc="Amazon Bedrock · apps-prd account (Opus 4.6 fallback)"
+    custom="us.anthropic.claude-opus-4-8";               custom_desc="Amazon Bedrock · apps-prd account (Opus 4.8 fallback)"
     ;;
   data-science)
     refresh_layer_default="data-science/us-east-1/bedrock-agentcore"
-    default_model="us.anthropic.claude-opus-4-6-v1"      # Opus 4.8 quota still pending in this account
-    opus="us.anthropic.claude-opus-4-6-v1";              opus_desc="Amazon Bedrock · data-science account (Opus 4.6; 4.8 quota pending)"
+    default_model="us.anthropic.claude-opus-4-6-v1"      # Opus 5 quota still pending in this account
+    opus="us.anthropic.claude-opus-4-6-v1";              opus_desc="Amazon Bedrock · data-science account (Opus 4.6 — deprecated; Opus 5 quota pending)"
     sonnet="us.anthropic.claude-sonnet-4-6";             sonnet_desc="Amazon Bedrock · data-science account (Sonnet 4.6; 5 quota pending)"
     haiku="us.anthropic.claude-haiku-4-5-20251001-v1:0"; haiku_desc="Amazon Bedrock · data-science account (fast, low-cost)"
     fable="us.anthropic.claude-fable-5";                 fable_desc="Amazon Bedrock · data-science account (Fable 5 — quota pending; also needs provider_data_share opt-in)"
-    custom="us.anthropic.claude-opus-4-8";               custom_desc="Amazon Bedrock · data-science account (Opus 4.8 — quota pending)"
+    custom="us.anthropic.claude-opus-5";                 custom_desc="Amazon Bedrock · data-science account (Opus 5 — quota pending)"
     ;;
   *)
     echo "ERROR: unknown CLAUDE_BEDROCK_ACCOUNT '$account' (expected: data-science | apps-prd)." >&2

--- a/docs/ai-sdlc/bin/claude-bedrock
+++ b/docs/ai-sdlc/bin/claude-bedrock
@@ -56,8 +56,8 @@ interactive() { [[ "$headless" == 0 && -t 0 && -t 1 ]]; }
 if [[ -z "${CLAUDE_BEDROCK_ACCOUNT:-}" ]]; then
   if interactive; then
     echo "AWS account for this Amazon Bedrock session:" >&2
-    echo "  1) data-science  [default]  — Opus 4.6 / Sonnet 4.6 (Opus 5 & Sonnet 5 quota pending)" >&2
-    echo "  2) apps-prd      (prod)     — Opus 5 / Sonnet 5 live" >&2
+    echo "  1) data-science  [default]  — Opus 4.6 / Sonnet 4.6 (Opus 5, Sonnet 5 & Fable 5 quota pending)" >&2
+    echo "  2) apps-prd      (prod)     — Opus 5 / Sonnet 5 / Fable 5 live" >&2
     printf "Account [1]: " >&2; read -r _a || _a=""
     case "$_a" in 2 | apps-prd | prd | prod) CLAUDE_BEDROCK_ACCOUNT="apps-prd" ;; *) CLAUDE_BEDROCK_ACCOUNT="data-science" ;; esac
   else
@@ -95,7 +95,8 @@ fi
 # The NAME shown in /model stays the raw us.anthropic.* inference-profile ID
 # (unambiguous evidence you're on Bedrock). _DESCRIPTION labels each row's origin.
 # Availability differs per account — see the header. When data-science's Opus 5 /
-# Sonnet 5 quota lands, promote them to the defaults here (and drop the "pending").
+# Sonnet 5 quota lands, promote them to the defaults here (and drop the "pending");
+# its Fable 5 needs that quota *and* the account-wide provider_data_share opt-in above.
 case "$account" in
   apps-prd)
     refresh_layer_default="apps-prd/us-east-1/notifications"

--- a/docs/ai-sdlc/claude-code-bedrock.md
+++ b/docs/ai-sdlc/claude-code-bedrock.md
@@ -99,8 +99,8 @@ the credential-refresh layer. Non-interactively (or under `-p`) it uses the env 
 
 | Account | Models available today | Default role |
 | --- | --- | --- |
-| **`data-science`** (default) | Opus 4.6 / Sonnet 4.6 / Haiku 4.5 — **Opus 4.8, Sonnet 5 & Fable 5 quota pending** (§5) | `devops` |
-| **`apps-prd`** (prod) | **Opus 4.8 / Sonnet 5** / Haiku 4.5 — live today; **Fable 5 live after the §5.1 data-retention opt-in** | `devops` |
+| **`data-science`** (default) | Opus 4.6 *(deprecated)* / Sonnet 4.6 / Haiku 4.5 — **Opus 5, Sonnet 5 & Fable 5 quota pending** (§5) | `devops` |
+| **`apps-prd`** (prod) | **Opus 5 / Sonnet 5** / Haiku 4.5 — live today; **Fable 5 live after the §5.1 data-retention opt-in** | `devops` |
 
 Not everyone has DevOps (some users only have DataScientist, etc.), so the role is a
 choice too. The launcher validates `bb-<account>-<role>` against your
@@ -149,18 +149,18 @@ ID (unambiguous evidence you're on Bedrock, not the native API). Example rows fo
 | Picker row (name — description) | Driven by |
 | --- | --- |
 | `us.anthropic.claude-sonnet-5` — *Amazon Bedrock · apps-prd account (balanced)* | `ANTHROPIC_DEFAULT_SONNET_MODEL` + `_DESCRIPTION` |
-| `us.anthropic.claude-opus-4-8` — *Amazon Bedrock · apps-prd account (most capable Opus)* | `ANTHROPIC_DEFAULT_OPUS_MODEL` + `_DESCRIPTION` |
+| `us.anthropic.claude-opus-5` — *Amazon Bedrock · apps-prd account (most capable Opus)* | `ANTHROPIC_DEFAULT_OPUS_MODEL` + `_DESCRIPTION` |
 | `us.anthropic.claude-haiku-…` — *Amazon Bedrock · apps-prd account (fast, low-cost)* | `ANTHROPIC_DEFAULT_HAIKU_MODEL` + `_DESCRIPTION` |
 | `us.anthropic.claude-fable-5` — *Amazon Bedrock · apps-prd account (Fable 5 — most capable, premium; needs provider_data_share opt-in)* | `ANTHROPIC_DEFAULT_FABLE_MODEL` + `_DESCRIPTION` |
-| `us.anthropic.claude-opus-4-6-v1` — *Amazon Bedrock · apps-prd account (Opus 4.6 fallback)* | `ANTHROPIC_CUSTOM_MODEL_OPTION` trio |
+| `us.anthropic.claude-opus-4-8` — *Amazon Bedrock · apps-prd account (Opus 4.8 fallback)* | `ANTHROPIC_CUSTOM_MODEL_OPTION` trio |
 
 **Fable is a first-class tier slot** (`ANTHROPIC_DEFAULT_FABLE_MODEL`) alongside Opus /
 Sonnet / Haiku — so it gets its own always-visible row **without** spending the single
-custom slot (which still holds the Opus 4.6 fallback). Selecting it, however, is gated
-on the account's data-retention mode — see **§5.1**.
+custom slot (which holds the previous-generation Opus fallback — Opus 4.8). Selecting it,
+however, is gated on the account's data-retention mode — see **§5.1**.
 
 A `data-science` session shows the same shape with that account's models (Opus 4.6 /
-Sonnet 4.6, Fable 5 marked "quota pending", plus Opus 4.8 as a "quota pending" custom
+Sonnet 4.6, Fable 5 marked "quota pending", plus Opus 5 as a "quota pending" custom
 row). There is exactly **one** custom slot: `ANTHROPIC_CUSTOM_MODEL_OPTION` (no numbered
 or array variant). For several *extra* non-tier models the mechanism is the
 `availableModels` / `modelOverrides` settings keys, but those live in a settings file
@@ -169,11 +169,11 @@ dual-mode wrapper.
 
 **Bedrock model-ID caveat:** IDs use the cross-region inference-profile form (`us.`
 prefix), but the **suffix is inconsistent across versions — don't extrapolate one ID
-from another.** Current-generation models are bare — Opus 4.8
-(`us.anthropic.claude-opus-4-8`), Sonnet 5 (`us.anthropic.claude-sonnet-5`) — while
-older ones carry suffixes: Opus 4.6 a `-v1`, Opus 4.5 a dated `-vN:0`, Haiku 4.5
-likewise (`us.anthropic.claude-haiku-4-5-20251001-v1:0`). Always confirm from the
-account:
+from another.** Current-generation models are bare — Opus 5
+(`us.anthropic.claude-opus-5`), Opus 4.8 (`us.anthropic.claude-opus-4-8`), Sonnet 5
+(`us.anthropic.claude-sonnet-5`) — while older ones carry suffixes: Opus 4.6 a `-v1`,
+Opus 4.5 a dated `-vN:0`, Haiku 4.5 likewise
+(`us.anthropic.claude-haiku-4-5-20251001-v1:0`). Always confirm from the account:
 
 ```bash
 aws bedrock list-inference-profiles --region us-east-1 --profile bb-<account>-devops \
@@ -193,11 +193,11 @@ principal in the account with `bedrock:InvokeModel*` can consume the model. Per
 
 Both `bedrock:*` grants are conditioned on `aws:RequestedRegion ∈
 {us-east-1, us-east-2, us-west-2}`, which covers the regions the `us.` cross-region
-inference profiles route to — so IAM is **not** what blocks a new model (verified: the
-DevOps role invokes Sonnet 4.6 / Opus 4.6 / Haiku 4.5 today). What's missing for a new
-model is gate 1/2 below, not IAM.
+inference profiles route to — so IAM is **not** what blocks a new model (verified: the same
+DevOps role invokes Opus 5 / Sonnet 5 in `apps-prd` and Opus 4.6 / Sonnet 4.6 in
+`data-science` today). What's missing for a new model is gate 1/2 below, not IAM.
 
-## 5. Model availability — the four gates (checked 2026-07-18, us-east-1)
+## 5. Model availability — the four gates (checked 2026-07-25, us-east-1)
 
 Four **independent** gates must all pass to invoke a model. A model can clear some and
 still refuse:
@@ -214,15 +214,19 @@ still refuse:
 
 | Model | `apps-prd` | `data-science` |
 | --- | --- | --- |
-| Opus 4.6, Sonnet 4.6, Haiku 4.5 | ✅ | ✅ |
-| **Opus 4.8** | ✅ | ⏳ **quota pending** |
+| Opus 4.6 *(deprecated — superseded by Opus 5)*, Sonnet 4.6, Haiku 4.5 | ✅ | ✅ |
+| **Opus 5** | ✅ | ⏳ **quota pending** |
+| Opus 4.8 *(previous-gen fallback — the custom `/model` row)* | ✅ | ⏳ **quota pending** |
 | **Sonnet 5** | ✅ | ⏳ **quota pending** |
 | **Fable 5** | ✅ **(after §5.1 opt-in — done 2026-07-18)** | ❌ quota pending **+** needs §5.1 opt-in |
 
-So **use `apps-prd` for Opus 4.8 / Sonnet 5 / Fable 5 today**; in `data-science` the launcher's
+Every ✅/⏳ above was re-verified on **2026-07-25** with a one-token `bedrock-runtime converse`
+per model per account — the only check that exercises all four gates at once.
+
+So **use `apps-prd` for Opus 5 / Sonnet 5 / Fable 5 today**; in `data-science` the launcher's
 `us.` profiles return *"not available for this account"* — a gate-1/2 (access/quota)
 block, **not** IAM. Heads-up: the pending Service Quotas cases you may see are for the
-separate **`global.*`** family (*Global cross-region* Opus 4.8 / Sonnet 5), which the
+separate **`global.*`** family (*Global cross-region* Opus 5 / Opus 4.8 / Sonnet 5), which the
 launcher does **not** use (and which the region condition blocks by design, §4) — so
 they won't unblock the launcher on their own. Turning on data-science's **`us.`**
 models is its own model-access + `us.`-quota step. Check a quota with:
@@ -272,7 +276,7 @@ what actually happens to a given model's data:
 | Model (this launcher) | `allowed_modes` | Under account = `provider_data_share` |
 | --- | --- | --- |
 | **Fable 5 / Mythos 5** | `["provider_data_share"]` | **Retained + shared with Anthropic** (≤30 d, trust & safety) — this is the whole point |
-| Opus 4.6/4.8, Sonnet 4.6/5, Haiku 4.5 | `["default","provider_data_share"]` | **AWS-only** — retained by AWS for abuse detection, **never shared with Anthropic** |
+| Opus 5, Opus 4.6/4.8, Sonnet 4.6/5, Haiku 4.5 | `["default","provider_data_share"]` | **AWS-only** — retained by AWS for abuse detection, **never shared with Anthropic** |
 
 So on `apps-prd` the **CI `@claude` PR reviewer runs on Sonnet, which is `default`-capable
 → its prompts/source stay AWS-only and are NOT shared with Anthropic.** The account-wide
@@ -352,7 +356,7 @@ Full reference: [Bedrock data-retention docs](https://docs.aws.amazon.com/bedroc
 
 | Symptom | Root cause | Fix |
 | --- | --- | --- |
-| `AccessDeniedException: <model> is not available for this account` (or a console `InvokeModelWithResponseStream` error) | Model **access or quota** not granted for that model **in that account** (gate 1/2, §5) — **not** IAM | Use `apps-prd` (has Opus 4.8 / Sonnet 5), or enable access + wait for the data-science quota case |
+| `AccessDeniedException: <model> is not available for this account` (or a console `InvokeModelWithResponseStream` error) | Model **access or quota** not granted for that model **in that account** (gate 1/2, §5) — **not** IAM | Use `apps-prd` (has Opus 5 / Sonnet 5), or enable access + wait for the data-science quota case |
 | `400 data retention mode 'default' is not available for this model` (Fable 5 / Mythos 5 only) | Account not opted into `provider_data_share` (gate 4, §5.1) — the model is `ACTIVE`; it's policy-gated, not missing | Set the **account** data-retention mode to `provider_data_share` per §5.1 — **account-wide setting** (sharing is per-model; only Fable/Mythos share — §5.1 table), get sign-off first |
 | `There's an issue with the selected model (us.anthropic....)`; debug log shows `dispatching to firstParty` | `CLAUDE_CODE_USE_BEDROCK` pinned/overridden by a settings `env` block — the Bedrock model ID went to the native Anthropic API (404) | Remove the key from every settings `env` block (§1) |
 | `403 The security token included in the request is invalid` | `AWS_PROFILE` pinned in a settings `env` block to a stale profile — it outranks the wrapper | Remove the `AWS_PROFILE` pin (§1); refresh credentials |

--- a/docs/ai-sdlc/claude-code-bedrock.md
+++ b/docs/ai-sdlc/claude-code-bedrock.md
@@ -169,9 +169,10 @@ dual-mode wrapper.
 
 **Bedrock model-ID caveat:** IDs use the cross-region inference-profile form (`us.`
 prefix), but the **suffix is inconsistent across versions — don't extrapolate one ID
-from another.** Current-generation models are bare — Opus 5
-(`us.anthropic.claude-opus-5`), Opus 4.8 (`us.anthropic.claude-opus-4-8`), Sonnet 5
-(`us.anthropic.claude-sonnet-5`) — while older ones carry suffixes: Opus 4.6 a `-v1`,
+from another.** Both lists below are illustrative, not exhaustive. Current-generation
+models are bare — Opus 5 (`us.anthropic.claude-opus-5`), Opus 4.8
+(`us.anthropic.claude-opus-4-8`), Sonnet 5 (`us.anthropic.claude-sonnet-5`), Fable 5
+(`us.anthropic.claude-fable-5`) — while older ones carry suffixes: Opus 4.6 a `-v1`,
 Opus 4.5 a dated `-vN:0`, Haiku 4.5 likewise
 (`us.anthropic.claude-haiku-4-5-20251001-v1:0`). Always confirm from the account:
 
@@ -276,7 +277,7 @@ what actually happens to a given model's data:
 | Model (this launcher) | `allowed_modes` | Under account = `provider_data_share` |
 | --- | --- | --- |
 | **Fable 5 / Mythos 5** | `["provider_data_share"]` | **Retained + shared with Anthropic** (≤30 d, trust & safety) — this is the whole point |
-| Opus 5, Opus 4.6/4.8, Sonnet 4.6/5, Haiku 4.5 | `["default","provider_data_share"]` | **AWS-only** — retained by AWS for abuse detection, **never shared with Anthropic** |
+| Opus 5, Opus 4.6/4.8, Sonnet 4.6/5, Haiku 4.5 | `["default","provider_data_share"]` | **AWS-only** — the model *accepts* `provider_data_share` but never requires data to leave AWS's boundary; may be retained by AWS for abuse detection, **never shared with Anthropic** |
 
 So on `apps-prd` the **CI `@claude` PR reviewer runs on Sonnet, which is `default`-capable
 → its prompts/source stay AWS-only and are NOT shared with Anthropic.** The account-wide
@@ -285,8 +286,14 @@ request that a safety classifier declines and that falls back to Opus 4.8 via fa
 credit follows **Opus 4.8's** AWS-only rules for the fallback invocation, not Fable 5's.)
 
 **Why only these two models.** Every Claude model on Bedrock declares which retention
-modes it permits via `allowed_modes` (table above). Older models allow `default`, so they
-work under any account setting **and never leave AWS**. **Fable 5 and Mythos 5 declare
+modes it permits via `allowed_modes` (table above). Every other model in this launcher —
+**including Opus 5, despite being newer than Fable 5** — allows `default`, so it works
+under any account setting **and never leaves AWS**. AWS's canonical list of models that
+*require* retention names only Fable 5 and Mythos 5
+([abuse detection](https://docs.aws.amazon.com/bedrock/latest/userguide/abuse-detection.html);
+[data retention](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html),
+which uses **Opus 4.8** as its worked example of a `["default","provider_data_share"]`
+model whose data "is retained by AWS only"). **Fable 5 and Mythos 5 declare
 `allowed_modes: ["provider_data_share"]` only** — they refuse `default` (and `none`),
 which is the trust-&-safety gate for frontier access.
 


### PR DESCRIPTION
## What?

* **`apps-prd`** — default model and the Opus tier slot move to **Opus 5** (`us.anthropic.claude-opus-5`). The single `ANTHROPIC_CUSTOM_MODEL_OPTION` slot moves from the Opus 4.6 fallback to **Opus 4.8**, so the fallback is one generation back instead of three.
* **`data-science`** — Opus 4.6 **stays** the default and Opus tier (still the only invocable Opus there), but is relabelled *deprecated*; its "quota pending" custom row now advertises Opus 5 instead of Opus 4.8.
* Docs updated to match: account/model tables, `/model` picker rows, the inference-profile ID caveat, the four-gates table (with re-check date + method), the IAM verification note, and the troubleshooting fix column.

Availability re-verified on **2026-07-25** with a one-token `bedrock-runtime converse` per model per account — the only check that exercises all four gates (model access, TPM quota, IAM, data retention) at once:

| Model | `apps-prd` | `data-science` |
| --- | --- | --- |
| **Opus 5** | ✅ | ❌ `not available for this account` (gate 1/2) |
| Opus 4.8 | ✅ | ❌ same |
| Sonnet 5 | ✅ | ❌ same |
| Opus 4.6 / Sonnet 4.6 / Haiku 4.5 | ✅ | ✅ |

<details>
<summary>Resulting <code>/model</code> picker — apps-prd session</summary>

```text
us.anthropic.claude-sonnet-5                 Amazon Bedrock · apps-prd account (balanced)
us.anthropic.claude-fable-5                  Amazon Bedrock · apps-prd account (Fable 5 — most capable, premium; needs provider_data_share opt-in)
us.anthropic.claude-opus-5                   Amazon Bedrock · apps-prd account (most capable Opus)      <- default
us.anthropic.claude-haiku-4-5-20251001-v1:0  Amazon Bedrock · apps-prd account (fast, low-cost)
us.anthropic.claude-opus-4-8                 Amazon Bedrock · apps-prd account (Opus 4.8 fallback)
```
</details>

## Why?

* Opus 4.6 is three generations behind and was occupying the one custom `/model` slot in `apps-prd` purely as a fallback; Opus 4.8 is the sensible previous-generation fallback now that Opus 5 is live.
* Opus 4.6 **cannot** be dropped from `data-science`: Opus 5, Opus 4.8 and Sonnet 5 are all still gate-1/2 blocked there, so removing it would leave that account with no Opus at all. Deprecation there is a label change only, until the `us.` quota lands.
* Bumping `ANTHROPIC_DEFAULT_OPUS_MODEL` in the launcher is also what stops Claude Code's *"Newer Opus model available — update settings?"* prompt from firing. Accepting that prompt writes a model pin into a settings `env` block, which per §1 of the doc outranks the wrapper and breaks plain `claude` — the launcher is the correct place to bump the model, not settings.
* Opus 5 declares `allowed_modes: ["default","provider_data_share"]`, so it stays **AWS-only**. No change to the Fable 5 data-retention blast radius, and the CI `@claude` reviewer's data is still not shared with Anthropic.

## Verification

* `bash -n docs/ai-sdlc/bin/claude-bedrock` — clean.
* `pre-commit run --files <both files>` — passed.
* End-to-end headless run: `CLAUDE_BEDROCK_ACCOUNT=apps-prd claude-bedrock -p "..."` reports `model=us.anthropic.claude-opus-5` and returns a completion.

## References

* [`docs/ai-sdlc/claude-code-bedrock.md`](docs/ai-sdlc/claude-code-bedrock.md) — §3.1 accounts, §3.3 `/model` picker, §5 the four gates, §5.1 data-retention blast radius.
* Follow-up, deliberately **not** in this PR: the CI `@claude` reviewer still defaults to `us.anthropic.claude-sonnet-4-6` (`.github/workflows/claude.yml`, `docs/ai-sdlc/README.md`, `CLAUDE.md`) while Sonnet 5 is live in the same account — that is a separate integration with its own cost/behaviour impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 5 to the available model options.
  * Updated default and custom model selections for supported Bedrock accounts.

* **Documentation**
  * Updated model availability, account guidance, quotas, and routing details.
  * Clarified model picker options, legacy model identifiers, and data-retention behavior.
  * Revised troubleshooting guidance for unavailable-model errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->