### PR TITLE
Fixed policies for BCM, they must be global

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -128,13 +128,7 @@ data "aws_iam_policy_document" "devops" {
       "wellarchitected:*",
       "workspaces-web:*",
       "workspaces:*",
-      "pricing:*",
-      "bcm-pricing-calculator:CreateWorkloadEstimate",
-      "bcm-pricing-calculator:GetWorkloadEstimate",
-      "bcm-pricing-calculator:UpdateWorkloadEstimate",
-      "bcm-pricing-calculator:ListWorkloadEstimates",
-      "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:ListWorkloadEstimateUsage"
+      "pricing:*"
     ]
     resources = ["*"]
     condition {
@@ -147,6 +141,20 @@ data "aws_iam_policy_document" "devops" {
         "us-west-2"
       ]
     }
+  }
+
+  statement {
+    sid    = "BcmPricingCalculatorGlobalAccess"
+    effect = "Allow"
+    actions = [
+      "bcm-pricing-calculator:CreateWorkloadEstimate",
+      "bcm-pricing-calculator:GetWorkloadEstimate",
+      "bcm-pricing-calculator:ListWorkloadEstimates",
+      "bcm-pricing-calculator:UpdateWorkloadEstimate",
+      "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
+      "bcm-pricing-calculator:ListWorkloadEstimateUsage"
+    ]
+    resources = ["*"]
   }
 
   statement {


### PR DESCRIPTION
## What?
* Moved policies for `bcm-pricing-calculator` to its own statement
* Set `bcm-pricing-calculator` statement in the policy with no region restriction

## Why?
* Service must be global. It seems to be that when a region restriction exists it fails.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Improvements**
  - Updated permissions to support creating, viewing, listing, and updating pricing calculator resources.
  - Added access for related workload estimate usage operations across applicable resources.
  - Consolidated pricing calculator permissions into a dedicated access policy for clearer administration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->