### PR TITLE
feat(sso): add Federico Bello user

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -112,6 +112,14 @@ locals {
         "devops",
       ]
     }
+    "federico.bello" = {
+      first_name = "Federico"
+      last_name  = "Bello"
+      email      = "federico.bello@binbash.com.ar"
+      groups = [
+        "datascientists",
+      ]
+    }
     "francisco.rivera" = {
       first_name = "Francisco"
       last_name  = "Rivera"


### PR DESCRIPTION
## What?
* Add **Federico Bello** (`federico.bello@binbash.com.ar`) to the IAM Identity Center users map in `management/global/sso/locals.tf`.
* Grants membership in the **DataScientists** group only — no `devops`, no `administrators`.
* Via `account_assignments.tf`, that group carries the **DataScientist** permission set (`PT8H` session) in the `data-science`, `workshop-genai-1` and `workshop-genai-2` accounts.

## Why?
* Onboarding a new data scientist who needs access to the Data Science / MLOps services (Bedrock, SageMaker, data lake) in the `data-science` account.
* Follows the same single-group pattern already used for other data-science-only members (`ignacio.gomez`, `lucas.langwagen`, `marcelo.rodriguez`).

## Plan

`leverage tofu plan` from `management/global/sso` — **2 to add, 0 to change, 0 to destroy** (no drift):

<details>
<summary>tofu plan output (redacted)</summary>

```text
OpenTofu will perform the following actions:

  # aws_identitystore_group_membership.default["federico.bello_datascientists"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = "<DATASCIENTISTS_GROUP_ID>"
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = (known after apply)
      + membership_id     = (known after apply)
    }

  # aws_identitystore_user.default["federico.bello"] will be created
  + resource "aws_identitystore_user" "default" {
      + display_name      = "Federico Bello"
      + external_ids      = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + user_id           = (known after apply)
      + user_name         = "federico.bello@binbash.com.ar"

      + emails {
          + primary = true
          + value   = "federico.bello@binbash.com.ar"
        }

      + name {
          + family_name = "Bello"
          + given_name  = "Federico"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

## References
* Same change shape as #1119 (`feat(sso): add Agustin Godnic user`).
* [IAM Identity Center — user provisioning](https://docs.aws.amazon.com/singlesignon/latest/userguide/addusers.html)
* Post-apply, Federico completes onboarding from the AWS Console: accept the Identity Center invitation email, set a password and register an MFA device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new user account with associated profile details and membership in the Datascientists group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->