### PR TITLE
feat(sso): add KiroPro group to manage Kiro Pro subscription seats

### DIFF
--- a/management/global/sso/README.md
+++ b/management/global/sso/README.md
@@ -52,24 +52,32 @@ console-only operation:
   so there is no `aws` CLI verb and therefore no `local-exec` fallback;
 - the `q:CreateAssignment` / `q:UpdateAssignment` IAM actions exist but are console-internal.
 
-What *is* managed here is the **seat roster**. Kiro can assign a tier to an IAM Identity Center
-group, so the `kiropro` group (display name `KiroPro`) carries the subscription:
+What *is* managed here is the **seat roster**. Kiro subscribes an IAM Identity Center group as a
+unit, so the `kiropro` group (display name `KiroPro`) carries the seats:
 
 - it is deliberately **absent from `account_assignments.tf`**, so it is bound to no permission
   set and grants no AWS access — it only exists to hold Kiro seats;
 - one group per tier. If a Pro+ / Power seat is ever needed, add a sibling group (e.g.
   `kiroproplus`) rather than mixing tiers in one group.
 
-**One-time console step** (after the group is applied): Amazon Q Developer console →
-**Kiro** → **Access management** → **Groups** → **Add group** → pick `KiroPro` → tier **Pro** →
-**Assign**. The `AWSServiceRoleForUserSubscriptions` service-linked role then keeps the
-subscriptions in sync as the group membership changes.
+**One-time console step** (after the group is applied): Amazon Q Developer console → **Kiro** →
+**Access management** → **Groups** tab → **Add group**. The *Assign groups* dialog stays empty
+until you type, so search for `KiroPro`, select it and choose **Done**.
+
+That dialog has no tier selector — the tier comes from the **Kiro profile plan**, managed with the
+**Change plan** / **Deactivate plan** buttons on the same page, so confirm the profile sits on
+**Kiro Pro** (USD 20/user/month). Once assigned, the Groups tab lists the group as `Subscribed`
+with its plan and user count, and the `AWSServiceRoleForUserSubscriptions` service-linked role
+keeps the subscriptions in sync as the group membership changes.
+
+> Group-based subscriptions are not immediate: the console warns of a delay of **up to 24 hours**
+> before members can actually access the subscription.
 
 **Granting or revoking a seat afterwards** is a code change only:
 1. Add or remove `"kiropro"` in the user's `groups` list in `locals.tf`.
 2. Run the Terraform workflow.
 3. Confirm the seat count under **Kiro → Access management → Subscriptions** — each member is
-   billed at USD 20/month.
+   billed at USD 20/month, allowing for the same up-to-24-hour propagation delay.
 
 Re-check whether a first-class resource has shipped before assuming this is still the case:
 [Subscribe your team](https://kiro.dev/docs/enterprise/subscribe/) ·

--- a/management/global/sso/README.md
+++ b/management/global/sso/README.md
@@ -1,0 +1,81 @@
+# Reference Architecture: IAM Identity Center (AWS SSO)
+
+## Overview
+This layer manages the AWS IAM Identity Center organization instance that lives in the
+**management** account (`us-east-1`):
+
+| File | Contents |
+|---|---|
+| `locals.tf` | `users`, `groups` and the derived `users_groups_membership` map |
+| `users_groups.tf` | `aws_identitystore_user` / `_group` / `_group_membership` resources |
+| `permission_sets.tf` + `policies.tf` | Permission sets and their inline/managed policies |
+| `account_assignments.tf` | Which group gets which permission set on which account |
+| `client-vpn-application.tf` | SSO-integrated AWS Client VPN custom SAML application |
+
+## Leverage Documentation
+
+- **How it works**
+    - [Identities](https://leverage.binbash.co/user-guide/ref-architecture-aws/features/identities/identities/)
+- **User guide**
+    1. [Configurations](https://leverage.binbash.com.ar/user-guide/ref-architecture-aws/configs/)
+    2. [Workflow](https://leverage.binbash.com.ar/user-guide/ref-architecture-aws/workflow/)
+
+---
+
+## AWS Terraform Management
+
+### Add/remove a user
+1. Go to `management/global/sso`.
+2. Edit `locals.tf` and add/remove the entry in the local `users` map. The map key is the
+   short username, and `email` must be the user's primary email — Identity Center uses it as
+   `user_name`, so the two have to match for sign-in to work.
+3. List every group the user belongs to in their `groups` attribute. Each value must be a key
+   of the local `groups` map.
+4. Run the [Terraform workflow](https://leverage.binbash.com.ar/user-guide/ref-architecture-aws/workflow/) to apply the changes.
+
+### Add/remove a group
+1. Edit the local `groups` map in `locals.tf`.
+2. If the new group is meant to grant AWS access, add its account assignments in
+   `account_assignments.tf`.
+3. **Two-step apply**: the `account-assignments` module looks the principal up by name, so the
+   group must exist *before* the permission set that references it. Apply the group first, then
+   the assignment (same when renaming or removing a referenced group).
+
+### Kiro subscriptions (Pro — USD 20 / user / month)
+
+Kiro seats are **not** provisionable with OpenTofu. As of 2026-09, subscription assignment is a
+console-only operation:
+
+- the AWS provider has no `q`/`kiro` service (only `qbusiness`, `qldb`, `quicksight`), and there
+  is no `awscc`/CloudFormation resource type either;
+- no `kiro` / `qdeveloper` / `user-subscriptions` client exists in the published AWS SDK models,
+  so there is no `aws` CLI verb and therefore no `local-exec` fallback;
+- the `q:CreateAssignment` / `q:UpdateAssignment` IAM actions exist but are console-internal.
+
+What *is* managed here is the **seat roster**. Kiro can assign a tier to an IAM Identity Center
+group, so the `kiropro` group (display name `KiroPro`) carries the subscription:
+
+- it is deliberately **absent from `account_assignments.tf`**, so it is bound to no permission
+  set and grants no AWS access — it only exists to hold Kiro seats;
+- one group per tier. If a Pro+ / Power seat is ever needed, add a sibling group (e.g.
+  `kiroproplus`) rather than mixing tiers in one group.
+
+**One-time console step** (after the group is applied): Amazon Q Developer console →
+**Kiro** → **Access management** → **Groups** → **Add group** → pick `KiroPro` → tier **Pro** →
+**Assign**. The `AWSServiceRoleForUserSubscriptions` service-linked role then keeps the
+subscriptions in sync as the group membership changes.
+
+**Granting or revoking a seat afterwards** is a code change only:
+1. Add or remove `"kiropro"` in the user's `groups` list in `locals.tf`.
+2. Run the Terraform workflow.
+3. Confirm the seat count under **Kiro → Access management → Subscriptions** — each member is
+   billed at USD 20/month.
+
+Re-check whether a first-class resource has shipped before assuming this is still the case:
+[Subscribe your team](https://kiro.dev/docs/enterprise/subscribe/) ·
+[Kiro enterprise IAM](https://kiro.dev/docs/enterprise/iam/)
+
+### AWS Client VPN application
+The custom SAML application used by AWS Client VPN is created here and assigned to the groups
+listed in the local `client_vpn_groups`. Set `enable_sso_client_vpn = false` in `locals.tf` to
+tear it down. The VPN endpoint itself lives in `network/us-east-1/client-vpn`.

--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -20,6 +20,7 @@ locals {
       groups = [
         "datascientists",
         "administrators",
+        "kiropro",
       ]
     }
     "angelo.fenoglio" = {
@@ -62,6 +63,7 @@ locals {
       groups = [
         "administrators",
         "devops",
+        "kiropro",
       ]
     }
     "dorian.machado" = {
@@ -90,6 +92,7 @@ locals {
         "devops",
         "datascientists",
         "marketplaceandpartnercentral",
+        "kiropro",
       ]
     }
     "ezequiel.godoy" = {
@@ -379,6 +382,18 @@ locals {
     managementmarketplaceaipublishers = {
       name        = "ManagementMarketplaceAIPublishers"
       description = "Provides access to publish AI products in AWS Marketplace and Partner Central from the Management account."
+    }
+    #
+    # NOTE Subscription-only group: it is intentionally NOT referenced by any
+    # permission set in account_assignments.tf, so it grants no AWS access.
+    # It exists so that Kiro Pro seats are assigned once to the group in the
+    # Kiro console (Kiro has no public API / OpenTofu resource for subscription
+    # assignment), while seat membership stays managed as code here.
+    # Ref: https://kiro.dev/docs/enterprise/subscribe/
+    #
+    kiropro = {
+      name        = "KiroPro"
+      description = "Members hold a Kiro Pro (USD 20/user/month) subscription, assigned to this group in the Kiro console."
     }
   }
 


### PR DESCRIPTION
## What?
* Adds a subscription-only IAM Identity Center group `KiroPro` (`kiropro` key) to `management/global/sso`, with **alex.delossantos**, **diego.ojeda** and **exequiel.barrirero** as members.
* The group is deliberately **not** referenced by any permission set in `account_assignments.tf`, so it grants **no AWS access** — it only carries Kiro seats.
* Adds a `README.md` to the layer (it had none): what each file does, how to add/remove users and groups, the two-step group/permission-set apply caveat, the Client VPN application, and the Kiro seat workflow.

## Why?
* We want three Kiro **Pro** seats (USD 20/user/month, USD 60/month total) managed as code.
* Kiro subscription assignment **cannot** be done from OpenTofu, verified 2026-09-01:
  * `terraform-provider-aws` has no `q`/`kiro` service package (only `qbusiness`, `qldb`, `quicksight`);
  * there is no `awscc`/CloudFormation resource type for Kiro or Q Developer;
  * no `kiro`/`qdeveloper`/`user-subscriptions` client exists in the published AWS SDK models (only the unrelated `license-manager-user-subscriptions`), so there is no `aws` CLI verb and therefore no `local-exec` fallback;
  * the `q:CreateAssignment` / `q:UpdateAssignment` IAM actions exist but are console-internal.
* Kiro **can** assign a tier to an Identity Center group, so this PR codifies the part that changes over time — the seat roster — and leaves a single manual step: assign the **Pro** tier to `KiroPro` once in the Kiro console (Amazon Q Developer console → Kiro → Access management → Groups → Add group). `AWSServiceRoleForUserSubscriptions` then keeps subscriptions in sync as membership changes.
* After that, granting or revoking a seat is only adding/removing `"kiropro"` in a user's `groups` list in `locals.tf`.
* One group per tier: a future Pro+ / Power seat gets a sibling group rather than mixing tiers.

## References
* [Kiro — Subscribe your team](https://kiro.dev/docs/enterprise/subscribe/) (console-only assignment; groups supported)
* [Kiro — Enterprise IAM](https://kiro.dev/docs/enterprise/iam/) (`AWSServiceRoleForUserSubscriptions`)
* [Enable Kiro enterprise subscription with IAM Identity Center](https://repost.aws/articles/AR3YUupHzQQ2mqMzL5Y8KvbQ/enable-kiro-enterprise-subscription-with-iam-identity-center-in-your-aws-account)

## Plan

Run from `management/global/sso`. Not applied yet — pending review.

<details>
<summary><code>leverage tofu plan</code> — 4 to add, 0 to change, 0 to destroy</summary>

```text
OpenTofu will perform the following actions:

  # aws_identitystore_group.default["kiropro"] will be created
  + resource "aws_identitystore_group" "default" {
      + description       = "Members hold a Kiro Pro (USD 20/user/month) subscription, assigned to this group in the Kiro console."
      + display_name      = "KiroPro"
      + external_ids      = (known after apply)
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
    }

  # aws_identitystore_group_membership.default["alex.delossantos_kiropro"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = "<SSO_USER_ID>"
      + membership_id     = (known after apply)
    }

  # aws_identitystore_group_membership.default["diego.ojeda_kiropro"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = "<SSO_USER_ID>"
      + membership_id     = (known after apply)
    }

  # aws_identitystore_group_membership.default["exequiel.barrirero_kiropro"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = "<SSO_USER_ID>"
      + membership_id     = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the KiroPro group and assigned its initial members for subscription management.
  * Documented AWS IAM Identity Center user and group workflows, KiroPro seat assignment, and the AWS Client VPN SAML application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->