### PR TITLE
feat(app-binbash-web): redirect /solutions/genai to /solutions/ai-and-agents

### DIFF
--- a/apps-prd/us-east-1/app-binbash-web/cloudfront-function.tf
+++ b/apps-prd/us-east-1/app-binbash-web/cloudfront-function.tf
@@ -12,7 +12,7 @@
 #
 #      /                     -> /index.html  (default root object)
 #      /pricing/             -> /pricing/index.html
-#      /solutions/genai      -> /solutions/genai/index.html
+#      /solutions/ai-and-agents -> /solutions/ai-and-agents/index.html
 #
 # NOTE: this path layout must agree with the app's `trailingSlash` setting —
 # with `trailingSlash: false` Next exports `{route}.html` instead and this

--- a/apps-prd/us-east-1/app-binbash-web/redirects.tf
+++ b/apps-prd/us-east-1/app-binbash-web/redirects.tf
@@ -2,7 +2,9 @@
 # Wix -> binbash-web redirect map, served as 301s by the viewer-request
 # CloudFront Function (see cloudfront-function.tf).
 #
-# WHY THIS EXISTS: 31 routes changed path in the migration out of Wix. Without
+# WHY THIS EXISTS: 31 routes changed path in the migration out of Wix, and a
+# further 2 (plus their locale variants) were renamed by the app AFTER that
+# migration — see post_migration_renames below. Without
 # these, every one of those URLs — all of them indexed, many of them linked
 # from outside — 404s the moment DNS cuts over, throwing away the accumulated
 # search ranking of the old site. 301 (not 302) is deliberate: it is the status
@@ -35,8 +37,8 @@ locals {
     "/cloud-partner/cast-ai"              = "/partners/cast-ai"
     "/competition"                        = "/leverage/competition"
     "/founders"                           = "/people/founders"
-    "/genai"                              = "/solutions/genai"
-    "/genai/exclusivegenai"               = "/solutions/genai/exclusive-genai"
+    "/genai"                              = "/solutions/ai-and-agents"
+    "/genai/exclusivegenai"               = "/solutions/ai-and-agents/exclusive-genai"
     "/how-we-work"                        = "/people/how-we-work"
     "/kashio"                             = "/case-studies/kashio"
     "/letsbuildyourstartup"               = "/events/lets-build-your-startup"
@@ -67,5 +69,34 @@ locals {
     "/top-rated"    = "/"
   }
 
-  wix_redirects = merge(local.wix_redirects_migrated, local.wix_redirects_retired)
+  # Routes THIS SITE renamed after the Wix migration — not Wix paths.
+  #
+  # Distinct from wix_redirects_migrated above, whose keys are paths Wix still
+  # serves. These keys are paths binbash-web itself published and then moved,
+  # so anything that linked or bookmarked them in the interim 404s without a
+  # row here. They are generated from the same MIGRATED table in the app repo:
+  # a row whose value changes between releases needs its OLD value adding here.
+  #
+  # /solutions/genai -> /solutions/ai-and-agents (binbashar/bb-ai-sales-tools#202,
+  # PRD F-AIAGENTS-01). The child moved with the parent, and BOTH rows are
+  # required: lookup is an exact match on the map (see cloudfront-function.tf),
+  # so a parent row does not cover its children.
+  #
+  # The locale variants are listed explicitly for the same reason — the function
+  # matches the whole path, so /es/... and /pt/... are separate keys, not a
+  # prefix of the bare one.
+  post_migration_renames = {
+    "/solutions/genai"                    = "/solutions/ai-and-agents"
+    "/solutions/genai/exclusive-genai"    = "/solutions/ai-and-agents/exclusive-genai"
+    "/es/solutions/genai"                 = "/es/solutions/ai-and-agents"
+    "/es/solutions/genai/exclusive-genai" = "/es/solutions/ai-and-agents/exclusive-genai"
+    "/pt/solutions/genai"                 = "/pt/solutions/ai-and-agents"
+    "/pt/solutions/genai/exclusive-genai" = "/pt/solutions/ai-and-agents/exclusive-genai"
+  }
+
+  wix_redirects = merge(
+    local.wix_redirects_migrated,
+    local.wix_redirects_retired,
+    local.post_migration_renames,
+  )
 }


### PR DESCRIPTION
Companion to **binbashar/bb-ai-sales-tools#202**, which renames `/solutions/genai` → `/solutions/ai-and-agents` and moves its `exclusive-genai` child with it.

**Without this, both paths 404 the moment that PR deploys.** #202's description names these redirects as a merge requirement; this is them.

## The change

Two Wix rows retargeted, and one new map added:

```hcl
# wix_redirects_migrated — retargeted
"/genai"                = "/solutions/ai-and-agents"           # was /solutions/genai
"/genai/exclusivegenai" = "/solutions/ai-and-agents/exclusive-genai"

# post_migration_renames — new
"/solutions/genai"                    = "/solutions/ai-and-agents"
"/solutions/genai/exclusive-genai"    = "/solutions/ai-and-agents/exclusive-genai"
"/es/solutions/genai"                 = "/es/solutions/ai-and-agents"
"/es/solutions/genai/exclusive-genai" = "/es/solutions/ai-and-agents/exclusive-genai"
"/pt/solutions/genai"                 = "/pt/solutions/ai-and-agents"
"/pt/solutions/genai/exclusive-genai" = "/pt/solutions/ai-and-agents/exclusive-genai"
```

## Why a third map instead of extending the existing one

`wix_redirects_migrated`'s keys are **paths Wix still serves**. These keys are paths **binbash-web itself published and then moved** — a rename after the migration, not a migration.

Keeping them apart has two payoffs: the "generated from the app's `MIGRATED` table" note above the Wix map stays true, and a future reader can tell at a glance which side of the cutover any row belongs to. Folding these in would have quietly made that provenance comment wrong — and a comment that no longer describes the code beneath it is the exact defect #202 spent a lot of effort removing.

## Why six rows and not two

The viewer-request function looks the path up as an **exact key** in the merged map, after normalising a trailing slash:

```js
var key = (uri.length > 1 && uri.endsWith('/')) ? uri.slice(0, -1) : uri;
var target = REDIRECTS[key];
```

So a parent row does **not** cover its children, and `/es/...` / `/pt/...` are separate keys rather than a prefix of the bare path. All six are needed or the missing ones 404.

The locale rows are defensive — binbash-web is not cut over yet, so nobody has visited `/es/solutions/genai` on the real site. They cost one line each and remove the question.

## Verified

- **41 keys across the three maps, no duplicate** — so `merge()` drops nothing silently. That was worth checking: `merge()` resolves a collision by letting the last map win, with no error.
- **No target still points at the retired route.**
- `tofu fmt` clean on both files.

No `plan` was run — that needs credentials for `apps-prd`. The change is data-only inside `locals`, and the function body is untouched apart from a comment.

## Also

`cloudfront-function.tf`'s header used `/solutions/genai` as its worked example of a pretty-URL rewrite. That path now 301s, which made it the one example in the file that would no longer demonstrate a rewrite. Updated to the new route.

## Merge order

Either order is safe. Merging this first means the redirects are live and inert until #202 deploys; merging #202 first leaves both paths 404 until this lands. **Prefer this one first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Next.js rewrite examples to use the new AI and Agents route.
  * Documented redirects for former GenAI paths, including localized variants.
  * Added coverage for renamed routes following the migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->