### PR TITLE
fix: grant Nestor Marketplace buyer access

### DIFF
--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -249,6 +249,13 @@ module "account_assignments" {
       account             = var.accounts.apps-devstg.id
     },
     {
+      permission_set_arn  = module.permission_sets.permission_sets["MarketplaceBuyer"].arn
+      permission_set_name = "MarketplaceBuyer"
+      principal_type      = local.principal_type_group
+      principal_name      = local.groups["marketplacevalidationbuyers"].name
+      account             = var.accounts.data-science.id
+    },
+    {
       permission_set_arn  = module.permission_sets.permission_sets["MarketplaceAIPublisher"].arn
       permission_set_name = "MarketplaceAIPublisher"
       principal_type      = local.principal_type_group


### PR DESCRIPTION
## What
- Assigns the existing `MarketplaceBuyer` permission set to `MarketplaceValidationBuyers` in the `data-science` account.
- Keeps the existing group-based Identity Center pattern; Nestor is already a member of `MarketplaceValidationBuyers` on this branch lineage.

## Why
- Nestor needs AWS Marketplace Subscriptions access from the Data Science account to continue buyer-side validation for the published listing.
- `MarketplaceBuyer` maps to `AWSMarketplaceManageSubscriptions`, matching the requested Subscriptions access.

## Validation
- `tofu fmt -check -diff account_assignments.tf locals.tf permission_sets.tf`

## Notes
- Scope is limited to Marketplace subscription management in `data-science` for the existing validation buyer group.
