### PR TITLE
chore(renovate): cap CI Python below 3.14

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -124,6 +124,14 @@
       "matchPackageNames": [
         "hashicorp/vault"
       ]
+    },
+    {
+      "allowedVersions": "<3.14",
+      "description": "Cap CI Python below 3.14: leverage CLI declares requires-python >=3.9,<3.14 (up to 3.1.0). Lift once upstream supports 3.14.",
+      "enabled": true,
+      "matchPackageNames": [
+        "python"
+      ]
     }
   ],
   "prConcurrentLimit": 5,

--- a/renovate.json
+++ b/renovate.json
@@ -129,6 +129,9 @@
       "allowedVersions": "<3.14",
       "description": "Cap CI Python below 3.14: leverage CLI declares requires-python >=3.9,<3.14 (up to 3.1.0). Lift once upstream supports 3.14.",
       "enabled": true,
+      "matchManagers": [
+        "github-actions"
+      ],
       "matchPackageNames": [
         "python"
       ]


### PR DESCRIPTION
## What?
* Adds a Renovate `packageRule` capping the `python` dependency at `<3.14`, so the bot stops proposing Python 3.14 for `.github/workflows/leverage-cli-test.yml`.
* No workflow behaviour changes — CI stays on Python 3.13.

## Why?
* Every `leverage` release on PyPI — including the latest, `3.1.0` (2026-08-25) — declares `requires-python = ">=3.9,<3.14"`. Python 3.14 is explicitly excluded.
* With `python-version: '3.14'`, `pipenv` cannot resolve the CLI and the `test_leverage` job dies at the install step:
  ```text
  Locking Failed!
  ERROR: No matching distribution found for leverage==2.1.1
  The conflict is caused by:
      The user requested leverage==2.1.1
  ```
* This has failed on all 10 runs of #969 since 2026-08-17, while the same job is green on every other active branch (`renovate/helm-minors`, `renovate/terraform-monorepo`, `feature/eks-demoapps-kgateway-private-gateway`) on 3.13 — so the regression comes solely from the version bump, not from the workflow or credentials.
* The real fix belongs upstream in `binbashar/leverage` (widen `requires-python`, and first bump the pinned deps most likely to break on 3.14: `boto3==1.33.2`, `docker==6.1.0`, `docutils==0.17.1`, `jinja2==3.0.1`). Once a release supports 3.14, drop this rule and let Renovate re-propose the bump.

## References
* Supersedes #969 (closed — Python 3.14 unsupported by the Leverage CLI).
* [PyPI · leverage 3.1.0 metadata](https://pypi.org/project/leverage/3.1.0/) — `Requires-Python: >=3.9, <3.14`
* [Renovate `allowedVersions` docs](https://docs.renovatebot.com/configuration-options/#allowedversions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to prevent Python upgrades to unsupported versions.
  * Python updates remain subject to manual review rather than automatic merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->