### PR TITLE
fix: grant Marketplace buyer license read access

### DIFF
--- a/management/global/sso/permission_sets.tf
+++ b/management/global/sso/permission_sets.tf
@@ -87,7 +87,7 @@ module "permission_sets" {
       relay_state                         = local.default_relay_state
       session_duration                    = local.default_session_duration
       tags                                = local.tags
-      inline_policy                       = ""
+      inline_policy                       = data.aws_iam_policy_document.marketplace_buyer.json
       policy_attachments                  = ["arn:aws:iam::aws:policy/AWSMarketplaceManageSubscriptions"]
       customer_managed_policy_attachments = []
     },

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -243,6 +243,19 @@ data "aws_iam_policy_document" "github_automation" {
 }
 
 #------------------------------------------------------------------------------
+# Marketplace Buyer
+#------------------------------------------------------------------------------
+data "aws_iam_policy_document" "marketplace_buyer" {
+  statement {
+    sid = "LicenseManagerReadAccess"
+    actions = [
+      "license-manager:ListReceivedLicenses",
+    ]
+    resources = ["*"]
+  }
+}
+
+#------------------------------------------------------------------------------
 # Data Scientist
 #------------------------------------------------------------------------------
 data "aws_iam_policy_document" "data_scientist" {


### PR DESCRIPTION
## What
- Adds an inline policy to the existing `MarketplaceBuyer` permission set with `license-manager:ListReceivedLicenses`.
- Keeps the existing `AWSMarketplaceManageSubscriptions` managed policy attachment.

## Why
- AWS Marketplace Manage Subscriptions calls AWS License Manager to list received licenses.
- Without this permission, users can see a `No permission to view licenses` warning when accessing subscriptions with the buyer role.

## Validation
- `leverage tofu format -check -diff`
- Change was applied manually before opening this PR and verified by signing in with the buyer role: the License Manager permission warning no longer appears.

## Notes
- Scope is limited to license read access required by the Marketplace buyer subscription view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketplace buyers now have permission to view received license information.
  * Updated access settings automatically include the required License Manager read access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->