### PR TITLE
feat(finops): adopt the bb-ai-marketplace aws-finops plugin for Ref Arch cost analysis (#1159)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "aws-cost-estimation@bb-ai-marketplace": true,
+    "aws-finops@bb-ai-marketplace": true,
     "aws-startup-advisor@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
@@ -17,7 +18,7 @@
   "extraKnownMarketplaces": {
     "bb-ai-marketplace": {
       "source": {
-        "ref": "v1.4.0",
+        "ref": "v1.6.0",
         "repo": "binbashar/bb-ai-marketplace",
         "source": "github"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ connected, stop and fix the setup rather than reaching for `aws ce ...`.
 - `docs/finops/known-charges.md` and `docs/finops/accepted-exceptions.md` are Phase 0
   suppression lists. Add a row when a run flags something the team decides is expected; never
   put dollar amounts in `known-charges.md` (that would let any amount pass under a known name).
-- Cost Explorer bills **$0.01/request** — a full run is ~10–20 calls.
+- Cost Explorer bills **$0.01 per _paginated_ request** (a multi-page result bills per page, not per call) — a full run is ~10–20 calls, so ~$0.10–$0.20 when they come back single-page.
 - Full runbook and the AWS-side prerequisites: `docs/finops/README.md`.
 
 > Distinct from `make infracost-breakdown` and the `aws-cost-estimation` plugin, which price a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,31 @@ leverage run decrypt          # decrypts secrets.enc -> secrets.dec.tf
 leverage run encrypt          # encrypts secrets.dec.tf -> secrets.enc, deletes plaintext
 ```
 
+### FinOps: analysing actual AWS spend
+The **`aws-finops`** plugin (`bb-ai-marketplace`, enabled in `.claude/settings.json`) reads the
+**management (payer) account** through the bundled `awslabs.billing-cost-management-mcp-server`
+MCP server. It is **MCP-only by design and never falls back to the AWS CLI** — if the MCP is not
+connected, stop and fix the setup rather than reaching for `aws ce ...`.
+
+```text
+/leverage-aws-creds-check --management-only   # preflight; must pass first
+/aws-finops-investigate                       # what is happening with the bill
+/aws-finops-optimize                          # how to reduce it
+```
+
+- Reports are written to `docs/finops/` and **committed** — each run is diffed against the last.
+- The MCP inherits `AWS_PROFILE` from the shell that launched Claude Code, so a management
+  profile (`bb-management-administrator`) must be exported **before** the session starts; it
+  cannot be fixed from inside one.
+- `docs/finops/known-charges.md` and `docs/finops/accepted-exceptions.md` are Phase 0
+  suppression lists. Add a row when a run flags something the team decides is expected; never
+  put dollar amounts in `known-charges.md` (that would let any amount pass under a known name).
+- Cost Explorer bills **$0.01/request** — a full run is ~10–20 calls.
+- Full runbook and the AWS-side prerequisites: `docs/finops/README.md`.
+
+> Distinct from `make infracost-breakdown` and the `aws-cost-estimation` plugin, which price a
+> *proposed* change. `aws-finops` reads money already spent.
+
 ### Advanced Operations
 ```bash
 # Targeted operations for efficiency
@@ -329,6 +354,7 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 - **`infracost.yml`**: Defines cost analysis entries for every layer across all accounts
 - **`renovate.json`**: Automated dependency updates
 - **`.pre-commit-config.yaml`**: Enforces `terraform_fmt`, JSON validation, trailing whitespace, private key detection
+- **`.claude/settings.json`**: Enabled Claude Code plugins and the `bb-ai-marketplace` marketplace pin. Always pin `extraKnownMarketplaces.*.source.ref` to a **released tag**, never a branch or a bare commit — the tag is the public contract the marketplace repo maintains. Adopting a new plugin version is a deliberate bump of that ref, and takes effect only after a Claude Code restart
 
 ## Important Development Notes
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ This repository contains all OpenTofu/Terraform configuration files used to crea
 - [Leverage CLI](https://leverage.binbash.co/user-guide/leverage-cli/installation/) (v2.2.0+)
 - [OpenTofu](https://opentofu.org/docs/intro/install/) (>= 1.6)
 - AWS SSO access configured for the target accounts
-- [uv](https://docs.astral.sh/uv/) (recommended for Python/Leverage CLI management)
+- [uv](https://docs.astral.sh/uv/) (recommended for Python/Leverage CLI management; also provides
+  `uvx`, which the Claude Code plugin MCP servers are launched with — see
+  [AI Development Configs](#ai-development-configs))
 
 ### Installation
 
@@ -100,6 +102,7 @@ here.
 - **[Claude Code](CLAUDE.md)** - Anthropic's AI coding assistant
   - [`CLAUDE.md`](CLAUDE.md) - Project instructions and context for Claude
   - [`.claude/agents/`](.claude/agents/) - Specialized agent definitions (architect, security, terraform-layer, etc.)
+  - [`.claude/settings.json`](.claude/settings.json) - Enabled plugins and the `bb-ai-marketplace` tag pin
   - [`.mcp.json`](.mcp.json) - Root-level MCP server configurations (AWS API, AWS Documentation)
 
 ### Usage
@@ -116,6 +119,29 @@ They provide:
 - AWS- and OpenTofu/Terraform-specific assistance
 - Consistent code formatting and structure guidelines
 - Direct access to AWS documentation and the AWS API
+
+### Plugins
+
+[`.claude/settings.json`](.claude/settings.json) enables a set of Claude Code plugins and pins
+[`binbashar/bb-ai-marketplace`](https://github.com/binbashar/bb-ai-marketplace) to a **released
+tag** — adopting a newer plugin version is a deliberate bump of that pin, never a branch that
+moves under us. Plugins that bundle an MCP server (`aws-cost-estimation`, `aws-finops`) launch it
+with `uvx`, so [uv](https://docs.astral.sh/uv/) must be installed, and they need a Claude Code
+restart plus a one-time per-server trust prompt before first use.
+
+### AWS cost analysis (FinOps)
+
+The **`aws-finops`** plugin analyses *actual* AWS spend from the Organizations management (payer)
+account: `/aws-finops-investigate` (baseline + month-over-month deltas, anomaly triage, tag
+hygiene, forecast vs budget) and `/aws-finops-optimize` (right-sizing, Savings Plans coverage,
+per-service waste). Reports land in [`docs/finops/`](docs/finops/) and are committed, so each run
+can be diffed against the last.
+
+Setup, the AWS-side prerequisites this repo provisions, and how to launch a session against the
+management profile: [`docs/finops/README.md`](docs/finops/README.md).
+
+> Not to be confused with `make infracost-breakdown` or the `aws-cost-estimation` plugin, which
+> price a *proposed* change before it is applied.
 
 ### Learn More
 

--- a/docs/finops/README.md
+++ b/docs/finops/README.md
@@ -1,7 +1,7 @@
 # FinOps — AWS cost analysis for the Reference Architecture
 
 How we analyse **actual** AWS spend for the binbash Organization: the
-[`aws-finops`](https://github.com/binbashar/bb-ai-marketplace/tree/master/plugins/aws-finops)
+[`aws-finops`](https://github.com/binbashar/bb-ai-marketplace/tree/v1.6.0/plugins/aws-finops)
 Claude Code plugin, the AWS-side prerequisites this repo provisions for it, and
 the reports it drops in this directory.
 
@@ -52,17 +52,24 @@ the Cost Explorer `LINKED_ACCOUNT` dimension.
 | Prerequisite | Where it is managed |
 | --- | --- |
 | Cost Explorer | Enabled account-wide (no OpenTofu resource exists; activated once in the console) |
-| Cost Anomaly Detection monitor | `management/global/aws-finops-agent/cost-anomaly.tf` — `aws_ce_anomaly_monitor` — **pending [PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** |
+| Cost Anomaly Detection | A default AWS-services monitor is auto-configured when Cost Explorer is enabled; an explicit `aws_ce_anomaly_monitor` comes with **[PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** (`management/global/aws-finops-agent/cost-anomaly.tf`) |
 | Compute Optimizer opt-in | `management/global/aws-finops-agent/compute-optimizer.tf` — `aws_computeoptimizer_enrollment_status` — **pending [PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** |
 | Cost Optimization Hub — org trusted access | [`management/global/organizations/organization.tf`](../../management/global/organizations/organization.tf) — `cost-optimization-hub.bcm.amazonaws.com` in `aws_service_access_principals` |
 | Cost Optimization Hub — org-wide enrollment | [`management/global/organizations/cost_optimization_hub_enabling.tf`](../../management/global/organizations/cost_optimization_hub_enabling.tf) — `aws_costoptimizationhub_enrollment_status` |
 | Read-only IAM for the plugin | [`management/global/base-identities/role_policies.tf`](../../management/global/base-identities/role_policies.tf) — `aws_iam_policy.aws_finops_readonly_access`, attached to `DeployMaster` |
 
-Each service takes **24–48 h to populate data** after first activation, so a run
-immediately after enabling one will legitimately come back empty. Until PR #1115
-merges and applies, `/aws-finops-investigate`'s anomaly phase and
-`/aws-finops-optimize`'s right-sizing phase have no source data — the rest of both
-reports still works.
+Data readiness differs per service, so a run right after enabling one will
+legitimately come back thin:
+
+| Service | When data appears |
+| --- | --- |
+| Cost Explorer | Current month in **~24 h**; the previous 13 months take a **few days longer**. Refreshed at least daily thereafter ([docs](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-enable.html)) |
+| Cost Anomaly Detection | Enabling Cost Explorer **auto-configures** a default AWS-services monitor and a daily summary subscription, so some anomaly data exists already; PR #1115 adds an explicit `DIMENSIONAL`/`SERVICE` monitor alongside it |
+| Compute Optimizer | Up to **24 h** after opt-in, and only for resources with **≥ 30 h** of CloudWatch metric history |
+| Cost Optimization Hub | Imports from Compute Optimizer and Savings Plans; recommendations **refresh daily**, so it is only as fresh as its upstreams |
+
+Until PR #1115 merges and applies, `/aws-finops-optimize`'s right-sizing phase has
+no Compute Optimizer source data — the rest of both reports still works.
 
 > The `Administrator` SSO permission set already covers every call the plugin
 > makes. `aws_finops_readonly_access` exists so the plugin can also run under
@@ -102,8 +109,12 @@ Then, in the session:
 Each skill writes its report into this directory. **Commit them** — the point of
 keeping them in-tree is diffing this month's run against the last one.
 
-> **Cost note.** The Cost Explorer API charges **$0.01 per request**; a full run is
-> ~10–20 calls, so **$0.10–$0.20 per report**. Not free, not a reason to hesitate.
+> **Cost note.** The Cost Explorer API charges **$0.01 per _paginated_ request** —
+> a query whose result spans several pages bills once per page, not once per call
+> ([docs](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-api-best-practices.html)).
+> A full run is ~10–20 calls, so **$0.10–$0.20 per report** when they come back
+> single-page, which is the normal case at this org's size. Not free, not a reason
+> to hesitate — but not a figure to quote at a much larger org either.
 
 ---
 

--- a/docs/finops/README.md
+++ b/docs/finops/README.md
@@ -1,0 +1,145 @@
+# FinOps — AWS cost analysis for the Reference Architecture
+
+How we analyse **actual** AWS spend for the binbash Organization: the
+[`aws-finops`](https://github.com/binbashar/bb-ai-marketplace/tree/master/plugins/aws-finops)
+Claude Code plugin, the AWS-side prerequisites this repo provisions for it, and
+the reports it drops in this directory.
+
+> **Scope.** This is about money already spent — reading the payer account's bill.
+> For estimating the cost of a *proposed* change before applying it, use
+> `make infracost-breakdown` or the `aws-cost-estimation` plugin instead.
+
+---
+
+## 1. What the plugin gives us
+
+| Skill | Answers | Output |
+| --- | --- | --- |
+| **`/aws-finops-investigate`** | *What is happening with the bill?* — baseline + month-over-month deltas, anomaly triage, tag hygiene, end-of-month forecast vs budget | `finops-investigation-<ts>.md` (here) |
+| **`/aws-finops-optimize`** | *How do we reduce it?* — right-sizing & idle resources, Savings Plans coverage/utilisation, per-service waste (incl. EKS/RDS extended-support surcharges) | `finops-optimization-<ts>.md` (here) |
+| **`/leverage-aws-creds-check --management-only`** | Read-only SSO/credentials preflight; gates the two above | terminal table |
+
+Every figure comes from the bundled **`awslabs.billing-cost-management-mcp-server`**
+MCP server. The skills are **MCP-only by design and never fall back to the AWS
+CLI**, so a report is reproducible rather than improvised.
+
+> **Distinct from the AWS FinOps Agent.** `management/global/aws-finops-agent`
+> (issue #1003, [PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115))
+> provisions AWS's own managed frontier agent. The two coexist — this plugin's
+> method is what you would feed that agent as custom instructions.
+
+---
+
+## 2. Prerequisites
+
+### 2.1 Local tooling
+
+| Requirement | Check | Install |
+| --- | --- | --- |
+| `uv` / `uvx` — runs the MCP server | `uvx --version` | `brew install uv` or `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| Plugin enabled | `aws-finops@bb-ai-marketplace` in [`.claude/settings.json`](../../.claude/settings.json) | already committed |
+
+The marketplace is pinned to a released tag in the same file
+(`extraKnownMarketplaces.bb-ai-marketplace.source.ref`). Bump that pin to adopt a
+newer plugin version; don't track a branch.
+
+### 2.2 AWS side — what this repo provisions
+
+The plugin reads the **management (payer) account** only. Consolidated billing
+means it already sees every member account's cost; member spend is attributed via
+the Cost Explorer `LINKED_ACCOUNT` dimension.
+
+| Prerequisite | Where it is managed |
+| --- | --- |
+| Cost Explorer | Enabled account-wide (no OpenTofu resource exists; activated once in the console) |
+| Cost Anomaly Detection monitor | `management/global/aws-finops-agent/cost-anomaly.tf` — `aws_ce_anomaly_monitor` — **pending [PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** |
+| Compute Optimizer opt-in | `management/global/aws-finops-agent/compute-optimizer.tf` — `aws_computeoptimizer_enrollment_status` — **pending [PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** |
+| Cost Optimization Hub — org trusted access | [`management/global/organizations/organization.tf`](../../management/global/organizations/organization.tf) — `cost-optimization-hub.bcm.amazonaws.com` in `aws_service_access_principals` |
+| Cost Optimization Hub — org-wide enrollment | [`management/global/organizations/cost_optimization_hub_enabling.tf`](../../management/global/organizations/cost_optimization_hub_enabling.tf) — `aws_costoptimizationhub_enrollment_status` |
+| Read-only IAM for the plugin | [`management/global/base-identities/role_policies.tf`](../../management/global/base-identities/role_policies.tf) — `aws_iam_policy.aws_finops_readonly_access`, attached to `DeployMaster` |
+
+Each service takes **24–48 h to populate data** after first activation, so a run
+immediately after enabling one will legitimately come back empty. Until PR #1115
+merges and applies, `/aws-finops-investigate`'s anomaly phase and
+`/aws-finops-optimize`'s right-sizing phase have no source data — the rest of both
+reports still works.
+
+> The `Administrator` SSO permission set already covers every call the plugin
+> makes. `aws_finops_readonly_access` exists so the plugin can also run under
+> `DeployMaster` — and so the exact permission surface is git-visible rather than
+> hiding behind `AdministratorAccess`.
+
+---
+
+## 3. Running a report
+
+The MCP server inherits `AWS_PROFILE` / `AWS_CONFIG_FILE` /
+`AWS_SHARED_CREDENTIALS_FILE` **from the shell that launched Claude Code**, so the
+management profile has to be exported *before* the session starts — you cannot fix
+it from inside one.
+
+```bash
+leverage aws sso login                                    # ~8 h token
+
+# refresh per-profile creds (any management layer will do)
+cd management/global/organizations && leverage tofu refresh-credentials && cd -
+
+export AWS_CONFIG_FILE="$HOME/.aws/bb/config"
+export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/bb/credentials"
+export AWS_PROFILE="bb-management-administrator"          # or bb-management-devops
+
+claude                                                    # restart the session
+```
+
+Then, in the session:
+
+```text
+/leverage-aws-creds-check --management-only   # must pass first
+/aws-finops-investigate
+/aws-finops-optimize
+```
+
+Each skill writes its report into this directory. **Commit them** — the point of
+keeping them in-tree is diffing this month's run against the last one.
+
+> **Cost note.** The Cost Explorer API charges **$0.01 per request**; a full run is
+> ~10–20 calls, so **$0.10–$0.20 per report**. Not free, not a reason to hesitate.
+
+---
+
+## 4. Keeping runs about *new* findings
+
+Two optional files suppress noise. Both are read as **Phase 0** of their skill, and
+both change only how a charge is *described* or whether it is *recommended* — never
+whether it is *counted* in totals and forecasts.
+
+| File | Read by | Suppresses |
+| --- | --- | --- |
+| [`known-charges.md`](known-charges.md) | `/aws-finops-investigate` | Recurring charges we already know about, so they stop showing up as "biggest movers" and anomalies |
+| [`accepted-exceptions.md`](accepted-exceptions.md) | `/aws-finops-optimize` | Spend we have reviewed and consciously accepted, so it stops being re-recommended |
+
+`accepted-exceptions.md` rows carry a **Baseline ($/mo)**; if an accepted item grows
+materially past it, the skill surfaces it as *"accepted, now growing"* rather than
+hiding a ballooning cost. `known-charges.md` deliberately records **no amounts** —
+the skill sanity-checks a known charge against its own recent months instead, so a
+charge that doubles under a familiar name still gets noticed.
+
+Add a row whenever a report flags something the team decides is expected. That is
+the maintenance loop.
+
+---
+
+## 5. Reading a report
+
+- **Marketplace / partner charges break the forecast.** Cost Explorer's end-of-month
+  forecast is built from usage trends and does **not** include a monthly AWS
+  Marketplace subscription that bills on a fixed day. If the org carries one, add it
+  to the forecast by hand before comparing against a budget.
+- **A rate change is not usage growth.** A service whose usage quantity is flat while
+  cost steps up on a specific date has repriced — most often an EKS cluster or
+  RDS/Aurora engine that crossed its end-of-standard-support date and now bills the
+  extended-support surcharge (issue #1160 tracks preventing that in the IaC). Report
+  it as a monthly/annualised run-rate step, not a one-off anomaly.
+- **Tag coverage bounds attribution.** The investigate skill's tag-hygiene phase
+  measures exactly what issue #842 (tagging strategy) is about; untagged spend is
+  spend nobody can be asked to own.

--- a/docs/finops/accepted-exceptions.md
+++ b/docs/finops/accepted-exceptions.md
@@ -1,0 +1,28 @@
+# Accepted exceptions
+
+Spend the team has **reviewed and consciously accepted**: Multi-AZ kept on a
+production database, a reserved capacity floor, a deliberately over-provisioned node
+pool. Read as **Phase 0** of every `/aws-finops-optimize` run.
+
+A matched finding is dropped from the Prioritised Action Plan and the priority tables
+so each run stays about *new* opportunities. Suppression changes only whether an item
+is *recommended* — matched spend is **still counted** in every total.
+
+**The Baseline column is what makes suppression safe.** If an accepted item grows
+materially past its baseline, the skill surfaces it in *Investigation Notes* as
+*"accepted, now growing"* with the old and new figures, instead of hiding a
+ballooning cost.
+
+| Account | Service / Resource | What's accepted | Reason | Baseline ($/mo) | Revisit |
+| --- | --- | --- | --- | --- | --- |
+| _(none yet)_ | | | | | |
+
+## Maintaining this file
+
+Seeded empty on purpose: the first `/aws-finops-optimize` run should report
+**everything**, and only findings the team then decides to live with belong here.
+Adding rows pre-emptively suppresses opportunities nobody has looked at yet.
+
+When you add one, fill in every column — a row without a **Baseline** cannot trigger
+the "accepted, now growing" escape hatch, and a row without a **Revisit** date is an
+exception that quietly becomes permanent.

--- a/docs/finops/known-charges.md
+++ b/docs/finops/known-charges.md
@@ -1,0 +1,33 @@
+# Known / expected charges
+
+Recurring charges the team has already confirmed are expected. Read as **Phase 0**
+of every `/aws-finops-investigate` run.
+
+A bill line matches a row when its Cost Explorer `SERVICE` name **contains** the
+**Match** text (case-insensitive) and — if the row names an account — it is billed
+into that account.
+
+A matched charge is described as *expected* instead of being raised as a finding, a
+"biggest mover", or an anomaly. It is **still counted** in every total, account
+breakdown and forecast. The allow-list changes how a charge is *described*, never
+whether it is *counted*.
+
+**No dollar amounts here, on purpose.** With no documented figure to rubber-stamp,
+the skill compares a matched charge against its own recent months — so a known
+charge that doubles still gets flagged as coming in higher than usual.
+
+| Match | Account | Cadence | What it is |
+| --- | --- | --- | --- |
+| `Drata` | management | Monthly (mid-month) | Compliance-automation SaaS bought through AWS Marketplace. Bills to the payer account, so it lands as management-account spend rather than against the workload accounts that benefit from it. |
+| `Partner Network` | management | Annual (March) | AWS Partner Network annual program fee. One large line every March; not a spike. |
+
+## Maintaining this file
+
+Add a row whenever an investigation flags something the team decides is expected and
+recurring. Delete a row when the charge stops (a cancelled subscription left in the
+list silently suppresses nothing, but it does mislead the next reader).
+
+**Confirm the Match string against a report.** These are substrings of the Cost
+Explorer `SERVICE` name, not product names — Marketplace sellers in particular can
+appear under a legal entity name. If a run still flags a charge listed here, widen or
+correct the Match text using the exact service name printed in that report.

--- a/management/global/base-identities/role_policies.tf
+++ b/management/global/base-identities/role_policies.tf
@@ -40,3 +40,54 @@ resource "aws_iam_policy" "deploy_master_access" {
 }
 EOF
 }
+
+#
+# Customer Managed Policy: aws-finops plugin read-only access
+#
+# Read-only AWS Billing & Cost Management permissions consumed by the `aws-finops`
+# Claude Code plugin (skills: aws-finops-investigate, aws-finops-optimize,
+# leverage-aws-creds-check) through the awslabs.billing-cost-management-mcp-server
+# MCP server. Attached to the DeployMaster role so any management profile that
+# assumes DeployMaster can run the plugin without static keys.
+#
+# NOTE: intentionally NO `aws:RequestedRegion` condition — Cost Explorer, Budgets,
+# Cost Optimization Hub, Savings Plans, Pricing and Free Tier are global / us-east-1
+# endpoints and a region condition can silently break them. Read verbs only.
+#
+resource "aws_iam_policy" "aws_finops_readonly_access" {
+  name        = "aws_finops_readonly_access"
+  description = "Read-only Billing & Cost Management access for the aws-finops Claude Code plugin"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AwsFinOpsReadOnly",
+            "Effect": "Allow",
+            "Action": [
+                "budgets:Describe*",
+                "budgets:ViewBudget",
+                "ce:Describe*",
+                "ce:Get*",
+                "ce:List*",
+                "compute-optimizer:Describe*",
+                "compute-optimizer:Get*",
+                "compute-optimizer:List*",
+                "cost-optimization-hub:Get*",
+                "cost-optimization-hub:List*",
+                "freetier:GetFreeTierUsage",
+                "organizations:Describe*",
+                "organizations:List*",
+                "pricing:DescribeServices",
+                "pricing:GetAttributeValues",
+                "pricing:GetProducts",
+                "savingsplans:Describe*",
+                "savingsplans:List*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/management/global/base-identities/roles.tf
+++ b/management/global/base-identities/roles.tf
@@ -106,7 +106,9 @@ module "iam_assumable_role_deploy_master" {
   mfa_age              = 86400 # Maximum CLI/API session duration in seconds between 3600 and 43200
   max_session_duration = 10800 # Max age of the session (in seconds) when assuming roles
   custom_role_policy_arns = [
-    aws_iam_policy.deploy_master_access.arn
+    aws_iam_policy.deploy_master_access.arn,
+    # Read-only Billing & Cost Management access for the aws-finops Claude Code plugin
+    aws_iam_policy.aws_finops_readonly_access.arn,
   ]
 }
 

--- a/management/global/organizations/cost_optimization_hub_enabling.tf
+++ b/management/global/organizations/cost_optimization_hub_enabling.tf
@@ -1,14 +1,17 @@
 #
 # Cost Optimization Hub: organization-wide enrollment
 #
-# Trusted access for `cost-optimization-hub.bcm.amazonaws.com` is granted in
-# `organization.tf` (aws_service_access_principals); enrolling here is the second
-# half of that switch and is what makes the payer account aggregate savings
-# recommendations for every member account.
+# Enrolling the payer account with include_member_accounts is what makes the Hub
+# aggregate savings recommendations for every member account -- trusted access alone
+# aggregates nothing. AWS enables trusted access implicitly as part of an org-wide
+# opt-in; we also declare the principal explicitly in `organization.tf`
+# (aws_service_access_principals) so the org's trusted services stay readable in one
+# place rather than being a side effect of this resource.
 #
 # Consumed from the management (payer) account by the `aws-finops` Claude Code
 # plugin (`/aws-finops-optimize`) through the awslabs.billing-cost-management-mcp-server
-# MCP server. Recommendations take 24-48h to populate after first enrollment.
+# MCP server. Recommendations refresh daily and are imported from Compute Optimizer and
+# Savings Plans, so the Hub is only ever as fresh as those upstreams.
 #
 # Free of charge; opting out is just `tofu destroy` of this resource. The service is
 # only available through the us-east-1 endpoint, which is the region this layer runs in

--- a/management/global/organizations/cost_optimization_hub_enabling.tf
+++ b/management/global/organizations/cost_optimization_hub_enabling.tf
@@ -1,0 +1,23 @@
+#
+# Cost Optimization Hub: organization-wide enrollment
+#
+# Trusted access for `cost-optimization-hub.bcm.amazonaws.com` is granted in
+# `organization.tf` (aws_service_access_principals); enrolling here is the second
+# half of that switch and is what makes the payer account aggregate savings
+# recommendations for every member account.
+#
+# Consumed from the management (payer) account by the `aws-finops` Claude Code
+# plugin (`/aws-finops-optimize`) through the awslabs.billing-cost-management-mcp-server
+# MCP server. Recommendations take 24-48h to populate after first enrollment.
+#
+# Free of charge; opting out is just `tofu destroy` of this resource. The service is
+# only available through the us-east-1 endpoint, which is the region this layer runs in
+# (management/config/backend.tfvars).
+#
+resource "aws_costoptimizationhub_enrollment_status" "this" {
+  include_member_accounts = true
+
+  depends_on = [
+    aws_organizations_organization.main,
+  ]
+}


### PR DESCRIPTION
## What?

Adopts the **`aws-finops`** plugin from [`binbashar/bb-ai-marketplace`](https://github.com/binbashar/bb-ai-marketplace), so FinOps analysis of the binbash AWS Organization runs from this repo like any other Leverage workflow — against the management (payer) account, with reports landing in-tree for review.

* **`.claude/settings.json`** — enables `aws-finops@bb-ai-marketplace` and moves the marketplace pin `v1.4.0` → **`v1.6.0`**, the first released tag carrying `aws-finops` **1.1.0**.
* **`management/global/base-identities`** — new `aws_finops_readonly_access` customer-managed policy, attached to the `DeployMaster` role. Read verbs only; the action list is the union of the IAM policies documented in the two skills' READMEs.
* **`management/global/organizations`** — new `aws_costoptimizationhub_enrollment_status` with `include_member_accounts = true`.
* **`docs/finops/`** — the runbook (`README.md`) plus the two optional Phase 0 suppression files the skills read: `known-charges.md` (pre-filled) and `accepted-exceptions.md` (seeded empty, on purpose).
* **`README.md` / `CLAUDE.md`** — `uvx` documented as a prerequisite, the plugin and its MCP-only contract documented, and a pin-a-released-tag rule recorded for `.claude/settings.json`.

## Why?

Closes the repo-side half of #1159. The plugin was validated end-to-end against this
organization before being generalised; this PR is what makes it reproducible for everyone
rather than something one laptop happened to have installed.

**Why `v1.6.0` and not the previously-latest `v1.5.0`.** `v1.5.0` still ships `aws-finops`
1.0.0. `1.1.0` carries the hardening from that first real run — the MCP setup wizard, the
`cost-explorer` parameter-encoding reference, the `aws-finops-optimize` correctness rules,
`accepted-exceptions.md` support, and **EKS/RDS extended-support surcharge detection**, which
is the detection half of the guardrail #1160 tracks.

**Why Cost Optimization Hub here.** Trusted access for `cost-optimization-hub.bcm.amazonaws.com`
was already granted in `organization.tf`, but nothing ever enrolled the payer account — so the
Hub aggregated nothing and `/aws-finops-optimize`'s savings deep-dive would have come back
empty. Enrolling belongs next to the trusted-access switch it completes, in a layer already on
`aws ~> 5.0`; the alternative (`cost-mgmt`) is locked to aws `3.76.1` and would have needed a
major provider bump across live billing alarms and budgets for one resource. The resource is
free of charge and opting out is a destroy of that single resource.

**Why an IAM policy when `Administrator` already covers it.** So the plugin can also run under
`DeployMaster` without static keys, and so the exact permission surface is git-visible rather
than hiding behind `AdministratorAccess`. It deliberately carries **no** `aws:RequestedRegion`
condition — Cost Explorer, Budgets, Cost Optimization Hub, Savings Plans, Pricing and Free Tier
are global / us-east-1 endpoints that a region condition can silently break.

## Merge order — this PR depends on an unmerged marketplace release

`v1.6.0` **does not exist yet**. The marketplace's `Release (prepare PR)` workflow is broken
(its CI user cannot `sts:AssumeRole` the configured Bedrock role — same failure as the previous
run in June), so the release was cut by hand along the path `AGENTS.md` also documents, with
both CI gates run locally and passing.

> **binbashar/bb-ai-marketplace#28 must be merged and tagged `v1.6.0` before this PR merges.**
> Until then the pin resolves to nothing and the plugin will not install.

## Plan

No `tofu plan` is attached: the SSO token for this workspace is expired and applying is a human
step after approval regardless. Both touched layers were verified offline against their **locked**
providers, which is what proves the new resource types and arguments exist:

```text
$ cd management/global/organizations && tofu init -backend=false && tofu validate
Success! The configuration is valid.        # aws 5.100.0

$ cd management/global/base-identities && tofu init -backend=false && tofu validate
Success! The configuration is valid.        # aws 4.x

$ pre-commit run --files <changed files>
check json...............................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
pretty format json.......................................................Passed
trim trailing whitespace.................................................Passed
Terraform fmt............................................................Passed
```

Reviewers should read the plan for **both** layers before applying — `management/global/organizations`
in particular has a wide blast radius (accounts, OUs, SCPs), so any pre-existing drift will surface
in the same plan as this one-resource addition.

## Not in this PR

* **Requirement 3, anomaly monitor + Compute Optimizer** — already implemented by #1115 (issue #1003)
  in `management/global/aws-finops-agent`. Duplicating them here would have collided with that open PR.
  Until #1115 merges and applies, `/aws-finops-investigate`'s anomaly phase and `/aws-finops-optimize`'s
  right-sizing phase have no source data; the rest of both reports still works.
* **Requirements 4–5, the two committed report runs** — the plugin's MCP server only starts at Claude
  Code launch and inherits `AWS_PROFILE` from the launching shell, so the first
  `/leverage-aws-creds-check --management-only`, `/aws-finops-investigate` and `/aws-finops-optimize`
  runs happen in a fresh session after this lands. They will be committed under `docs/finops/` as the
  baseline to diff future runs against. #1159 stays open until then.

## References

* Refs #1159
* Requires: binbashar/bb-ai-marketplace#28 (release `v1.6.0`)
* Related: #1115 / #1003 (AWS's own managed FinOps Agent — the two coexist), #1160 (extended-support
  guardrail: this is the detection side, that is the prevention side), #842 (tagging strategy — the
  investigate skill's tag-hygiene phase measures exactly that coverage)
* Plugin docs: [`plugins/aws-finops`](https://github.com/binbashar/bb-ai-marketplace/tree/master/plugins/aws-finops)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an AWS FinOps plugin for analyzing actual account spend and generating reports in `docs/finops/`.
  - Enabled organization-wide Cost Optimization Hub aggregation.
  - Added read-only billing and cost-management access required for FinOps analysis.

- **Documentation**
  - Added setup, credential, permissions, report interpretation, accepted-exception, and known-charge guidance.
  - Documented plugin installation, prerequisites, report output, and distinctions between available cost-analysis tools.
  - Updated marketplace configuration guidance to use released versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->