### PR TITLE
feat(finops): enable Compute Optimizer org-wide and a Cost Anomaly monitor (#1159)

### DIFF
--- a/docs/finops/README.md
+++ b/docs/finops/README.md
@@ -52,8 +52,9 @@ the Cost Explorer `LINKED_ACCOUNT` dimension.
 | Prerequisite | Where it is managed |
 | --- | --- |
 | Cost Explorer | Enabled account-wide (no OpenTofu resource exists; activated once in the console) |
-| Cost Anomaly Detection | A default AWS-services monitor is auto-configured when Cost Explorer is enabled; an explicit `aws_ce_anomaly_monitor` comes with **[PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** (`management/global/aws-finops-agent/cost-anomaly.tf`) |
-| Compute Optimizer opt-in | `management/global/aws-finops-agent/compute-optimizer.tf` — `aws_computeoptimizer_enrollment_status` — **pending [PR #1115](https://github.com/binbashar/le-tf-infra-aws/pull/1115)** |
+| Cost Anomaly Detection | [`management/global/cost-mgmt/cost_anomaly.tf`](../../management/global/cost-mgmt/cost_anomaly.tf) — `aws_ce_anomaly_monitor` (`DIMENSIONAL`/`SERVICE`). A payer-account monitor evaluates the consolidated bill, so it covers every linked account with no org plumbing |
+| Compute Optimizer — org trusted access | [`management/global/organizations/organization.tf`](../../management/global/organizations/organization.tf) — `compute-optimizer.amazonaws.com` in `aws_service_access_principals` |
+| Compute Optimizer — org-wide enrollment | [`management/global/organizations/compute_optimizer_enabling.tf`](../../management/global/organizations/compute_optimizer_enabling.tf) — `aws_computeoptimizer_enrollment_status` with `include_member_accounts` |
 | Cost Optimization Hub — org trusted access | [`management/global/organizations/organization.tf`](../../management/global/organizations/organization.tf) — `cost-optimization-hub.bcm.amazonaws.com` in `aws_service_access_principals` |
 | Cost Optimization Hub — org-wide enrollment | [`management/global/organizations/cost_optimization_hub_enabling.tf`](../../management/global/organizations/cost_optimization_hub_enabling.tf) — `aws_costoptimizationhub_enrollment_status` |
 | Read-only IAM for the plugin | [`management/global/base-identities/role_policies.tf`](../../management/global/base-identities/role_policies.tf) — `aws_iam_policy.aws_finops_readonly_access`, attached to `DeployMaster` |
@@ -64,12 +65,14 @@ legitimately come back thin:
 | Service | When data appears |
 | --- | --- |
 | Cost Explorer | Current month in **~24 h**; the previous 13 months take a **few days longer**. Refreshed at least daily thereafter ([docs](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-enable.html)) |
-| Cost Anomaly Detection | Enabling Cost Explorer **auto-configures** a default AWS-services monitor and a daily summary subscription, so some anomaly data exists already; PR #1115 adds an explicit `DIMENSIONAL`/`SERVICE` monitor alongside it |
+| Cost Anomaly Detection | Anomalies appear only **after** a monitor exists — enabling Cost Explorer does **not** create one (verified: `ce:GetAnomalyMonitors` returned zero on this payer account). AWS needs ~10 days of history to learn a service's pattern before it will call something anomalous |
 | Compute Optimizer | Up to **24 h** after opt-in, and only for resources with **≥ 30 h** of CloudWatch metric history |
 | Cost Optimization Hub | Imports from Compute Optimizer and Savings Plans; recommendations **refresh daily**, so it is only as fresh as its upstreams |
 
-Until PR #1115 merges and applies, `/aws-finops-optimize`'s right-sizing phase has
-no Compute Optimizer source data — the rest of both reports still works.
+Compute Optimizer is also the Cost Optimization Hub's upstream, so enrolling it
+org-wide is what makes both the Hub *and* `/aws-finops-optimize`'s right-sizing
+phase return anything. Enrolling the payer account alone would aggregate almost
+nothing — the workloads live in the member accounts.
 
 > The `Administrator` SSO permission set already covers every call the plugin
 > makes. `aws_finops_readonly_access` exists so the plugin can also run under
@@ -88,8 +91,11 @@ it from inside one.
 ```bash
 leverage aws sso login                                    # ~8 h token
 
-# refresh per-profile creds (any management layer will do)
-cd management/global/organizations && leverage tofu refresh-credentials && cd -
+# refresh per-profile creds -- use a SINGLE-PROFILE layer. refresh-credentials scans
+# the layer's .tf files for profiles and hard-exits on the first role it cannot assume,
+# writing nothing at all; base-identities references only var.profile, organizations
+# references four member accounts and dies on the first one that has drifted.
+cd management/global/base-identities && leverage tofu refresh-credentials && cd -
 
 export AWS_CONFIG_FILE="$HOME/.aws/bb/config"
 export AWS_SHARED_CREDENTIALS_FILE="$HOME/.aws/bb/credentials"

--- a/docs/finops/README.md
+++ b/docs/finops/README.md
@@ -66,7 +66,7 @@ legitimately come back thin:
 | --- | --- |
 | Cost Explorer | Current month in **~24 h**; the previous 13 months take a **few days longer**. Refreshed at least daily thereafter ([docs](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-enable.html)) |
 | Cost Anomaly Detection | Anomalies appear only **after** a monitor exists — enabling Cost Explorer does **not** create one (verified: `ce:GetAnomalyMonitors` returned zero on this payer account). AWS needs ~10 days of history to learn a service's pattern before it will call something anomalous |
-| Compute Optimizer | Up to **24 h** after opt-in, and only for resources with **≥ 30 h** of CloudWatch metric history |
+| Compute Optimizer | Up to **24 h** after opt-in to finish analysing. Per-resource minimums then differ: EC2 and EC2 Auto Scaling **≥ 30 h** of CloudWatch metrics in 14 days, EBS **≥ 30 consecutive h** attached to a running instance, Aurora/RDS instances **≥ 30 h**, ECS on Fargate **≥ 24 h**. Lambda needs **no CloudWatch data** — instead ≥ 50 invocations in 14 days and memory ≤ 1792 MB ([docs](https://docs.aws.amazon.com/compute-optimizer/latest/ug/requirements.html)) |
 | Cost Optimization Hub | Imports from Compute Optimizer and Savings Plans; recommendations **refresh daily**, so it is only as fresh as its upstreams |
 
 Compute Optimizer is also the Cost Optimization Hub's upstream, so enrolling it

--- a/management/global/cost-mgmt/.terraform.lock.hcl
+++ b/management/global/cost-mgmt/.terraform.lock.hcl
@@ -2,20 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/aws" {
-  version     = "3.76.1"
-  constraints = ">= 2.70.0, ~> 3.0"
+  version     = "5.100.0"
+  constraints = ">= 2.70.0, ~> 5.0"
   hashes = [
-    "h1:6bbE/bERSiphUYSAh1qS69xjxpCV6cY7QQe2AhZZTI0=",
-    "h1:JFPZI6QfatlJUK0YdRuAQxA7NakOAPXsMrnoZYAbu44=",
-    "zh:0f89f65f6ed18d2494cdf32e52cc5f901b777be2bc88fa4083384fb970d7681f",
-    "zh:27c186f42e6b9e52999326c1eb980a6671ca9f8e25dc4d4ba89dae511fc2999c",
-    "zh:32beaeebc296e382fcef5b7aeea63c5c4559e4594df51c5454096858eaa8d041",
-    "zh:5144d9508eeceba201f9c08352733b2bf5e0c32cbc1c791cea36e17057e240d8",
-    "zh:775dba94213786ffe0ba5d021f6616d6c13ca143d5d7d6f62b281667c69552c6",
-    "zh:adb805d8379b88e34e3eeb1d575e2947bcdc96422b59533b15d49262d3f8b89c",
-    "zh:c7653e132bed1b1af404ebac77ba44e2eb14ebe3c787f2ebcf3aaab4ff119da9",
-    "zh:dbb3f32cb4bd65d14ad095b604e26ebf94b0c6cf6072404a469dfc9a5e2957da",
-    "zh:f430eee3f19c5f646bc56c326a1446d7d54cabb865fd76acf300ee7dd3c6e797",
-    "zh:fa3765abb4b2e1d331e1ae2c4ff39525659b0b3a9455d0fb0880e0bdff78daad",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
   ]
 }

--- a/management/global/cost-mgmt/README.md
+++ b/management/global/cost-mgmt/README.md
@@ -1,0 +1,55 @@
+# Cost Management - Quick Reference
+
+Account-level cost **governance** for the management (payer) account: alarms and budgets
+that fire on spend, plus the anomaly monitor that fires on a change in spend *shape*.
+
+Because this is the payer account, everything here sees the **consolidated bill** — every
+linked account's spend is already included, with no per-account setup.
+
+## What's in here
+
+| Resource | What it does |
+| --- | --- |
+| `module.aws_cost_mgmt_billing_alert_50` / `_100` | CloudWatch billing alarms at fixed USD thresholds |
+| `module.aws_cost_mgmt_budget_notif_75` / `_100` | AWS Budgets notifications at 75% / 100% of the monthly limit |
+| `aws_ce_anomaly_monitor.service` | Cost Anomaly Detection, `DIMENSIONAL` on `SERVICE` |
+
+## Key Considerations
+
+- **Alarms and budgets answer a different question than the anomaly monitor.** The first two
+  fire on an *absolute monthly threshold*. The monitor fires when a service departs from its
+  own learned pattern — which is what catches a misconfiguration days before it would breach
+  a budget, and what catches a rate change on a service too small to move the total.
+- **Enabling Cost Explorer does *not* create a default anomaly monitor.** This is a common
+  assumption and it is wrong; `ce:GetAnomalyMonitors` returned zero on this account before
+  `aws_ce_anomaly_monitor.service` was added. With no monitor declared, anomaly data simply
+  does not exist.
+- **New monitors are not instantly useful.** AWS needs roughly **10 days** of history to learn
+  a service's pattern before it will call anything anomalous. A report run right after this
+  applies will legitimately come back empty.
+- **No `aws_ce_anomaly_subscription`, on purpose.** Anomaly alerts publish as
+  `costalerts.amazonaws.com`, but the costs SNS topic in
+  [`management/us-east-1/notifications`](../../us-east-1/notifications) allows only
+  `budgets.amazonaws.com` and is KMS-encrypted — so alerting needs both a topic-policy and a
+  key-policy change in other layers. Anomalies are still readable through
+  `ce:GetAnomalies`; nothing is lost except a push notification.
+- **Notifications come from another layer.** The alarms and budgets publish to the costs SNS
+  topic read from `data.terraform_remote_state.notifications`. Changing who gets paged is a
+  change in `management/us-east-1/notifications`, not here.
+- **Provider is pinned `aws ~> 5.0`.** `aws_ce_anomaly_monitor` needs `>= 4.19`; the layer was
+  on `~> 3.0` until then. The two binbash cost modules only require `>= 2.70.0`, so the pin is
+  this layer's own choice, not a module constraint.
+
+## Who reads this data
+
+The [`aws-finops`](../../../docs/finops/README.md) Claude Code plugin reads the monitor
+(`/aws-finops-investigate`, anomaly-triage phase) from the management account via the
+`awslabs.billing-cost-management-mcp-server` MCP server.
+
+Compute Optimizer and the Cost Optimization Hub — the other half of what that plugin reads —
+are **org-wide** enrollments and live in
+[`management/global/organizations`](../organizations) instead.
+
+> Distinct from `management/global/cost-report`, which posts a daily Slack digest, and from
+> `make infracost-breakdown`, which prices a *proposed* change. This layer is about money
+> already spent.

--- a/management/global/cost-mgmt/config.tf
+++ b/management/global/cost-mgmt/config.tf
@@ -13,7 +13,7 @@ terraform {
   required_version = "~> 1.6"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 5.0"
   }
 
   backend "s3" {

--- a/management/global/cost-mgmt/cost_anomaly.tf
+++ b/management/global/cost-mgmt/cost_anomaly.tf
@@ -1,0 +1,31 @@
+#
+# Cost Anomaly Detection
+#
+# The budgets and billing alarms above fire on an absolute monthly threshold. This
+# fires on a *change in shape* -- a service whose spend departs from its own learned
+# pattern -- which is what catches a misconfiguration days before it would breach a
+# budget, and what catches a rate change on a service too small to move the total.
+#
+# A monitor created in the payer account evaluates the consolidated bill, so it covers
+# every linked account without any Organizations trusted access of its own.
+#
+# Read from the management (payer) account by the `aws-finops` Claude Code plugin
+# (`/aws-finops-investigate`, anomaly-triage phase) via `ce:GetAnomalyMonitors` and
+# `ce:GetAnomalies`. Contrary to a common assumption, enabling Cost Explorer does *not*
+# auto-create a monitor -- with none declared here the anomaly phase returns nothing.
+#
+# No `aws_ce_anomaly_subscription` yet, deliberately: anomaly alerts publish as
+# `costalerts.amazonaws.com`, and the costs SNS topic
+# (management/us-east-1/notifications) allows only `budgets.amazonaws.com` and is
+# KMS-encrypted, so wiring it up needs both a topic-policy and a key-policy change.
+# The plugin reads anomalies through the API and needs no subscription.
+#
+# Free of charge -- Cost Anomaly Detection has no cost, monitored or not.
+#
+resource "aws_ce_anomaly_monitor" "service" {
+  name              = "${var.project}-${var.environment}-service-monitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
+
+  tags = local.tags
+}

--- a/management/global/organizations/.terraform.lock.hcl
+++ b/management/global/organizations/.terraform.lock.hcl
@@ -5,7 +5,9 @@ provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
     "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
     "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
     "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
     "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
@@ -23,7 +25,9 @@ provider "registry.opentofu.org/hashicorp/aws" {
 provider "registry.opentofu.org/hashicorp/null" {
   version = "3.2.4"
   hashes = [
+    "h1:346niW/SBt/jtCZctHefjkQGqtX9YgxSkCAKeCzQhXw=",
     "h1:8ghdTVY6mALCeMuACnbrTmPaEzgamIYlgvunvqI2ZSY=",
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
     "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
     "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
     "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",

--- a/management/global/organizations/README.md
+++ b/management/global/organizations/README.md
@@ -47,9 +47,19 @@ Three things to know before touching either:
    Savings Plans, so enrolling the Hub while Compute Optimizer is `Inactive` produces an empty
    Hub. Disabling Compute Optimizer silently degrades the Hub.
 
-Data is not immediate: Compute Optimizer needs up to **24 h** after opt-in and only reports on
-resources with **>= 30 h** of CloudWatch metric history; Hub recommendations refresh daily and
-are only ever as fresh as those upstreams.
+Data is not immediate. Compute Optimizer takes up to **24 h** after opt-in to finish its first
+analysis, and each resource type then has its own minimum before it is eligible at all:
+
+| Resource | Minimum before a recommendation appears |
+| --- | --- |
+| EC2 instances, EC2 Auto Scaling groups | >= 30 h of CloudWatch metrics in the past 14 days |
+| EBS volumes | >= 30 *consecutive* hours attached to a running instance |
+| Aurora / RDS DB instances | >= 30 h of CloudWatch metrics in the past 14 days (Performance Insights required for over-provisioned findings) |
+| ECS services on Fargate | >= 24 h of CloudWatch and ECS utilization metrics in the past 14 days |
+| Lambda functions | **No CloudWatch data required** — instead >= 50 invocations in 14 days, and memory <= 1792 MB |
+
+See [Resource requirements](https://docs.aws.amazon.com/compute-optimizer/latest/ug/requirements.html) for the full list. Hub recommendations refresh
+daily and are only ever as fresh as those upstreams.
 
 > The *account-level* half of cost governance — billing alarms, budgets and the Cost Anomaly
 > Detection monitor — lives in [`management/global/cost-mgmt`](../cost-mgmt). Consumers of all

--- a/management/global/organizations/README.md
+++ b/management/global/organizations/README.md
@@ -25,6 +25,50 @@ AWS Organizations Multi-Account baseline layout.
 3. Or edit the `policies_scp.tf` file to add/remove/update Service Control Policies.
 4. Finally, run the Terraform workflow to actually apply the changes
 
+### Org-wide cost telemetry (Compute Optimizer + Cost Optimization Hub)
+
+Two org-wide enrollments live here rather than in a cost layer, because each needs its
+trusted-access principal in `organization.tf`'s `aws_service_access_principals` **and** an
+enrollment resource, and the two must land together.
+
+| File | Resource | Feeds |
+| --- | --- | --- |
+| `compute_optimizer_enabling.tf` | `aws_computeoptimizer_enrollment_status` | Right-sizing and idle-resource findings |
+| `cost_optimization_hub_enabling.tf` | `aws_costoptimizationhub_enrollment_status` | Priced savings recommendations |
+
+Three things to know before touching either:
+
+1. **Trusted access alone enrols nothing.** Granting the service principal only *permits* the
+   service org-wide; without the enrollment resource it aggregates nothing. That gap went
+   unnoticed for the Cost Optimization Hub until it was found returning an empty result set.
+2. **`include_member_accounts` is the whole point.** The payer account holds no workloads, so
+   a management-only opt-in aggregates almost nothing. Both resources set it to `true`.
+3. **Compute Optimizer is the Hub's upstream.** The Hub imports from Compute Optimizer and
+   Savings Plans, so enrolling the Hub while Compute Optimizer is `Inactive` produces an empty
+   Hub. Disabling Compute Optimizer silently degrades the Hub.
+
+Data is not immediate: Compute Optimizer needs up to **24 h** after opt-in and only reports on
+resources with **>= 30 h** of CloudWatch metric history; Hub recommendations refresh daily and
+are only ever as fresh as those upstreams.
+
+> The *account-level* half of cost governance — billing alarms, budgets and the Cost Anomaly
+> Detection monitor — lives in [`management/global/cost-mgmt`](../cost-mgmt). Consumers of all
+> of it are documented in [`docs/finops/README.md`](../../../docs/finops/README.md).
+
+#### Editing `aws_service_access_principals`
+
+Check the live list before you apply:
+
+```bash
+aws organizations list-aws-service-access-for-organization \
+  --query 'EnabledServicePrincipals[].ServicePrincipal' --output text
+```
+
+Anything enabled out of band but missing from `organization.tf` will be **removed** on the next
+apply — read the plan, not just the diff. `private-marketplace.marketplace.amazonaws.com` was
+found exactly this way and adopted into the list; do not drop it without intending to turn off
+AWS Private Marketplace.
+
 ### Add/remove AWS accounts
 1. Go to `management/global/organizations`.
 2. Edit `locals.tf` to add/remove accounts from the local `accounts` variable.

--- a/management/global/organizations/compute_optimizer_enabling.tf
+++ b/management/global/organizations/compute_optimizer_enabling.tf
@@ -11,9 +11,12 @@
 # (`/aws-finops-optimize`) through the awslabs.billing-cost-management-mcp-server MCP
 # server, and by the Cost Optimization Hub as its upstream.
 #
-# Recommendations appear up to 24 h after opt-in, and only for resources with at least
-# 30 h of CloudWatch metric history -- a run made right after this applies will still
-# come back thin.
+# Recommendations appear up to 24 h after opt-in, and each resource type has its own
+# eligibility minimum on top of that (EC2/RDS 30 h of CloudWatch metrics, EBS 30
+# consecutive hours attached, ECS on Fargate 24 h; Lambda needs no CloudWatch data but
+# does need 50 invocations in 14 days). A run made right after this applies will still
+# come back thin. See the README table, or:
+# https://docs.aws.amazon.com/compute-optimizer/latest/ug/requirements.html
 #
 # Free of charge; opting out is just `tofu destroy` of this resource.
 #

--- a/management/global/organizations/compute_optimizer_enabling.tf
+++ b/management/global/organizations/compute_optimizer_enabling.tf
@@ -1,0 +1,27 @@
+#
+# Compute Optimizer: organization-wide enrollment
+#
+# Compute Optimizer is what produces the right-sizing and idle-resource findings that
+# `aws_costoptimizationhub_enrollment_status` (see cost_optimization_hub_enabling.tf)
+# imports and prices. Enrolling the payer account alone would aggregate almost nothing:
+# the workloads live in the member accounts, so `include_member_accounts` is what makes
+# both the Hub and the plugin's right-sizing phase return anything at all.
+#
+# Consumed from the management (payer) account by the `aws-finops` Claude Code plugin
+# (`/aws-finops-optimize`) through the awslabs.billing-cost-management-mcp-server MCP
+# server, and by the Cost Optimization Hub as its upstream.
+#
+# Recommendations appear up to 24 h after opt-in, and only for resources with at least
+# 30 h of CloudWatch metric history -- a run made right after this applies will still
+# come back thin.
+#
+# Free of charge; opting out is just `tofu destroy` of this resource.
+#
+resource "aws_computeoptimizer_enrollment_status" "this" {
+  status                  = "Active"
+  include_member_accounts = true
+
+  depends_on = [
+    aws_organizations_organization.main,
+  ]
+}

--- a/management/global/organizations/organization.tf
+++ b/management/global/organizations/organization.tf
@@ -15,7 +15,12 @@ resource "aws_organizations_organization" "main" {
     "sso.amazonaws.com",
     "fms.amazonaws.com",
     "inspector2.amazonaws.com",
+    "compute-optimizer.amazonaws.com",
     "cost-optimization-hub.bcm.amazonaws.com",
+    # Enabled out of band (AWS Private Marketplace) and adopted here so an apply of
+    # this layer stops planning its removal. Do not drop it without disabling Private
+    # Marketplace on purpose.
+    "private-marketplace.marketplace.amazonaws.com",
     "securityhub.amazonaws.com",
   ]
 


### PR DESCRIPTION
## What?

* Enable **Compute Optimizer org-wide** in `management/global/organizations`, beside the Cost Optimization Hub enrollment it feeds — plus its `compute-optimizer.amazonaws.com` trusted-access principal.
* Add a **Cost Anomaly Detection monitor** (`DIMENSIONAL`/`SERVICE`) in `management/global/cost-mgmt`, beside the billing alarms and budgets already there.
* Adopt `private-marketplace.marketplace.amazonaws.com` into `aws_service_access_principals` — it is enabled in AWS but was never declared, so **any** apply of this layer planned its removal.
* Bump `cost-mgmt` from `aws ~> 3.0` to `~> 5.0`; regenerate both lock files for all four platforms.
* **Document both layers for ref-arch users**: `cost-mgmt` had no `README.md` at all, and `organizations/README.md` mentioned cost nowhere — it never covered #1161's Cost Optimization Hub enrollment either.
* Update `docs/finops/README.md`: correct prerequisite locations, and fix two claims that turned out to be wrong (below).
* Companion commit on #1115 removes both resources from `management/global/aws-finops-agent`, so no layer duplicates them.

## Why?

* `/aws-finops-investigate`'s anomaly phase and `/aws-finops-optimize`'s right-sizing phase both returned **nothing**, because neither telemetry source was ever enabled. This is the last AWS-side gap in #1159.
* **The Cost Optimization Hub has been aggregating nothing.** #1161 enrolled it org-wide, but its upstream — Compute Optimizer — was `Inactive` in every account. Same trusted-access-without-enrollment shape #1161 fixed for the Hub itself, one level up.
* **`include_member_accounts` is the whole point.** #1115 opted in the management account only. The payer account holds no workloads, so that would still have aggregated almost nothing.
* **Neither resource is agent-specific.** Owning them in the FinOps-Agent layer coupled org-wide cost telemetry to a preview service whose agentspace can only be created by hand — which is why they have sat unapplied since July. `aws_computeoptimizer_enrollment_status` is also an account-level singleton, so two layers managing it would fight on every apply.
* Two documented claims were **false**, both verified against the payer account:
  * Enabling Cost Explorer does *not* auto-create a default anomaly monitor — `ce:GetAnomalyMonitors` returned zero.
  * `cost-mgmt`'s `aws ~> 3.0` pin was not a module constraint; both binbash cost modules require only `>= 2.70.0`. `aws_ce_anomaly_monitor` needs `>= 4.19`, so the bump was unavoidable — and the plan shows it causes no drift.

## Status — applied 2026-09-11 :warning:

This was applied ahead of merge, at the repo owner's explicit instruction. **The code here is
now behind live state, not ahead of it** — merging is what stops other branches planning a
destroy of what already exists.

| Layer | Apply | Result |
| --- | --- | --- |
| `management/global/cost-mgmt` | full | `1 added, 0 changed, 0 destroyed` |
| `management/global/organizations` | **targeted** | `1 added, 1 changed, 0 destroyed` |

Verified independently against AWS afterwards, not read off the apply log:

| Check | Result |
| --- | --- |
| `compute-optimizer get-enrollment-status` | `status=Active`, `memberAccountsEnrolled=true` |
| `organizations list-aws-service-access-for-organization` | `compute-optimizer.amazonaws.com` present; `private-marketplace.marketplace.amazonaws.com` **still present** — the removal never fired |
| `ce get-anomaly-monitors` | `bb-management-service-monitor`, `DIMENSIONAL`/`SERVICE` |

### Why `organizations` was applied with `-target`

`-target=aws_computeoptimizer_enrollment_status.this -target=aws_organizations_organization.main`

The layer declares a vestigial `aws.apps-prd` provider alias used only by
`data.aws_iam_roles.apps-prd`. That profile no longer exists on disk (see **Merge order**),
so an untargeted apply fails with `failed to get shared config profile`. Targeting prunes the
data source out of the graph, so the provider is never configured.

Consequences, both benign and both still pending exactly as they were before this PR:

* The layer's **17 `import` blocks** (`policy_scp_attachments.tf`, already on `master`) did not run.
* **#1161's `aws_costoptimizationhub_enrollment_status` was not adopted into state.** The Hub stays enrolled — it was enabled out of band — its resource is simply still absent from state. A later untargeted apply picks both up.

### Data is not immediate

Compute Optimizer needs ~24 h and only reports on resources with >= 30 h of CloudWatch metric
history; the anomaly monitor needs ~10 days to learn each service's pattern. Both clocks
started 2026-09-11. Reports run before then will legitimately come back thin.

## Reviewed plans

<details>
<summary><code>management/global/organizations</code> — 2 to add, 1 to change, 0 to destroy</summary>

```text
OpenTofu planned the following actions, but then encountered a problem:

  # aws_computeoptimizer_enrollment_status.this will be created
  + resource "aws_computeoptimizer_enrollment_status" "this" {
      + id                                 = (known after apply)
      + include_member_accounts            = true
      + number_of_member_accounts_opted_in = (known after apply)
      + status                             = "Active"
    }

  # aws_costoptimizationhub_enrollment_status.this will be created
  + resource "aws_costoptimizationhub_enrollment_status" "this" {
      + id                      = (known after apply)
      + include_member_accounts = true
      + status                  = (known after apply)
    }

  # aws_organizations_organization.main will be updated in-place
  ~ resource "aws_organizations_organization" "main" {
      ~ aws_service_access_principals = [
          + "compute-optimizer.amazonaws.com",
            # (14 unchanged elements hidden)
        ]
        id                            = "<ORGANIZATION_ID>"
        # (10 unchanged attributes hidden)
    }

Plan: 17 to import, 2 to add, 1 to change, 0 to destroy.
```
</details>

Two notes on that plan:

* The second create, `aws_costoptimizationhub_enrollment_status`, is **not from this PR** — it is #1161's resource, which was enrolled out of band and never entered state. This apply adopts it.
* The 17 imports are the pre-existing `import` blocks in `policy_scp_attachments.tf`, already on `master`. Omitted from the excerpt: they are pure account/OU identifiers with no review value on a public repo.

<details>
<summary><code>management/global/cost-mgmt</code> — 1 to add, 0 to change, 0 to destroy</summary>

```text
OpenTofu will perform the following actions:

  # aws_ce_anomaly_monitor.service will be created
  + resource "aws_ce_anomaly_monitor" "service" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + monitor_dimension = "SERVICE"
      + monitor_type      = "DIMENSIONAL"
      + name              = "bb-management-service-monitor"
      + tags              = {
          + "Environment" = "management"
          + "Layer"       = "cost-mgmt"
          + "Terraform"   = "true"
        }
      + tags_all          = {
          + "Environment" = "management"
          + "Layer"       = "cost-mgmt"
          + "Terraform"   = "true"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```
</details>

## Deliberately not included

* **No `aws_ce_anomaly_subscription`.** Anomaly alerts publish as `costalerts.amazonaws.com`; the costs SNS topic allows only `budgets.amazonaws.com` and is KMS-encrypted, so alerting needs a topic-policy *and* a key-policy change in two other layers. The plugin reads anomalies through the API and needs no subscription. Worth its own PR.
* **The 17 pending imports and the Hub resource**, per the targeting note above. Unchanged by this PR either way.

## Merge order :rotating_light:

**`organizations/config.tf` on this branch names a profile that no longer exists.** The
apps-prd SSO role moved to `DevOpsPrd` and `leverage aws configure sso` renamed the profile
with it, so `bb-apps-prd-devops` is gone and `bb-apps-prd-devopsprd` took its place. This
branch predates that.

A local `fix/apps-prd-devopsprd-profile` branch carries the rename across all 23 references
(including this layer) but **has no PR yet**. Either:

1. open that PR and merge it with this one — the two touch different lines of
   `organizations/config.tf`, so they merge cleanly; or
2. cherry-pick its rename commit into this branch before merging.

Until then `master` keeps a stale profile reference in that layer, and an untargeted plan of
`organizations` fails for everyone.

**Merging this promptly matters more than usual.** `master` and `fix/apps-prd-devopsprd-profile`
contain none of `compute_optimizer_enabling.tf`, `cost_anomaly.tf`, or the
`compute-optimizer.amazonaws.com` principal — so an untargeted plan from either currently
proposes **destroying** the enrollment and removing the principal. Those branches also carry
the pre-`providers lock` lock files, so `organizations` there fails with
`Required plugins are not installed` until a `tofu init`.

## References

* Part of #1159 (adopt the `bb-ai-marketplace` `aws-finops` plugin) — this closes its last AWS-side prerequisite gap.
* Companion commit on #1115 / #1003 removes the duplicated resources from the FinOps-Agent layer.
* Builds on #1161, which enrolled the Cost Optimization Hub org-wide.
* Related: #1160 (extended-support surcharge guardrail) — the detection side reads these same sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-level Cost Anomaly Detection monitoring for the management account.
  * Enabled organization-wide Compute Optimizer enrollment, including member accounts, to support cost optimization recommendations.
  * Enabled trusted access for Compute Optimizer and Private Marketplace services.

* **Documentation**
  * Added guidance for cost governance, anomaly monitoring, budget alerts, and cost optimization telemetry.
  * Updated FinOps setup instructions, data-readiness details, and credential-refresh guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
