### PR TITLE
fix(sso): rename the apps-prd profile to match the DevOpsPrd permission set

### DIFF
--- a/.claude/agents/leverage-architect.md
+++ b/.claude/agents/leverage-architect.md
@@ -91,9 +91,9 @@ provider "aws" {
   profile = var.profile                           # current account
 }
 provider "aws" {
-  alias   = "apps-prd"
+  alias   = "apps-devstg"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"      # cross-account
+  profile = "${var.project}-apps-devstg-devops"   # cross-account
 }
 ```
 

--- a/.github/workflows/security-keys.yml
+++ b/.github/workflows/security-keys.yml
@@ -30,7 +30,7 @@ jobs:
             aws_region: us-east-2
             required_state_file: false
           - layer: apps-prd/us-east-1/security-keys
-            aws_profile: bb-apps-prd-devops
+            aws_profile: bb-apps-prd-devopsprd
             aws_region: us-east-1
             required_state_file: false
           - layer: security/us-east-1/security-keys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,12 +116,28 @@ The `leverage` CLI is installed in a local venv managed by [uv](https://docs.ast
 # Authenticate with AWS SSO (interactive — requires browser, user must run manually)
 leverage aws sso login
 
+# ...and mint every account's credentials in the same step (leverage >= 3.1.0)
+leverage aws sso login --refresh-all
+
+# Re-mint all account credentials without logging in again (needs a live SSO token).
+# Smart: skips profiles with >30 min left, warns and continues past accounts whose
+# permission set you no longer hold, and prints an "N refreshed, N skipped, N failed"
+# summary. Runs from anywhere in the repo — no layer directory needed.
+leverage aws sso refresh
+leverage aws sso refresh --force    # re-mint even the still-valid ones
+
 # Initialize makefiles (first time setup)
 make init-makefiles
 
 # Initialize OpenTofu for a specific layer (run from layer directory)
 leverage tofu init
 ```
+
+> `leverage aws sso refresh` supersedes running `leverage tofu refresh-credentials` from a
+> layer for the common "everything expired" case. The layer-scoped command still exists and
+> is still what runs automatically before every `leverage tofu` command, but it **hard-exits
+> on the first account whose permission set you lack** (`raise_on_permission_error=True`),
+> writing nothing — so prefer `aws sso refresh` when several accounts are stale.
 
 ### Development Workflow
 ```bash
@@ -360,7 +376,17 @@ source = "github.com/binbashar/tofu-aws-tfstate-backend.git?ref=v1.0.29"
 ### Naming Conventions
 - AWS resources: `{project}-{environment}-{resource}` (e.g., `bb-shared-devops`)
 - Project prefix: `${var.project}-${var.environment}-{resource}`
-- AWS profiles: `{project}-{account}-devops` (e.g., `bb-shared-devops`, `bb-network-devops`)
+- AWS profiles: `{project}-{account}-{sso-permission-set-lowercased}` (e.g., `bb-shared-devops`,
+  `bb-network-devops`, and `bb-apps-prd-devopsprd` for the prod-only `DevOpsPrd` permission set)
+- **The profile name is not a free choice — it is derived from the SSO permission set.** Leverage
+  builds it as `f"{project}-{account_name}-{sso_role.lower()}"` (`leverage/modules/auth.py`), for
+  both `leverage aws sso refresh` and the auto-refresh that precedes every `leverage tofu` command.
+  It ignores the `profile` value in `{account}/config/backend.tfvars` when deriving the name, so a
+  permission set renamed in `management/global/sso` **must** be followed by renaming the profile
+  everywhere it appears in this repo. Skip that and the layer silently keeps reading a profile
+  leverage can no longer mint, and every command fails with `ExpiredToken`. Grep for the old name
+  before merging: cross-account references live in `network/`, `shared/`, `management/global/organizations`
+  and `.github/workflows/security-keys.yml`, not just in the account's own `backend.tfvars`.
 - Tags: Consistent tagging with `Terraform`, `Environment`, `Layer` via `local.tags`
 - **PRM compliance tag (`aws-apn-id`)**: Present in `data-science/us-east-1/bedrock-agent-kyb`, `bedrock-agentcore`, and `bedrock-kyb-bda` for AWS Partner Revenue Measurement attribution. Value `pc:b6t445987ttlzwgcll8zdt8nv` maps to AWS Marketplace product `prod-zw4ehbg5ayh2m`. **Do NOT add this tag to other layers without explicit Partner Development Manager approval** — the product code attributes consumption to a specific Marketplace listing. For Bedrock model invocations specifically, Resource Tagging only works for Amazon/OSS models via an Application Inference Profile; Anthropic Claude invocations need the User Agent String method instead. See [AWS PRM Bedrock docs](https://docs.aws.amazon.com/PRM/latest/aws-prm-onboarding-guide/bedrock-best-practices.html).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,13 @@ PR with this exact, repeatable procedure so no sensitive data leaks:
    editing in place — `sed -i` is non-portable (BSD/macOS requires `-i ''`, GNU/Linux requires
    bare `-i`), and this procedure must run on both macOS and Linux (CI). The scan must print nothing:
    ```bash
-   sed -E 's/[0-9]{12}/<ACCOUNT_NAME_ACCOUNT_ID>/g; s/(AKIA|ASIA)[A-Z0-9]{16}/***/g' /tmp/plan-clean.txt > /tmp/plan-redacted.txt
-   grep -nE '[0-9]{12}|arn:aws:iam::[0-9]|AKIA|ASIA|-----BEGIN' /tmp/plan-redacted.txt   # expect no output
+   sed -E 's/\b[0-9]{12}\b/<ACCOUNT_NAME_ACCOUNT_ID>/g; s/(AKIA|ASIA)[A-Z0-9]{16}/***/g' /tmp/plan-clean.txt > /tmp/plan-redacted.txt
+   grep -nE '\b[0-9]{12}\b|arn:aws:iam::[0-9]|AKIA|ASIA|-----BEGIN' /tmp/plan-redacted.txt   # expect no output
    ```
    Use the named placeholder form, e.g. `<MANAGEMENT_ACCOUNT_ID>` (see the bullets above).
+   The `\b` word boundaries matter: unanchored, `[0-9]{12}` also eats any longer digit run —
+   epoch-nanosecond timestamps and numeric resource IDs get rewritten into fake account-ID
+   placeholders, and the scan still passes on the mangled result.
 4. **Embed** the redacted excerpt (`/tmp/plan-redacted.txt`) in the PR body inside a collapsible `<details>` block with a
    ```` ```text ```` fence (keep the What / Why / References sections intact). Never paste the
    raw refresh log.

--- a/apps-prd/config/account.tfvars
+++ b/apps-prd/config/account.tfvars
@@ -6,4 +6,4 @@
 environment = "apps-prd"
 
 # SSO
-sso_role = "DevOps"
+sso_role = "DevOpsPrd"

--- a/apps-prd/config/backend.tfvars
+++ b/apps-prd/config/backend.tfvars
@@ -3,7 +3,7 @@
 #
 
 # AWS Profile (required by the backend but also used for other resources)
-profile = "bb-apps-prd-devops"
+profile = "bb-apps-prd-devopsprd"
 
 # S3 bucket
 bucket = "bb-apps-prd-terraform-backend"

--- a/apps-prd/us-east-1/app-aws-startups-accelerate/README.md
+++ b/apps-prd/us-east-1/app-aws-startups-accelerate/README.md
@@ -21,7 +21,7 @@ deployed by the app repository's CI through a least-privilege GitHub OIDC role
    ACM certificate ARN via `terraform_remote_state` and cannot plan until the
    certificate exists.
 2. From this directory: `leverage tofu init && leverage tofu plan && leverage tofu apply`
-   (requires valid `bb-apps-prd-devops` and `bb-shared-devops` credentials).
+   (requires valid `bb-apps-prd-devopsprd` and `bb-shared-devops` credentials).
 
 Outputs consumed by the app repository CI: `deploy_role_arn`, `s3_bucket`,
 `cf_distribution_id` (`leverage tofu output`).

--- a/apps-prd/us-east-1/app-binbash-web/README.md
+++ b/apps-prd/us-east-1/app-binbash-web/README.md
@@ -107,7 +107,7 @@ repo's CI (`RPO` 0 — the source of truth is git; `RTO` is one workflow run).
    ACM certificate ARN (`binbash_web_certificate_arn`) via `terraform_remote_state`.
    Note that layer currently fails on an unrelated expired certificate — issue #1143.
 2. From this directory: `leverage tofu init && leverage tofu plan && leverage tofu apply`
-   (requires valid `bb-apps-prd-devops` and `bb-shared-devops` credentials).
+   (requires valid `bb-apps-prd-devopsprd` and `bb-shared-devops` credentials).
 
 ## Handoff to the app repository
 

--- a/apps-prd/us-east-1/base-network/locals.tf
+++ b/apps-prd/us-east-1/base-network/locals.tf
@@ -170,7 +170,7 @@ locals {
   apps-prd-vpcs = {
     apps-prd-base = {
       region  = var.region
-      profile = "${var.project}-apps-prd-devops"
+      profile = "${var.project}-apps-prd-devopsprd"
       bucket  = "${var.project}-apps-prd-terraform-backend"
       key     = "apps-prd/network/terraform.tfstate"
     }

--- a/management/global/organizations/README.md
+++ b/management/global/organizations/README.md
@@ -61,7 +61,7 @@ As an example, we will set up the `apps-prd` account by using the `apps-devstg` 
     3. Do the same with `apps-prd/config/account.tfvars`
     4. Open up `apps-prd/config/backend.tfvars` again and replace this:
         ```
-        profile = "bb-apps-prd-devops"
+        profile = "bb-apps-prd-devopsprd"
         ```
         with this:
         ```
@@ -103,7 +103,7 @@ As an example, we will set up the `apps-prd` account by using the `apps-devstg` 
         ```
         with this:
         ```
-        profile = "bb-apps-prd-devops"
+        profile = "bb-apps-prd-devopsprd"
         ```
     2. This is needed because we only want to use the OAAR role for exceptional cases, not on daily basis.
     3. Now, let's configure your DevOps credentials (if you haven't already done so).

--- a/management/global/organizations/config.tf
+++ b/management/global/organizations/config.tf
@@ -27,7 +27,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 #=============================#
 # Backend Config (partial)    #

--- a/network/us-east-1/base-network/config.tf
+++ b/network/us-east-1/base-network/config.tf
@@ -27,7 +27,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 #=============================#

--- a/network/us-east-1/base-network/locals.tf
+++ b/network/us-east-1/base-network/locals.tf
@@ -145,13 +145,13 @@ locals {
   apps-prd-vpcs = {
     apps-prd-base = {
       region  = var.region
-      profile = "${var.project}-apps-prd-devops"
+      profile = "${var.project}-apps-prd-devopsprd"
       bucket  = "${var.project}-apps-prd-terraform-backend"
       key     = "apps-prd/network/terraform.tfstate"
     }
     #apps-prd-k8s-eks = {
     #  region  = var.region
-    # profile = "${var.project}-apps-prd-devops"
+    # profile = "${var.project}-apps-prd-devopsprd"
     #  bucket  = "${var.project}-apps-prd-terraform-backend"
     # key     = "apps-prd/k8s-eks/network/terraform.tfstate"
     #}

--- a/network/us-east-1/client-vpn/locals.tf
+++ b/network/us-east-1/client-vpn/locals.tf
@@ -41,13 +41,13 @@ locals {
   apps_prd_vpcs = {
     apps-prd-base = {
       region  = var.region
-      profile = "${var.project}-apps-prd-devops"
+      profile = "${var.project}-apps-prd-devopsprd"
       bucket  = "${var.project}-apps-prd-terraform-backend"
       key     = "apps-prd/network/terraform.tfstate"
     }
     #apps-prd-k8s-eks = {
     #  region  = var.region
-    # profile = "${var.project}-apps-prd-devops"
+    # profile = "${var.project}-apps-prd-devopsprd"
     #  bucket  = "${var.project}-apps-prd-terraform-backend"
     # key     = "apps-prd/k8s-eks/network/terraform.tfstate"
     #}

--- a/network/us-east-1/transit-gateway/config.tf
+++ b/network/us-east-1/transit-gateway/config.tf
@@ -27,7 +27,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 #=============================#

--- a/network/us-east-1/transit-gateway/locals.tf
+++ b/network/us-east-1/transit-gateway/locals.tf
@@ -55,13 +55,13 @@ locals {
   apps-prd-vpcs = {
     apps-prd-base = {
       region  = var.region
-      profile = "${var.project}-apps-prd-devops"
+      profile = "${var.project}-apps-prd-devopsprd"
       bucket  = "${var.project}-apps-prd-terraform-backend"
       key     = "apps-prd/network/terraform.tfstate"
     }
     #apps-prd-k8s-eks = {
     #  region  = var.region
-    #  profile = "${var.project}-apps-prd-devops"
+    #  profile = "${var.project}-apps-prd-devopsprd"
     #  bucket  = "${var.project}-apps-prd-terraform-backend"
     #  key     = "apps-prd/k8s-eks/network/terraform.tfstate"
     #}

--- a/network/us-east-2/base-network/config.tf
+++ b/network/us-east-2/base-network/config.tf
@@ -27,7 +27,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region_secondary
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 #=============================#

--- a/network/us-east-2/transit-gateway/config.tf
+++ b/network/us-east-2/transit-gateway/config.tf
@@ -27,7 +27,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region_secondary
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 #=============================#

--- a/network/us-east-2/transit-gateway/locals.tf
+++ b/network/us-east-2/transit-gateway/locals.tf
@@ -92,13 +92,13 @@ locals {
   apps-prd-vpcs = {
     apps-prd-base = {
       region  = var.region
-      profile = "${var.project}-apps-prd-devops"
+      profile = "${var.project}-apps-prd-devopsprd"
       bucket  = "${var.project}-apps-prd-terraform-backend"
       key     = "apps-prd/network/terraform.tfstate"
     }
     #apps-prd-k8s-eks = {
     #  region  = var.region
-    # profile = "${var.project}-apps-prd-devops"
+    # profile = "${var.project}-apps-prd-devopsprd"
     #  bucket  = "${var.project}-apps-prd-terraform-backend"
     # key     = "apps-prd/k8s-eks/network/terraform.tfstate"
     #}

--- a/shared/global/base-dns/binbash.co/config.tf
+++ b/shared/global/base-dns/binbash.co/config.tf
@@ -15,7 +15,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 #=============================#
@@ -135,7 +135,7 @@ data "terraform_remote_state" "vpc-apps-prd" {
 
   config = {
     region  = var.region
-    profile = "${var.project}-apps-prd-devops"
+    profile = "${var.project}-apps-prd-devopsprd"
     bucket  = "${var.project}-apps-prd-terraform-backend"
     key     = "apps-prd/network/terraform.tfstate"
   }

--- a/shared/global/base-dns/binbash.com.ar/config.tf
+++ b/shared/global/base-dns/binbash.com.ar/config.tf
@@ -21,7 +21,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 #=============================#
@@ -152,7 +152,7 @@ data "terraform_remote_state" "vpc-apps-prd" {
 
   config = {
     region  = var.region
-    profile = "${var.project}-apps-prd-devops"
+    profile = "${var.project}-apps-prd-devopsprd"
     bucket  = "${var.project}-apps-prd-terraform-backend"
     key     = "apps-prd/network/terraform.tfstate"
   }

--- a/shared/us-east-1/base-network/config.tf
+++ b/shared/us-east-1/base-network/config.tf
@@ -21,13 +21,13 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd"
   region  = var.region
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 provider "aws" {
   alias   = "apps-prd-dr"
   region  = var.region_secondary
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 provider "aws" {

--- a/shared/us-east-1/base-network/locals.tf
+++ b/shared/us-east-1/base-network/locals.tf
@@ -145,7 +145,7 @@ locals {
   apps-prd-vpcs = {
     apps-prd-base = {
       region  = var.region
-      profile = "${var.project}-apps-prd-devops"
+      profile = "${var.project}-apps-prd-devopsprd"
       bucket  = "${var.project}-apps-prd-terraform-backend"
       key     = "apps-prd/network/terraform.tfstate"
     }

--- a/shared/us-east-2/base-network/config.tf
+++ b/shared/us-east-2/base-network/config.tf
@@ -15,7 +15,7 @@ provider "aws" {
 provider "aws" {
   alias   = "apps-prd-dr"
   region  = var.region_secondary
-  profile = "${var.project}-apps-prd-devops"
+  profile = "${var.project}-apps-prd-devopsprd"
 }
 
 provider "aws" {


### PR DESCRIPTION
## What?

* Rename the apps-prd AWS profile from `bb-apps-prd-devops` to **`bb-apps-prd-devopsprd`** everywhere it appears — `apps-prd/config/backend.tfvars`, the cross-account references in `network/` (5 layers), `shared/` (4 layers) and `management/global/organizations`, the `security-keys` CI matrix, and the layer READMEs.
* Set `apps-prd/config/account.tfvars` `sso_role` to `DevOpsPrd`, matching what Identity Center actually grants.
* Switch the `leverage-architect` agent doc's cross-account example from apps-prd to apps-devstg, so the illustration keeps showing the normal convention rather than the exception.
* CLAUDE.md: add the profile-name ↔ permission-set coupling rule under Naming Conventions, document the leverage 3.1.0 `aws sso refresh` / `sso login --refresh-all` commands, and anchor the plan-redaction `sed` on word boundaries (separate commit — see below).

## Why?

* #1173 gated apps-prd behind a dedicated `DevOpsPrd` permission set, but left every reference pointing at `bb-apps-prd-devops`. **That name is not a free choice.** Leverage derives the profile as `f"{project}-{account_name}-{sso_role.lower()}"` in `leverage/modules/auth.py`, for both the new `leverage aws sso refresh` and the auto-refresh that runs before every `leverage tofu` command. It ignores the `profile` value in `backend.tfvars` when deriving the name.
* So `bb-apps-prd-devops` became unmintable the moment the permission set was renamed, and **every OpenTofu operation on apps-prd fails** for everyone holding prod access:

  ```text
  INFO   Attempting to get temporary credentials for apps-prd account.
  INFO   Using already configured temporary credentials.      # checked bb-apps-prd-devopsprd
  Error: validating provider credentials: ... ExpiredToken    # tofu used bb-apps-prd-devops
  ```

  It only ever worked before because role `DevOps` → `bb-<acct>-devops` happened to match what the repo writes.
* Found while testing the new credential-refresh feature in leverage CLI 3.1.0. `leverage aws sso refresh` reports the failure and keeps going (`2 failed`), where the layer-scoped `refresh-credentials` hard-exits — which is why the breakage surfaced now rather than at the next apps-prd change.
* The second commit fixes a real defect in our own documented plan-redaction procedure, hit while preparing the excerpt below: unanchored `[0-9]{12}` matches inside any longer digit run, so it rewrote `1749584492000000000` into `<ACCOUNT_NAME_ACCOUNT_ID>0000000` — and the verification grep still passed, because the pattern it scans for had been consumed too.

## Verification

`leverage tofu init -reconfigure` then `plan` on `apps-prd/us-east-1/notifications`, authenticating with the renamed profile. No infrastructure change — the only diff is the `terraform-aws-notify-slack` module's known `null_resource.archive` timestamp churn, which replans on every run regardless of this PR.

<details>
<summary><code>leverage tofu plan</code> — apps-prd/us-east-1/notifications</summary>

```text
OpenTofu will perform the following actions:

  # module.notify_slack_monitoring.module.lambda.null_resource.archive[0] must be replaced
-/+ resource "null_resource" "archive" {
      ~ id       = "558924229812139360" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "timestamp" = "1749584492000000000" -> "1788983453583896000"
            # (1 unchanged element hidden)
        }
    }

  # module.notify_slack_monitoring_sec.module.lambda.null_resource.archive[0] must be replaced
-/+ resource "null_resource" "archive" {
      ~ id       = "2331410414097008533" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "timestamp" = "1749584492000000000" -> "1788983453583879000"
            # (1 unchanged element hidden)
        }
    }

Plan: 2 to add, 0 to change, 2 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

</details>

## Notes for reviewers

* **Locally initialized apps-prd layers need `leverage tofu init -reconfigure` once** after merge — the backend block's `profile` is part of the backend config, so tofu treats the rename as a backend change. Atlantis clones fresh, so CI is unaffected.
* The Atlantis server's own `~/.aws/bb/config` needs a `bb-apps-prd-devopsprd` profile before it can plan apps-prd layers. I could not verify the server-side config from here.
* `aws_profile` in `.github/workflows/security-keys.yml` is declared as an input but never consumed by `testing-workflow.yml` (those tests run against LocalStack), so that line is renamed for consistency only.
* The underlying CLI behaviour — re-deriving a profile name it already has, instead of using the resolved reference — is being reported upstream to `binbashar/leverage`.

## References

* Follows up #1173 (`feat(sso): gate apps-prd behind a dedicated DevOpsPrd permission set`)
* [leverage CLI v3.1.0](https://github.com/binbashar/leverage/releases/tag/v3.1.0) — `aws sso refresh`, `sso login --refresh-all`
* `leverage/modules/auth.py` — `get_layer_profile` / `_get_sso_profile_from_section`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated production AWS access to use the `DevOpsPrd` SSO role and corresponding credential profile across infrastructure operations.
  - Updated security automation and deployment workflows to use the revised production credentials.
  - Updated cross-account provider guidance to target the development/staging environment where applicable.

- **Documentation**
  - Updated deployment and account setup instructions with the revised production credential profile.
  - Added guidance for refreshing AWS SSO credentials and aligning local profiles with permission-set names.
  - Clarified account-ID redaction commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->