### PR TITLE
feat(dns): add hq.binbash.co CNAME, retire investor.binbash.co

### DIFF
--- a/shared/global/base-dns/binbash.co/.terraform.lock.hcl
+++ b/shared/global/base-dns/binbash.co/.terraform.lock.hcl
@@ -7,6 +7,8 @@ provider "registry.opentofu.org/hashicorp/aws" {
   hashes = [
     "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
     "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
+    "h1:XdzNcLs1X9EajZP/fazeC2u9El+qLayLB+TgGPiL3d8=",
+    "h1:we2D/YbkMwtTi4ZrPwcwsDi8jXB2kC9jikZP2UqgI08=",
     "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
     "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
     "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",

--- a/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
+++ b/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
@@ -53,6 +53,33 @@ resource "aws_route53_record" "CNAME_mkt_studio_binbash_co" {
 }
 
 #
+# le-binbash-hq-portal (Vercel) — two hostnames, one project.
+# `hq` is the primary going forward; `investor` is the legacy hostname kept
+# alive so existing links keep working, and will be turned into a redirect
+# once `hq` is verified. Each Vercel domain gets its own project-specific
+# CNAME target, so the two values differ by design.
+#
+resource "aws_route53_record" "CNAME_hq_binbash_co" {
+  zone_id = aws_route53_zone.public.id
+  name    = "hq.binbash.co"
+  records = ["7c298364b5aed262.vercel-dns-017.com."]
+  type    = "CNAME"
+  ttl     = 300
+}
+
+# NOTE: created out-of-band before being codified here, then imported into
+# state. Its value is intentionally written without the trailing dot to match
+# what Route 53 already holds — adding one would make the import plan rewrite
+# a live production record for no functional gain.
+resource "aws_route53_record" "CNAME_investor_binbash_co" {
+  zone_id = aws_route53_zone.public.id
+  name    = "investor.binbash.co"
+  records = ["a8cf64c6e339687a.vercel-dns-017.com"]
+  type    = "CNAME"
+  ttl     = 300
+}
+
+#
 # MX records
 #
 resource "aws_route53_record" "MX_gmail_binbash_co" {

--- a/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
+++ b/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
@@ -53,11 +53,8 @@ resource "aws_route53_record" "CNAME_mkt_studio_binbash_co" {
 }
 
 #
-# le-binbash-hq-portal (Vercel) — two hostnames, one project.
-# `hq` is the primary going forward; `investor` is the legacy hostname kept
-# alive so existing links keep working, and will be turned into a redirect
-# once `hq` is verified. Each Vercel domain gets its own project-specific
-# CNAME target, so the two values differ by design.
+# Vercel-hosted endpoints. Each hostname is issued its own CNAME target, so
+# the two values differ by design and are not interchangeable.
 #
 resource "aws_route53_record" "CNAME_hq_binbash_co" {
   zone_id = aws_route53_zone.public.id
@@ -69,8 +66,8 @@ resource "aws_route53_record" "CNAME_hq_binbash_co" {
 
 # NOTE: created out-of-band before being codified here, then imported into
 # state. Its value is intentionally written without the trailing dot to match
-# what Route 53 already holds — adding one would make the import plan rewrite
-# a live production record for no functional gain.
+# what Route 53 already holds — adding one would rewrite a live record for no
+# functional gain. Other records in this zone are dot-less for the same reason.
 resource "aws_route53_record" "CNAME_investor_binbash_co" {
   zone_id = aws_route53_zone.public.id
   name    = "investor.binbash.co"

--- a/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
+++ b/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
@@ -53,25 +53,13 @@ resource "aws_route53_record" "CNAME_mkt_studio_binbash_co" {
 }
 
 #
-# Vercel-hosted endpoints. Each hostname is issued its own CNAME target, so
-# the two values differ by design and are not interchangeable.
+# Vercel-hosted endpoint. Vercel issues a per-hostname CNAME target, so this
+# value is specific to this hostname and is not interchangeable with another.
 #
 resource "aws_route53_record" "CNAME_hq_binbash_co" {
   zone_id = aws_route53_zone.public.id
   name    = "hq.binbash.co"
   records = ["7c298364b5aed262.vercel-dns-017.com."]
-  type    = "CNAME"
-  ttl     = 300
-}
-
-# NOTE: created out-of-band before being codified here, then imported into
-# state. Its value is intentionally written without the trailing dot to match
-# what Route 53 already holds — adding one would rewrite a live record for no
-# functional gain. Other records in this zone are dot-less for the same reason.
-resource "aws_route53_record" "CNAME_investor_binbash_co" {
-  zone_id = aws_route53_zone.public.id
-  name    = "investor.binbash.co"
-  records = ["a8cf64c6e339687a.vercel-dns-017.com"]
   type    = "CNAME"
   ttl     = 300
 }


### PR DESCRIPTION
## What?

* Add a `hq.binbash.co` CNAME (TTL 300) pointing at its Vercel-issued target.
* **Retire `investor.binbash.co`.** The record was created out-of-band and missing from state, so it is first *imported* (clearing the drift), then *destroyed* through OpenTofu — keeping code and state in sync throughout instead of deleting it by hand.
* Record the missing `darwin_arm64` / `linux_arm64` provider checksums in this layer's `.terraform.lock.hcl`.

> [!WARNING]
> `investor.binbash.co` is a **hard removal, not a redirect** — it no longer resolves, so any existing link or bookmark pointing at it now fails. Preserving those links would have required keeping the DNS record and configuring a 308 on the Vercel project; that was considered and deliberately not chosen.

## Why?

* `hq.binbash.co` was attached and verified on the Vercel side but reported **Invalid Configuration**, because the Route 53 record it points at did not exist. This PR was the missing half.
* With `hq` serving, the older hostname is no longer needed.
* Routing the deletion through OpenTofu (import, then destroy) means the zone ends up fully described by code, with no leftover drift.
* The lock file only carried `linux_amd64` / `darwin_amd64` hashes for `aws 4.67.0`. A native arm64 OpenTofu therefore fails `plan` with `Required plugins are not installed` immediately after installing the provider it just fetched. Regenerated across the full platform set so linux CI/Atlantis and both macOS architectures all verify:
  ```bash
  tofu providers lock -platform=linux_amd64 -platform=linux_arm64 \
    -platform=darwin_amd64 -platform=darwin_arm64
  ```

## Plans

Layer: `shared/global/base-dns/binbash.co`. `leverage tofu validate` → **Success**, `leverage tofu format` → no changes. Infracost: **+$0**.

Applied in two steps. Before the `hq` import the plan read `2 to add`; that second "add" was the un-imported `investor` record, and the import is what removed it.

<details>
<summary>Step 1 — <code>leverage tofu plan</code>: 1 to add, 0 to change, 0 to destroy</summary>

```text
OpenTofu will perform the following actions:

  # aws_route53_record.CNAME_hq_binbash_co will be created
  + resource "aws_route53_record" "CNAME_hq_binbash_co" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "hq.binbash.co"
      + records         = [
          + "7c298364b5aed262.vercel-dns-017.com.",
        ]
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "<BINBASH_CO_ZONE_ID>"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

<details>
<summary>Step 2 — <code>leverage tofu plan</code>: 0 to add, 0 to change, 1 to destroy</summary>

```text
OpenTofu will perform the following actions:

  # aws_route53_record.CNAME_investor_binbash_co will be destroyed
  # (because aws_route53_record.CNAME_investor_binbash_co is not in configuration)
  - resource "aws_route53_record" "CNAME_investor_binbash_co" {
      - fqdn                             = "investor.binbash.co" -> null
      - id                               = "<BINBASH_CO_ZONE_ID>_investor.binbash.co_CNAME" -> null
      - multivalue_answer_routing_policy = false -> null
      - name                             = "investor.binbash.co" -> null
      - records                          = [
          - "a8cf64c6e339687a.vercel-dns-017.com",
        ] -> null
      - ttl                              = 300 -> null
      - type                             = "CNAME" -> null
      - zone_id                          = "<BINBASH_CO_ZONE_ID>" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

Refresh logs intentionally omitted (they embed account IDs, IAM usernames and resource IDs, and add no review value). No account IDs, ARNs or credentials appear in the excerpts above.

## Status: already applied

> [!NOTE]
> Unlike the usual review-then-apply flow, this layer was **applied before merge** at the author's request — first to unblock the Vercel domain, then to retire the old hostname. The plans above are what ran.

```text
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.   # step 1
Apply complete! Resources: 0 added, 0 changed, 1 destroyed.   # step 2
```

Post-apply verification:

| Check | Result |
|---|---|
| `leverage tofu plan` (re-run) | `No changes. Your infrastructure matches the configuration.` |
| CNAMEs left in the zone for these hosts | `hq.binbash.co.` only — `investor` removed |
| `curl -sSI https://hq.binbash.co` | `200`, valid TLS chain |
| Vercel domain config for `hq` | `configuredBy: CNAME`, `verified: true`, `conflicts: []` |
| `dig +short investor.binbash.co CNAME` | no answer |

The layer is in sync with code and state, so merging this PR is a no-op against live infrastructure — it brings the repo up to date with what is already deployed.

## References

* Hosted zone: the `binbash.co` public zone in the shared account.
* Loose end for a follow-up: `investor.binbash.co` is still attached as a domain on the Vercel project (its certificate will simply go unrenewed). Detaching it there is a dashboard-side cleanup outside this repo.
