### PR TITLE
Fixed policies for BCM, they must be global along with ce princing and billing

### DIFF
--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -144,15 +144,7 @@ data "aws_iam_policy_document" "devops" {
   statement {
     sid = "BcmPricingCalculatorGlobalAccess"
     actions = [
-      "bcm-pricing-calculator:CreateWorkloadEstimate",
-      "bcm-pricing-calculator:GetWorkloadEstimate",
-      "bcm-pricing-calculator:ListWorkloadEstimates",
-      "bcm-pricing-calculator:UpdateWorkloadEstimate",
-      "bcm-pricing-calculator:DeleteWorkloadEstimate",
-      "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:ListWorkloadEstimateUsage",
-      "bcm-pricing-calculator:UpdateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:DeleteWorkloadEstimateUsage",
+      "bcm-pricing-calculator:*",
       "ce:*",
       "pricing:*",
       "billing:*"

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "devops" {
       "bedrock-agentcore:*",
       "billing:Get*",
       "billing:List*",
+      "ce:*",
       "cloudformation:*",
       "cloudfront:*",
       "cloudshell:*",
@@ -127,9 +128,7 @@ data "aws_iam_policy_document" "devops" {
       "wellarchitected:*",
       "workspaces-web:*",
       "workspaces:*",
-      "ce:*",
-      "pricing:*",
-      "billing:*"
+      "pricing:*"
     ]
     resources = ["*"]
     condition {

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -126,7 +126,10 @@ data "aws_iam_policy_document" "devops" {
       "wafv2:*",
       "wellarchitected:*",
       "workspaces-web:*",
-      "workspaces:*"
+      "workspaces:*",
+      "ce:*",
+      "pricing:*",
+      "billing:*"
     ]
     resources = ["*"]
     condition {
@@ -139,18 +142,6 @@ data "aws_iam_policy_document" "devops" {
         "us-west-2"
       ]
     }
-  }
-
-  statement {
-    sid = "BcmPricingCalculatorGlobalAccess"
-    actions = [
-      "bcm-pricing-calculator:*",
-      "ce:*",
-      "pricing:*",
-      "billing:*"
-    ]
-    effect    = "Allow"
-    resources = ["*"]
   }
 
   statement {

--- a/management/global/sso/policies.tf
+++ b/management/global/sso/policies.tf
@@ -28,7 +28,6 @@ data "aws_iam_policy_document" "devops" {
       "bedrock-agentcore:*",
       "billing:Get*",
       "billing:List*",
-      "ce:*",
       "cloudformation:*",
       "cloudfront:*",
       "cloudshell:*",
@@ -127,14 +126,7 @@ data "aws_iam_policy_document" "devops" {
       "wafv2:*",
       "wellarchitected:*",
       "workspaces-web:*",
-      "workspaces:*",
-      "pricing:*",
-      "bcm-pricing-calculator:CreateWorkloadEstimate",
-      "bcm-pricing-calculator:GetWorkloadEstimate",
-      "bcm-pricing-calculator:UpdateWorkloadEstimate",
-      "bcm-pricing-calculator:ListWorkloadEstimates",
-      "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
-      "bcm-pricing-calculator:ListWorkloadEstimateUsage"
+      "workspaces:*"
     ]
     resources = ["*"]
     condition {
@@ -147,6 +139,26 @@ data "aws_iam_policy_document" "devops" {
         "us-west-2"
       ]
     }
+  }
+
+  statement {
+    sid = "BcmPricingCalculatorGlobalAccess"
+    actions = [
+      "bcm-pricing-calculator:CreateWorkloadEstimate",
+      "bcm-pricing-calculator:GetWorkloadEstimate",
+      "bcm-pricing-calculator:ListWorkloadEstimates",
+      "bcm-pricing-calculator:UpdateWorkloadEstimate",
+      "bcm-pricing-calculator:DeleteWorkloadEstimate",
+      "bcm-pricing-calculator:CreateWorkloadEstimateUsage",
+      "bcm-pricing-calculator:ListWorkloadEstimateUsage",
+      "bcm-pricing-calculator:UpdateWorkloadEstimateUsage",
+      "bcm-pricing-calculator:DeleteWorkloadEstimateUsage",
+      "ce:*",
+      "pricing:*",
+      "billing:*"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
   }
 
   statement {


### PR DESCRIPTION
## What?
* bcm policies removed 
* ce, billing and pricing moved back to original statement

## Why?
* Calculator creation is only possible from `root` account, thus not viable for being created from memebers account by non admin users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Access Changes

* Updated DevOps permissions for billing and pricing services.
* Cost Explorer and pricing service access remain available.
* Removed dedicated Billing and Cost Management Pricing Calculator permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->