### PR TITLE
feat(sso): gate apps-prd behind a dedicated DevOpsPrd permission set

### DIFF
--- a/management/global/sso/README.md
+++ b/management/global/sso/README.md
@@ -37,9 +37,31 @@ This layer manages the AWS IAM Identity Center organization instance that lives 
 1. Edit the local `groups` map in `locals.tf`.
 2. If the new group is meant to grant AWS access, add its account assignments in
    `account_assignments.tf`.
-3. **Two-step apply**: the `account-assignments` module looks the principal up by name, so the
-   group must exist *before* the permission set that references it. Apply the group first, then
-   the assignment (same when renaming or removing a referenced group).
+3. **Two-step apply**: the `account-assignments` module looks the principal up by name (a
+   `data "aws_identitystore_group"` on `DisplayName`), so the group must exist *before* the
+   assignment that references it — otherwise `plan` itself fails to resolve the data source.
+   Apply the group first, then the assignment (same when renaming or removing a referenced
+   group):
+   ```bash
+   leverage tofu apply -target='aws_identitystore_group.default["<group_key>"]'
+   leverage tofu apply
+   ```
+
+### Production (`apps-prd`) access
+
+Production is **not** reachable through the `devops` group. The `DevOps` permission set is
+assigned to every account *except* `apps-prd`; `apps-prd` is assigned only to the `devopsprd`
+group (display name `DevOpsPrd`), so production access is an explicit membership rather than a
+side effect of being on the DevOps team.
+
+`DevOpsPrd` carries the **same inline policy** as `DevOps` (`data.aws_iam_policy_document.devops`)
+and the same `PT2H` session — it gates *who* reaches production, not *what* they can do there.
+If prod ever needs different permissions, give it its own policy document rather than editing the
+shared one.
+
+To grant or revoke production access, add or remove `"devopsprd"` in the user's `groups` list in
+`locals.tf` and run the Terraform workflow. Note that `readonly` and `securityauditor` still carry
+their own `apps-prd` assignments, so those groups retain view-only access independently of this.
 
 ### Kiro subscriptions (Pro — USD 20 / user / month)
 

--- a/management/global/sso/account_assignments.tf
+++ b/management/global/sso/account_assignments.tf
@@ -90,13 +90,6 @@ module "account_assignments" {
       permission_set_name = "DevOps"
       principal_type      = local.principal_type_group
       principal_name      = local.groups["devops"].name
-      account             = var.accounts.apps-prd.id
-    },
-    {
-      permission_set_arn  = module.permission_sets.permission_sets["DevOps"].arn
-      permission_set_name = "DevOps"
-      principal_type      = local.principal_type_group
-      principal_name      = local.groups["devops"].name
       account             = var.accounts.network.id
     },
     {
@@ -105,6 +98,21 @@ module "account_assignments" {
       principal_type      = local.principal_type_group
       principal_name      = local.groups["devops"].name
       account             = var.accounts.data-science.id
+    },
+
+    # -------------------------------------------------------------------------
+    # DevOpsPrd Permissions
+    #
+    # apps-prd is intentionally absent from the DevOps block above: production
+    # is reached only through the DevOpsPrd group, so being a DevOps team
+    # member does not by itself grant production access.
+    # -------------------------------------------------------------------------
+    {
+      permission_set_arn  = module.permission_sets.permission_sets["DevOpsPrd"].arn
+      permission_set_name = "DevOpsPrd"
+      principal_type      = local.principal_type_group
+      principal_name      = local.groups["devopsprd"].name
+      account             = var.accounts.apps-prd.id
     },
 
     # -------------------------------------------------------------------------

--- a/management/global/sso/locals.tf
+++ b/management/global/sso/locals.tf
@@ -63,6 +63,7 @@ locals {
       groups = [
         "administrators",
         "devops",
+        "devopsprd",
         "kiropro",
       ]
     }
@@ -82,6 +83,7 @@ locals {
       groups = [
         "administrators",
         "devops",
+        "devopsprd",
         "datascientists",
         "marketplaceandpartnercentral",
         "kiropro",
@@ -337,6 +339,17 @@ locals {
     devops = {
       name        = "DevOps"
       description = "Provides full access to many AWS services and resources except billing."
+    }
+    #
+    # NOTE Production access is deliberately NOT granted through the `devops`
+    # group. The DevOps permission set is assigned to every account except
+    # apps-prd; apps-prd is reached only through this group, so prod access is
+    # an explicit, separately reviewed membership rather than a side effect of
+    # being a DevOps team member.
+    #
+    devopsprd = {
+      name        = "DevOpsPrd"
+      description = "Provides the DevOps permission set in the apps-prd (production) account."
     }
     finops = {
       name        = "FinOps"

--- a/management/global/sso/permission_sets.tf
+++ b/management/global/sso/permission_sets.tf
@@ -22,6 +22,20 @@ module "permission_sets" {
       policy_attachments                  = []
       customer_managed_policy_attachments = []
     },
+    #
+    # Same inline policy as DevOps -- this set exists to gate *who* reaches
+    # production, not to grant different permissions there.
+    #
+    {
+      name                                = "DevOpsPrd"
+      description                         = "Provides full access to many AWS services and resources except billing, in the apps-prd (production) account."
+      relay_state                         = local.default_relay_state
+      session_duration                    = "PT2H"
+      tags                                = local.tags
+      inline_policy                       = data.aws_iam_policy_document.devops.json
+      policy_attachments                  = []
+      customer_managed_policy_attachments = []
+    },
     {
       name                                = "FinOps"
       description                         = "Provides access to billing and cost management."


### PR DESCRIPTION
## What?
Production access stops being a side effect of DevOps group membership.

* Adds a **`devopsprd` group** (display name `DevOpsPrd`) and a **`DevOpsPrd` permission set**, assigned **only** to `apps-prd`.
* **Drops the `DevOps` → `apps-prd` assignment.** The `DevOps` set stays on security, shared, apps-devstg, network and data-science.
* `diego.ojeda` and `exequiel.barrirero` join `devopsprd` (keeping their existing groups).
* Documents the model and the two-step apply in the layer README.

`DevOpsPrd` reuses `data.aws_iam_policy_document.devops` and the same `PT2H` session — it gates **who** reaches production, not **what** they can do there.

## Why?
* All **28** members of the `DevOps` group currently hold DevOps access to production simply by being on the team. Production should be an explicit, separately reviewed membership.
* Keeping the same policy means zero behaviour change for the two people who retain access, so the review is purely about the principal list.

### Blast radius — 26 people lose production access

| | |
|---|---|
| **Keeps prod** (via `devopsprd`) | `diego.ojeda`, `exequiel.barrirero` |
| **Loses prod** (26) | `agustin.godnic`, `angelo.fenoglio`, `ariel.jalil`, `dario.villavicencio`, `dorian.machado`, `ezequiel.godoy`, `favio.tolosa`, `franco.gauchat`, `hecber.cordova`, `hernan.rezilo`, `jose.peinado`, `juan.delacamara`, `juan.delatorre`, `juan.rodriguez`, `julian.curetti`, `kevin.santos`, `luis.gallardo`, `manuel.quinteros`, `marcos.pagnucco`, `martin.galeano`, `matias.rodriguez`, `maximiliano.dumon`, `nestor.navarro`, `nicolas.suarez`, `rene.montilva`, `tomas.gauchat` |

Not changed by this PR: `readonly` and `securityauditor` keep their own `apps-prd` assignments, so `marcos.pagnucco` and `matias.rodriguez` retain **view-only** prod access through `readonly`. The `Administrator` → `apps-prd` assignment remains commented out. AWS Client VPN is assigned to `devops` and is unaffected.

## ⚠️ Two-step apply required
The `account-assignments` module resolves principals with `data "aws_identitystore_group"` on `DisplayName`, so **`plan` itself fails** until the group exists. Confirmed on this branch — a full plan renders the 5 additions and then errors:

```text
Error: reading IdentityStore Group (<IDENTITY_STORE_ID>): ... ResourceNotFoundException: GROUP not found.

  with module.account_assignments.data.aws_identitystore_group.this["DevOpsPrd"],
```

So apply in two passes from `management/global/sso`:

```bash
# 1. create the group (and its memberships / the permission set)
leverage tofu apply -target='aws_identitystore_group.default["devopsprd"]'

# 2. now the assignment swap can resolve and plan
leverage tofu apply
```

Pass 2 is the one that actually **revokes** prod from the `DevOps` group, so the change is not complete until it runs. Its plan can only be produced after pass 1 — please review it at that point rather than merging on pass 1 alone.

## Plan (pass 1)

<details>
<summary><code>leverage tofu plan</code> — management/global/sso · <b>5 to add</b>, then the expected group-lookup error</summary>

```text
OpenTofu planned the following actions, but then encountered a problem:

  # aws_identitystore_group.default["devopsprd"] will be created
  + resource "aws_identitystore_group" "default" {
      + description       = "Provides the DevOps permission set in the apps-prd (production) account."
      + display_name      = "DevOpsPrd"
      + external_ids      = (known after apply)
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
    }

  # aws_identitystore_group_membership.default["diego.ojeda_devopsprd"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = "<UUID_REDACTED>"
      + membership_id     = (known after apply)
    }

  # aws_identitystore_group_membership.default["exequiel.barrirero_devopsprd"] will be created
  + resource "aws_identitystore_group_membership" "default" {
      + group_id          = (known after apply)
      + id                = (known after apply)
      + identity_store_id = "<IDENTITY_STORE_ID>"
      + member_id         = "<UUID_REDACTED>"
      + membership_id     = (known after apply)
    }

  # module.permission_sets.aws_ssoadmin_permission_set.this["DevOpsPrd"] will be created
  + resource "aws_ssoadmin_permission_set" "this" {
      + arn              = (known after apply)
      + created_date     = (known after apply)
      + description      = "Provides full access to many AWS services and resources except billing, in the apps-prd (production) account."
      + id               = (known after apply)
      + instance_arn     = "arn:aws:sso:::instance/<REDACTED>"
      + name             = "DevOpsPrd"
      + session_duration = "PT2H"
      + tags             = {
          + "Layer"     = "sso"
          + "Terraform" = "true"
        }
      + tags_all         = {
          + "Layer"     = "sso"
          + "Terraform" = "true"
        }
    }

  # module.permission_sets.aws_ssoadmin_permission_set_inline_policy.this["DevOpsPrd"] will be created
  + resource "aws_ssoadmin_permission_set_inline_policy" "this" {
      + id                 = (known after apply)
      + inline_policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "workspaces:*",
                          + "workspaces-web:*",
                          + "wellarchitected:*",
                          + "wafv2:*",
                          + "waf:*",
                          + "waf-regional:*",
                          + "uxc:*",
                          + "trustedadvisor:*",
                          + "transfer:*",
                          + "textract:*",
                          + "tag:*",
                          + "synthetics:*",
                          + "supportplans:*",
                          + "support:*",
                          + "sts:*",
                          + "states:*",
                          + "sso:ListInstances",
                          + "sso:DescribeRegisteredRegions",
                          + "ssm:*",
                          + "sqs:*",
                          + "sqlworkbench:*",
                          + "sns:*",
                          + "shield:*",
                          + "ses:*",
                          + "servicequotas:*",
                          + "servicediscovery:*",
                          + "securityhub:*",
                          + "secretsmanager:*",
                          + "scheduler:*",
                          + "sagemaker:*",
                          + "s3vectors:*",
                          + "s3files:*",
                          + "s3:*",
                          + "route53resolver:*",
                          + "route53domains:*",
                          + "route53:*",
                          + "resource-groups:*",
                          + "resource-explorer:*",
                          + "resource-explorer-2:*",
                          + "redshift:*",
                          + "redshift-data:*",
                          + "rds:*",
                          + "rds-data:*",
                          + "ram:*",
                          + "quicksight:*",
                          + "q:*",
                          + "pricing:*",
                          + "pipes:*",
                          + "notifications:*",
                          + "networkmanager:*",
                          + "network-firewall:*",
                          + "logs:*",
                          + "lightsail:*",
                          + "license-manager:*",
                          + "lambda:*",
                          + "lakeformation:*",
                          + "kms:*",
                          + "kinesis:*",
                          + "kafka:*",
                          + "inspector2:*",
                          + "iam:*",
                          + "health:*",
                          + "guardduty:*",
                          + "glue:*",
                          + "freetier:*",
                          + "fms:*",
                          + "firehose:*",
                          + "execute-api:*",
                          + "events:*",
                          + "es:*",
                          + "elasticloadbalancing:*",
                          + "elasticfilesystem:*",
                          + "elasticbeanstalk:*",
                          + "elasticache:*",
                          + "eks:*",
                          + "ecs:*",
                          + "ecr:*",
                          + "ecr-public:*",
                          + "ec2:*",
                          + "ec2-instance-connect:*",
                          + "dynamodb:*",
                          + "ds:*",
                          + "dms:*",
                          + "dlm:*",
                          + "datasync:*",
                          + "config:*",
                          + "compute-optimizer:*",
                          + "cognito-idp:*",
                          + "cognito-identity:*",
                          + "codestar-connections:*",
                          + "codepipeline:*",
                          + "codedeploy:*",
                          + "codeconnections:*",
                          + "codebuild:*",
                          + "cloudwatch:*",
                          + "cloudtrail:*",
                          + "cloudshell:*",
                          + "cloudfront:*",
                          + "cloudformation:*",
                          + "ce:*",
                          + "billing:List*",
                          + "billing:Get*",
                          + "bedrock:*",
                          + "bedrock-agentcore:*",
                          + "backup:*",
                          + "backup-storage:*",
                          + "aws-portal:*",
                          + "aws-marketplace:*",
                          + "autoscaling:*",
                          + "athena:*",
                          + "appsync:*",
                          + "apprunner:*",
                          + "application-autoscaling:*",
                          + "appconfig:*",
                          + "apigateway:*",
                          + "aoss:*",
                          + "amplify:*",
                          + "airflow:*",
                          + "aidevops:*",
                          + "acm:*",
                          + "account:List*",
                          + "account:Get*",
                          + "access-analyzer:*",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "aws:RequestedRegion" = [
                                  + "us-east-1",
                                  + "us-east-2",
                                  + "us-east-1",
                                  + "us-west-2",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                      + Sid       = "MultiServiceFullAccessCustom"
                    },
                  + {
                      + Action    = "ec2:RunInstances"
                      + Condition = {
                          + "ForAnyValue:StringNotLike" = {
                              + "ec2:InstanceType" = [
                                  + "*.nano",
                                  + "*.micro",
                                  + "*.small",
                                  + "*.medium",
                                  + "*.large",
                                  + "*.xlarge",
                                ]
                            }
                        }
                      + Effect    = "Deny"
                      + Resource  = "arn:aws:ec2:*:*:instance/*"
                      + Sid       = "Ec2RunInstanceCustomSize"
                    },
                  + {
                      + Action    = [
                          + "rds:CreateDBInstance",
                          + "rds:CreateDBCluster",
                        ]
                      + Condition = {
                          + "ForAnyValue:StringNotLike" = {
                              + "rds:DatabaseClass" = [
                                  + "*.micro",
                                  + "*.small",
                                  + "*.medium",
                                  + "*.large",
                                ]
                            }
                        }
                      + Effect    = "Deny"
                      + Resource  = "arn:aws:rds:*:*:db:*"
                      + Sid       = "RdsFullAccessCustomSize"
                    },
                  + {
                      + Action   = [
                          + "organizations:RegisterDelegatedAdministrator",
                          + "organizations:ListRoots",
                          + "organizations:ListOrganizationalUnitsForParent",
                          + "organizations:ListDelegatedAdministrators",
                          + "organizations:ListAccountsForParent",
                          + "organizations:ListAccounts",
                          + "organizations:ListAWSServiceAccessForOrganization",
                          + "organizations:EnableAWSServiceAccess",
                          + "organizations:DisableAWSServiceAccess",
                          + "organizations:DescribeOrganization",
                          + "organizations:DeregisterDelegatedAdministrator",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "OrganizationWide"
                    },
                  + {
                      + Action   = [
                          + "inspector2:UpdateOrganizationConfiguration",
                          + "inspector2:EnableDelegatedAdminAccount",
                          + "inspector2:Enable",
                          + "inspector2:DisassociateMember",
                          + "inspector2:DisableDelegatedAdminAccount",
                          + "inspector2:Disable",
                          + "inspector2:AssociateMember",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "InspectorAdministration"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + instance_arn       = "arn:aws:sso:::instance/<REDACTED>"
      + permission_set_arn = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Error: reading IdentityStore Group (<IDENTITY_STORE_ID>): operation error identitystore: GetGroupId, https response error StatusCode: 400, RequestID: <UUID_REDACTED>, ResourceNotFoundException: GROUP not found.

  with module.account_assignments.data.aws_identitystore_group.this["DevOpsPrd"],
  on .terraform/modules/account_assignments/modules/account-assignments/main.tf line 7, in data "aws_identitystore_group" "this":
   7: data "aws_identitystore_group" "this" {

```

</details>

> Redacted: account IDs, Identity Center store ID, and SSO instance / permission-set ARNs.

## Notes for the reviewer
* **Base branch** is `master`. #1171 and #1172 squash-merged, so this branch was rebuilt by cherry-picking its single commit onto the new `master` (rebasing would have replayed the already-merged commits). Re-planned afterwards: identical `5 to add` and the same expected group-lookup error, with no action on `tomas.gauchat` or the offboarded users.
* A single-pass alternative exists — the module accepts `identitystore_group_depends_on`, which would defer the data reads to apply time. Deliberately **not** used here: it changes dependency wiring for all 13 assignments, which is more blast radius than this change warrants. Worth considering as its own PR.

## References
* Layer runbook: [`management/global/sso/README.md`](https://github.com/binbashar/le-tf-infra-aws/blob/master/management/global/sso/README.md) → *Production (`apps-prd`) access*
* Depends on: #1171, #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

