### PR TITLE
feat(dns): add Anthropic domain verification TXT for binbash.co and binbash.com.ar

### DIFF
--- a/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
+++ b/shared/global/base-dns/binbash.co/zone_public_binbash.co.tf
@@ -99,6 +99,11 @@ resource "aws_route53_record" "TXT_github_binbash_co" {
 #
 # TXT records
 #
+# Route 53 allows a single TXT rrset per name, so every apex verification string
+# has to live in this one resource. Its name is historical (it held only the
+# Google one originally) - renaming it would delete and recreate the rrset,
+# briefly dropping all verifications at once, so it stays as is.
+#
 resource "aws_route53_record" "TXT_google_domain_verification" {
   zone_id = aws_route53_zone.public.id
   name    = "binbash.co"
@@ -106,6 +111,7 @@ resource "aws_route53_record" "TXT_google_domain_verification" {
   records = [
     "google-site-verification=7-ckJxbKpPRrcQ-foy3UIkImTGlp60MUtDgzfudJZmM",
     "linkedin-site-verification=bbe1c109-7cab-456f-9669-2f66982d41bf",
+    "anthropic-domain-verification-jcv3w0=g6sw9GAekRtiZCemfuqS1lP56",
   ]
   ttl = 300
 }

--- a/shared/global/base-dns/binbash.com.ar/.terraform.lock.hcl
+++ b/shared/global/base-dns/binbash.com.ar/.terraform.lock.hcl
@@ -5,8 +5,10 @@ provider "registry.opentofu.org/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 3.4.0, ~> 4.10"
   hashes = [
+    "h1:QPBp5QCM5lreJYYmzCs0UTa5ECuJLBBd6K+UeXYd3bE=",
     "h1:UqjO17j/5vsp9hNMIcsHhMg7aPnCwP13nAaFWQF/Uzs=",
     "h1:XdzNcLs1X9EajZP/fazeC2u9El+qLayLB+TgGPiL3d8=",
+    "h1:we2D/YbkMwtTi4ZrPwcwsDi8jXB2kC9jikZP2UqgI08=",
     "zh:2b1321bd60deb949ccb13266e15a2ccacbd80a30c4aa48458d4ca8cffb34491f",
     "zh:67b909726b0e4d6e9c8a4ddd8036fcb248fcee9b710280b8563045f7657a721a",
     "zh:8c4decefe264717ec0bced279d187cb82aff8a1ab8f1da312240f61299647658",

--- a/shared/global/base-dns/binbash.com.ar/zone_public.binbash.com.ar.tf
+++ b/shared/global/base-dns/binbash.com.ar/zone_public.binbash.com.ar.tf
@@ -88,12 +88,27 @@ resource "aws_route53_record" "aws_public_hosted_zone_1_TXT_record_4" {
   ttl     = 300
 }
 
+#
+# Route 53 allows a single TXT rrset per name, so the apex SPF record and every
+# apex domain-verification string share this one resource. Adding a verification
+# here means editing this list - a second aws_route53_record at "binbash.com.ar"
+# of type TXT would collide with this one rather than coexist.
+#
+# The openai-domain-verification string was added out of band in the console and
+# is adopted here so it stops being drift: without it in this list, the next
+# apply of this layer would rewrite the rrset and drop it.
+#
 resource "aws_route53_record" "aws_public_hosted_zone_TXT_record_google_spf" {
   zone_id = aws_route53_zone.aws_public_hosted_zone_1.id
   name    = "binbash.com.ar"
   type    = "TXT"
-  records = ["v=spf1 include:_spf.google.com ~all", "google-site-verification=LaYgwNHSBPq2LZnpW91PQVbpCcUtVKicSPgRablVl1w"]
-  ttl     = 300
+  records = [
+    "v=spf1 include:_spf.google.com ~all",
+    "google-site-verification=LaYgwNHSBPq2LZnpW91PQVbpCcUtVKicSPgRablVl1w",
+    "openai-domain-verification=dv-f7CZqJtxT4VSGs2ZPI7UqVGO",
+    "anthropic-domain-verification-vxpxwm=PScWzFZs7RntoG6SQgD7c3MGp",
+  ]
+  ttl = 300
 }
 
 #


### PR DESCRIPTION
## What?

Adds the Anthropic domain-verification TXT strings for **both** corporate domains:

| Domain | Layer | Value |
| --- | --- | --- |
| `binbash.co` | `shared/global/base-dns/binbash.co` | `anthropic-domain-verification-jcv3w0=...` |
| `binbash.com.ar` | `shared/global/base-dns/binbash.com.ar` | `anthropic-domain-verification-vxpxwm=...` |

Route 53 permits a single TXT rrset per name, so in both zones the value is
appended to the existing apex TXT resource rather than getting a resource of its
own — a second `aws_route53_record` at the apex with `type = "TXT"` would collide
with the existing one instead of coexisting. A comment recording that constraint
was added to each resource.

**Drift adopted:** `openai-domain-verification=dv-...` was live in the
`binbash.com.ar` apex rrset but absent from the Terraform code — added out of band
in the console. It is now in the list. Without that, the next apply of this layer
would have rewritten the rrset and silently dropped the OpenAI verification.

`.terraform.lock.hcl` for `binbash.com.ar` was refreshed with `linux_amd64`,
`linux_arm64`, `darwin_amd64` and `darwin_arm64` hashes so Atlantis and both macOS
architectures verify.

## Why?

Anthropic's domain verification flow requires a `TXT` record at `@` before it will
confirm ownership of each domain.

## Plans

`leverage tofu format` clean, `leverage tofu validate` passes on both layers.

<details>
<summary><code>binbash.co</code> — applied, 0 add / 1 change / 0 destroy</summary>

```text
OpenTofu will perform the following actions:

  # aws_route53_record.TXT_google_domain_verification will be updated in-place
  ~ resource "aws_route53_record" "TXT_google_domain_verification" {
        id                               = "Z07094013VFYCFPMVTXMM_binbash.co_TXT"
        name                             = "binbash.co"
      ~ records                          = [
          + "anthropic-domain-verification-jcv3w0=g6sw9GAekRtiZCemfuqS1lP56",
            # (2 unchanged elements hidden)
        ]
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

<details>
<summary><code>binbash.com.ar</code> — pending apply</summary>

```text
OpenTofu will perform the following actions:

  # aws_route53_record.aws_public_hosted_zone_TXT_record_google_spf will be updated in-place
  ~ resource "aws_route53_record" "aws_public_hosted_zone_TXT_record_google_spf" {
        id                               = "Z1F75NUGYJVN3L_binbash.com.ar_TXT"
        name                             = "binbash.com.ar"
      ~ records                          = [
          + "anthropic-domain-verification-vxpxwm=PScWzFZs7RntoG6SQgD7c3MGp",
            # (3 unchanged elements hidden)
        ]
        # (5 unchanged attributes hidden)
    }

  # aws_route53_zone.aws_private_hosted_zone_1 will be updated in-place
  ~ resource "aws_route53_zone" "aws_private_hosted_zone_1" {
        id                  = "Z0720681OVT4N4IWRPDJ"
        name                = "aws.binbash.com.ar"
      ~ tags                = {
            "Environment" = "shared"
          ~ "Layer"       = "base-dns/binbash.com.ar" -> "base-dns_binbash.com.ar"
            "Terraform"   = "true"
        }
      ~ tags_all            = {
          ~ "Layer"       = "base-dns/binbash.com.ar" -> "base-dns_binbash.com.ar"
            # (2 unchanged elements hidden)
        }
        # (6 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

  # module.domain-redirect-binbash_com_ar-to-binbash_co.aws_route53_record.validation_record_us_east_1["binbash.com.ar"] will be updated in-place
  ~ resource "aws_route53_record" "validation_record_us_east_1" {
        id                               = "Z1F75NUGYJVN3L__33532c7e2a0dabd72967b17d703b5a74.binbash.com.ar._CNAME"
        name                             = "_33532c7e2a0dabd72967b17d703b5a74.binbash.com.ar"
      ~ ttl                              = 3600 -> 60
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.

Warning: Deprecated attribute

  on .terraform/modules/domain-redirect-binbash_com_ar-to-binbash_co/main.tf line 96, in resource "aws_cloudfront_distribution" "redirect":
  96:     domain_name = aws_s3_bucket.redirect_bucket.website_endpoint

The attribute "website_endpoint" is deprecated. Refer to the provider
documentation for details.

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with module.domain-redirect-binbash_com_ar-to-binbash_co.aws_s3_bucket.redirect_bucket,
  on .terraform/modules/domain-redirect-binbash_com_ar-to-binbash_co/main.tf line 145, in resource "aws_s3_bucket" "redirect_bucket":
 145: resource "aws_s3_bucket" "redirect_bucket" {

Use the aws_s3_bucket_lifecycle_configuration resource instead

(and 2 more similar warnings elsewhere)

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

### Note on the `binbash.com.ar` plan

That plan carries two **pre-existing drifts unrelated to this change**, left
deliberately unapplied here:

- `aws_route53_zone.aws_private_hosted_zone_1` — tag `Layer` would change from
  `base-dns/binbash.com.ar` to `base-dns_binbash.com.ar` (from `layer_name`
  auto-detection in `common-variables.tf`).
- `module.domain-redirect-...validation_record_us_east_1` — `ttl` would change
  from `3600` to `60` (module default).

Both are harmless, but they belong to a separate change. The apply for this PR is
therefore targeted:

```bash
cd shared/global/base-dns/binbash.com.ar
leverage tofu apply -target=aws_route53_record.aws_public_hosted_zone_TXT_record_google_spf
```

## References

- Same pattern as #1076 (LinkedIn site-verification TXT appended to the `binbash.co` rrset)
