### PR TITLE
docs: the leverage tofu subcommand is format, not fmt

### DIFF
--- a/.claude/agents/dependency-update.md
+++ b/.claude/agents/dependency-update.md
@@ -224,7 +224,7 @@ Location: `/renovate.json`
 3. **Validation checks:**
    ```bash
    # Format check
-   leverage tofu fmt -check
+   leverage tofu format -check
 
    # Validation
    leverage tofu validate
@@ -232,8 +232,8 @@ Location: `/renovate.json`
    # Plan without applying
    leverage tofu plan -out=tfplan
 
-   # Review plan
-   leverage tofu show tfplan
+   # Review plan — `show` is not exposed by the wrapper, use native tofu
+   tofu show tfplan
    ```
 
 ## Handling Breaking Changes

--- a/.claude/agents/dependency-update.md
+++ b/.claude/agents/dependency-update.md
@@ -229,12 +229,18 @@ Location: `/renovate.json`
    # Validation
    leverage tofu validate
 
-   # Plan without applying
-   leverage tofu plan -out=tfplan
+   # Plan without applying — write the binary plan OUTSIDE the repo, never commit tfplan
+   plan_file="$(mktemp -t tfplan)"
+   leverage tofu plan -out="$plan_file"
 
    # Review plan — `show` is not exposed by the wrapper, use native tofu
-   tofu show tfplan
+   tofu show "$plan_file"
+   rm -f "$plan_file"
    ```
+
+   Before pasting any plan output into a PR, follow the redaction procedure in CLAUDE.md
+   ("Standard workflow: posting a `tofu plan` to a PR for review") — drop the refresh log and
+   replace account IDs with named placeholders.
 
 ## Handling Breaking Changes
 1. **Identify affected resources** using MCP server

--- a/.claude/agents/feature-implementation.md
+++ b/.claude/agents/feature-implementation.md
@@ -152,7 +152,7 @@ data-science/us-east-1/
 
 2. **Format and lint:**
    ```bash
-   leverage tofu fmt
+   leverage tofu format
    pre-commit run --files *.tf
    ```
 

--- a/.claude/agents/issue-fix.md
+++ b/.claude/agents/issue-fix.md
@@ -78,7 +78,7 @@ You are a specialized agent for debugging and fixing issues in the Leverage Refe
    ```bash
    # Navigate to specific layer
    cd {account}/{region}/{layer}
-   leverage tofu fmt -recursive
+   leverage tofu format
    ```
 
 3. **Use MCP to verify syntax:**

--- a/.claude/agents/terraform-layer.md
+++ b/.claude/agents/terraform-layer.md
@@ -41,7 +41,7 @@ leverage tofu init
 leverage tofu plan
 leverage tofu apply
 leverage tofu destroy
-leverage tofu fmt
+leverage tofu format
 
 # Validation
 leverage tofu validate
@@ -65,7 +65,7 @@ Always ensure backend.tfvars contains:
 - `key` - State file path (auto-generated)
 
 ## Testing Requirements
-1. Run `leverage tofu fmt` to format code
+1. Run `leverage tofu format` to format code
 2. Run `leverage tofu validate` to check syntax
 3. Run `leverage tofu plan` to preview changes
 4. Check for security issues with `tfsec` or `checkov`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ This is the **Binbash Leverage Reference Architecture** - a comprehensive OpenTo
 - Use variables and locals for all configurable values; avoid hardcoding
 - Structure files logically: main config, locals, variables, outputs, modules
 - Follow the [Leverage AWS directory structure](https://leverage.binbash.co/user-guide/ref-architecture-aws/dir-structure)
-- Always run `leverage tofu fmt` for formatting and `leverage tofu validate` for validation
+- Always run `leverage tofu format` for formatting and `leverage tofu validate` for validation
+  (the subcommand is `format`, not `fmt` — `fmt` errors with `No such command`)
 
 ### Module Guidelines
 - **Always prefer Binbash Leverage modules** - Check the [module library](https://github.com/binbashar/le-dev-tools/blob/master/terraform/Makefile) first
@@ -151,8 +152,11 @@ leverage run layer_dependency
 # Validate configuration
 leverage tofu validate
 
-# Format code (recursive)
-leverage tofu fmt -recursive
+# Format code — always recursive, the wrapper appends -recursive for you
+leverage tofu format
+
+# Check formatting without rewriting (extra args pass through to `tofu fmt`)
+leverage tofu format -check
 
 # Run tests (not exposed by leverage wrapper — use native tofu)
 tofu test
@@ -341,12 +345,13 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 8. **Security-first** - Follow AWS Well-Architected Framework and Leverage security guidelines
 9. **Documentation** - Reference official [Leverage Documentation](https://leverage.binbash.co) for guidance
 10. **Testing** - Use native `tofu test` for module unit tests (the leverage wrapper does not expose `test`) and integrate with CI/CD
-11. **Code quality** - Always run `leverage tofu fmt` and `leverage tofu validate` before commits
+11. **Code quality** - Always run `leverage tofu format` and `leverage tofu validate` before commits
 12. **Atlantis integration** - The repository uses Atlantis for automated OpenTofu/Terraform workflows
 
 ### CI / Pre-commit
 - CI job "Test and Lint" runs `make pre-commit` → `pre-commit run --all-files`
-- Includes `terraform_fmt` hook — always run `leverage tofu fmt -recursive` before pushing
+- Includes `terraform_fmt` hook — always run `leverage tofu format` before pushing (it is already
+  recursive; the hook itself is a pre-commit hook name, unrelated to the wrapper's subcommand)
 - `pretty-format-json` hook sorts keys alphabetically and autofixes — ensure JSON files have sorted keys before pushing
 - **Infracost** workflow for cost impact analysis on PRs
 - Slack notifications on pipeline success/failure

--- a/README.md
+++ b/README.md
@@ -163,12 +163,18 @@ leverage tofu validate          # Validate configuration
 ```
 
 > `leverage tf` is a shorthand alias for `leverage tofu`. Both run OpenTofu.
-
+>
 > The wrapper exposes only a curated subset of subcommands: `apply`, `destroy`, `force-unlock`,
 > `format`, `import`, `init`, `output`, `plan`, `refresh-credentials`, `validate`,
-> `validate-layout`, `version`. Note it is `format`, **not** `fmt`. For anything else — `state`,
-> `show`, `console`, `providers`, `workspace`, `graph`, `get`, `test` — run the native `tofu`
-> binary from the layer directory, loading the AWS profile from the layer's `config/backend.tfvars`:
+> `validate-layout`, `version`. Note it is `format`, **not** `fmt` — and `format` is already
+> recursive, being equivalent to `tofu fmt -recursive`. See the
+> [leverage tofu reference](https://leverage.binbash.co/user-guide/leverage-cli/reference/tofu/tofu/).
+> That page does not currently cover `force-unlock` or `refresh-credentials`; the list above comes
+> from `leverage tofu --help` on the pinned CLI, which is the authority.
+>
+> For anything else — `state`, `show`, `console`, `providers`, `workspace`, `graph`, `get`, `test` —
+> run the native `tofu` binary from the layer directory, loading the AWS profile from the layer's
+> `config/backend.tfvars`:
 >
 > ```bash
 > tofu state list                 # List resources in state

--- a/README.md
+++ b/README.md
@@ -157,13 +157,23 @@ leverage tofu init              # Initialize the layer
 leverage tofu plan              # Preview changes
 leverage tofu apply             # Apply changes
 leverage tofu destroy           # Destroy infrastructure
-leverage tofu fmt               # Format code
+leverage tofu format            # Format code (always recursive)
+leverage tofu format -check     # Check formatting without rewriting
 leverage tofu validate          # Validate configuration
-leverage tofu state list        # List resources in state
-leverage tofu state show <res>  # Show a specific resource in state
 ```
 
 > `leverage tf` is a shorthand alias for `leverage tofu`. Both run OpenTofu.
+
+> The wrapper exposes only a curated subset of subcommands: `apply`, `destroy`, `force-unlock`,
+> `format`, `import`, `init`, `output`, `plan`, `refresh-credentials`, `validate`,
+> `validate-layout`, `version`. Note it is `format`, **not** `fmt`. For anything else — `state`,
+> `show`, `console`, `providers`, `workspace`, `graph`, `get`, `test` — run the native `tofu`
+> binary from the layer directory, loading the AWS profile from the layer's `config/backend.tfvars`:
+>
+> ```bash
+> tofu state list                 # List resources in state
+> tofu state show <res>           # Show a specific resource in state
+> ```
 
 ## Release Management
 ### [Reference Architecture | Releases](https://github.com/binbashar/le-tf-infra-aws/releases)


### PR DESCRIPTION
## What?

* `leverage tofu fmt` does not exist — the wrapper's subcommand is **`format`**. Fixed every place
  the docs told you to run it:
  * `CLAUDE.md` — 4 occurrences, 2 of them in copy-pasteable code blocks
  * `README.md` — the layer-commands block
  * `.claude/agents/issue-fix.md`, `terraform-layer.md` (×2), `feature-implementation.md`,
    `dependency-update.md`
* Dropped `-recursive` from the guidance. The wrapper appends it unconditionally, so
  `leverage tofu format` is already recursive.
* Documented `leverage tofu format -check`, since extra args do pass through to `tofu fmt`.
* Fixed two adjacent wrong commands found in the same blocks:
  * `README.md` documented `leverage tofu state list` / `state show`, which the wrapper does not
    expose either → replaced with the native `tofu` equivalents, plus the full list of what the
    wrapper *does* expose.
  * `dependency-update.md` documented `leverage tofu show tfplan`; `show` is not exposed → now
    `tofu show tfplan`.

Docs only. No infrastructure change, no plan, nothing to apply.

## Why?

The command errors outright:

```console
$ leverage tofu fmt
Usage: leverage tofu [OPTIONS] COMMAND [ARGS]...
Try 'leverage tofu --help' for help.

Error: No such command 'fmt'.
```

So `CLAUDE.md`'s "**Always** run `leverage tofu fmt` before commits" was an instruction that could
never succeed — and it contradicted `CLAUDE.md` itself, which already listed `format` correctly in
both of its enumerations of the wrapper's curated subcommands. The `.claude/agents/*.md` copies
matter most: those are instructions handed to subagents, which will run the failing command and
skip formatting entirely, leaving the `terraform_fmt` pre-commit hook to fail in CI instead.

### Why `-recursive` goes away

From `leverage/modules/tf.py`:

```python
@click.command("format", context_settings=CONTEXT_SETTINGS)
@click.argument("args", nargs=-1)
@pass_runner
def _format(tf, args):
    """Check if all files meet the canonical format and rewrite them accordingly."""
    args = args if "-recursive" in args else (*args, "-recursive")
    tf.run("fmt", *args)
```

`-recursive` is appended unconditionally, so passing it is a no-op. The `tf.run("fmt", *args)` is
also why `format -check` works.

### Verified

```console
$ leverage tofu format          # exit 0
$ leverage tofu format -check   # exit 0
$ tofu show -h                  # Usage: tofu [global options] show ...
```

## Deliberately left alone

* `docs/superpowers/specs/2026-07-17-finops-agent-mgmt-design.md:124` — a dated design record of
  what was planned that day, not guidance.
* `apps-devstg/us-east-1/tools-apigw-apps-proxy --/README.md` — four `leverage tf state show` lines
  with the same problem, but in a **disabled** layer; they belong to that layer's own cleanup.

## References

* Noticed while shipping #1144 (issue #1143), where `leverage tofu fmt -recursive` per `CLAUDE.md`
  failed and `tofu fmt -check` had to be used instead.
