### PR TITLE
feat(sso): add Tomas Gauchat user with DevOps permission set

### DIFF
--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -341,6 +341,14 @@ locals {
         "devops",
       ]
     }
+    "tomas.gauchat" = {
+      first_name = "Tomas"
+      last_name  = "Gauchat"
+      email      = "tomas.gauchat@binbash.com.ar"
+      groups = [
+        "devops",
+      ]
+    }
   }
 
   #----------------------------------------------------------------------------


### PR DESCRIPTION
## What?
* Adds `tomas.gauchat` to the IAM Identity Center `users` map in `management/global/sso/locals.tf`, with membership in the `devops` group.
* Creates 2 resources — `aws_identitystore_user.default["tomas.gauchat"]` and `aws_identitystore_group_membership.default["tomas.gauchat_devops"]`. No new account assignments.
* Via the `DevOps` group he inherits the **DevOps** permission set in the **security, shared, apps-devstg, apps-prd, network and data-science** accounts (not management — that is `administrators` only), and the `bb-client-vpn` SSO SAML application, which is assigned to `client_vpn_groups = ["devops"]`.

## Why?
* Onboarding: Tomas Gauchat needs DevOps-level access to the Ref Arch accounts.
* Group-based, so access stays derived from the roster in `locals.tf` rather than granted per user — same shape as every other DevOps member.

## Post-apply step (not automatable)
`CreateUser` sends no invitation, so the user is created **without a password** and cannot sign in yet. After apply, finish onboarding from the Identity Center console (Users → Tomas Gauchat → **Reset password** → *Send an email* OTP, or generate a one-time password). There is no public API for this.

## Plan

<details>
<summary><code>leverage tofu plan</code> — management/global/sso (account IDs / Identity Center IDs redacted)</summary>

```text
OpenTofu will perform the following actions:

  # aws_identitystore_group_membership.default["tomas.gauchat_devops"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = "<DEVOPS_GROUP_ID>"
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = (known after apply)
      + membership_id     = (known after apply)
    }

  # aws_identitystore_user.default["tomas.gauchat"] will be created
  + resource "aws_identitystore_user" "default" {
      + display_name      = "Tomas Gauchat"
      + external_ids      = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + user_id           = (known after apply)
      + user_name         = "tomas.gauchat@binbash.com.ar"

      + emails {
          + primary = true
          + value   = "tomas.gauchat@binbash.com.ar"
        }

      + name {
          + family_name = "Gauchat"
          + given_name  = "Tomas"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

## References
* Layer runbook: [`management/global/sso/README.md`](https://github.com/binbashar/le-tf-infra-aws/blob/master/management/global/sso/README.md) → *Add/remove a user*
* Leverage docs: [Identities](https://leverage.binbash.co/user-guide/ref-architecture-aws/features/identities/identities/)
* Same shape as #1167 (add Federico Bello)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Management**
  - Added Tomas Gauchat to SSO access with membership in the DevOps group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->