### PR TITLE
Added policies for devops to be able to run bcm princip calculator creation

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -132,13 +132,9 @@ data "aws_iam_policy_document" "devops" {
       "bcm-pricing-calculator:CreateWorkloadEstimate",
       "bcm-pricing-calculator:GetWorkloadEstimate",
       "bcm-pricing-calculator:UpdateWorkloadEstimate",
-      "bcm-pricing-calculator:DeleteWorkloadEstimate",
       "bcm-pricing-calculator:ListWorkloadEstimates",
       "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:ListWorkloadEstimateUsage",
-      "bcm-pricing-calculator:BatchCreateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:BatchUpdateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:BatchDeleteWorkloadEstimateUsage"
+      "bcm-pricing-calculator:ListWorkloadEstimateUsage"
     ]
     resources = ["*"]
     condition {

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -128,7 +128,17 @@ data "aws_iam_policy_document" "devops" {
       "wellarchitected:*",
       "workspaces-web:*",
       "workspaces:*",
-      "pricing:*"
+      "pricing:*",
+      "bcm-pricing-calculator:CreateWorkloadEstimate",
+      "bcm-pricing-calculator:GetWorkloadEstimate",
+      "bcm-pricing-calculator:UpdateWorkloadEstimate",
+      "bcm-pricing-calculator:DeleteWorkloadEstimate",
+      "bcm-pricing-calculator:ListWorkloadEstimates",
+      "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
+      "bcm-pricing-calculator:ListWorkloadEstimateUsage",
+      "bcm-pricing-calculator:BatchCreateWorkloadEstimateUsage",
+      "bcm-pricing-calculator:BatchUpdateWorkloadEstimateUsage",
+      "bcm-pricing-calculator:BatchDeleteWorkloadEstimateUsage"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
## What?
* Policies that allow DevOps to run the [AWS Estimate creator script](https://github.com/binbashar/bb-genai-workbench/tree/master/scripts/aws_calculator_creator)
* This script creates an estimation based on a target architecture extracted to `json` using the [target-infra-json skill](https://github.com/binbashar/bb-genai-workbench/tree/master/.claude/skills/target-infra-json)

## Why?
* The idea is to save time when creating an estimation based on a target infrastructure worked out in the workbench repo.

## Ref
* [AWS AWS Billing And Cost Management Pricing Calculator IAM Actions](https://awsfundamentals.com/iam/bcm-pricing-calculator)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pricing calculator operations, including workload and usage estimate management.
  * Expanded permissions for pricing-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->